### PR TITLE
🔧 chore(skill): simplify git-commit skill rules and layout

### DIFF
--- a/.agents/skills/git-commit/SKILL.md
+++ b/.agents/skills/git-commit/SKILL.md
@@ -1,190 +1,75 @@
 ---
 name: git-commit
-description: 'Execute git commit with conventional commit message analysis, intelligent staging, and message generation. Use when user asks to commit changes, create a git commit, or mentions "/commit". Supports: (1) Auto-detecting type and scope from changes, (2) Generating conventional commit messages from diff, (3) Interactive commit with optional type/scope/description overrides, (4) Intelligent file staging for logical grouping'
+description: 'Execute git commit with conventional commit message analysis and optional Gitmoji prepending.'
 license: MIT
 allowed-tools: Bash
-source: https://github.com/github/awesome-copilot/blob/main/skills/git-commit/SKILL.md
 ---
 
-# Git Commit with Conventional Commits
+# Git Commit (Conventional Commits + Gitmoji)
 
 ## Overview
 
-Create standardized, semantic git commits using the Conventional Commits specification. Analyze the actual diff to determine appropriate type, scope, and message.
+Generate standardized, semantic git commits using the Conventional Commits specification.
+If the commit message uses a Conventional Commit type, prepend the corresponding Gitmoji. Otherwise, Gitmojis are purely for reference.
 
-## Conventional Commit with Gitmoji Format
+## Commit Format
 
-Every commit message must begin with a Gitmoji followed by a space, then the conventional commit prefix:
-
+When a conventional commit type is present, format the message as:
 ```
 <emoji> <type>(scope): <description>
 
 [optional body]
-
-[optional footer(s)]
 ```
-
-Or using Gitmoji shortcodes (e.g. for environment compatibility):
-
-```
-:shortcode: <type>(scope): <description>
-```
+*(Note: `scope` is optional)*
 
 ### Examples:
-- `✨ feat(auth): add google login`
-- `🐛 fix(db): resolve deadlock on transaction`
-- `:pencil2: docs(readme): fix typos in installation steps`
+- `✨ feat(auth): add google login` (with scope)
+- `🐛 fix: resolve deadlock on transaction` (without scope)
+- `docs: update installation steps` (no conventional emoji matched, or if emoji is not desired/applicable)
 
-## Commit Types and Gitmojis
+## Conventional Commit Types and Gitmojis
 
-Below is the mapping between Conventional Commit types and their corresponding Gitmojis (from [gitmoji.dev](https://gitmoji.dev)):
+Below is the mapping for conventional types. If one of these types is used, prepend the primary emoji:
 
-| Type | Primary Gitmoji | Direct Emoji | Shortcode | Purpose |
-| :--- | :---: | :---: | :---: | :--- |
-| `feat` | ✨ / 🚀 | `✨` / `🚀` | `:sparkles:` / `:rocket:` | New feature / Deploy stuff |
-| `fix` | 🐛 / 🚑️ | `🐛` / `🚑️` | `:bug:` / `:ambulance:` | Bug fix / Critical hotfix |
-| `docs` | 📝 | `📝` | `:memo:` | Documentation only |
-| `style` | 🎨 / 💄 | `🎨` / `💄` | `:art:` / `:lipstick:` | Format (no logic) / UI and styles |
-| `refactor` | ♻️ | `♻️` | `:recycle:` | Code refactor |
-| `perf` | ⚡️ | `⚡️` | `:zap:` | Performance improvement |
-| `test` | ✅ / 🧪 | `✅` / `🧪` | `:white_check_mark:` / `:test_tube:` | Add/update tests / Failing test |
-| `build` | 📦️ / 📌 | `📦️` / `📌` | `:package:` / `:pushpin:` | Build system/dependencies |
-| `ci` | 👷 / 💚 | `👷` / `💚` | `:construction_worker:` / `:green_heart:` | CI config / Fix CI build |
-| `chore` | 🔧 / 🔨 | `🔧` / `🔨` | `:wrench:` / `:hammer:` | Maintenance/config/scripts |
-| `revert` | ⏪️ | `⏪️` | `:rewind:` | Revert commit |
+| Type | Emoji | Description |
+| :--- | :---: | :--- |
+| `feat` | `✨` | New feature |
+| `fix` | `🐛` | Bug fix |
+| `docs` | `📝` | Documentation changes |
+| `style` | `🎨` | Formatting, UI, style changes (no logic changes) |
+| `refactor` | `♻️` | Code refactoring |
+| `perf` | `⚡️` | Performance improvements |
+| `test` | `✅` | Adding or updating tests |
+| `build` | `📦️` | Build system or external dependencies |
+| `ci` | `👷` | CI configuration and scripts |
+| `chore` | `🔧` | General maintenance, chores, config changes |
+| `revert` | `⏪️` | Reverting a previous commit |
 
-## Common Gitmoji Reference
+### Specific Scopes/Use-cases (Optional but Recommended)
 
-| Emoji | Shortcode | Description |
-| :---: | :--- | :--- |
-| 🔒️ | `:lock:` | Fix security or privacy issues |
-| 🔐 | `:closed_lock_with_key:` | Add or update secrets |
-| 🔖 | `:bookmark:` | Release / Version tags |
-| 🚧 | `:construction:` | Work in progress |
-| ➕ | `:heavy_plus_sign:` | Add a dependency |
-| ➖ | `:heavy_minus_sign:` | Remove a dependency |
-| 🌐 | `:globe_with_meridians:` | Internationalization & localization |
-| 💩 | `:poop:` | Write bad code that needs to be improved |
-| 🔀 | `:twisted_rightwards_arrows:` | Merge branches |
-| 👽️ | `:alien:` | Update code due to external API changes |
-| 🚚 | `:truck:` | Move or rename resources/files |
-| 📄 | `:page_facing_up:` | Add or update license |
-| 💥 | `:boom:` | Introduce breaking changes |
-| 🍱 | `:bento:` | Add or update assets |
-| ♿️ | `:wheelchair:` | Improve accessibility |
-| 💡 | `:bulb:` | Add or update comments in source code |
-| 🍻 | `:beers:` | Write code drunkenly |
-| 💬 | `:speech_balloon:` | Add or update text and literals |
-| 🗃️ | `:card_file_box:` | Perform database related changes |
-| 🔊 | `:loud_sound:` | Add or update logs |
-| 🔇 | `:mute:` | Remove logs |
-| 👥 | `:busts_in_silhouette:` | Add or update contributor(s) |
-| 🚸 | `:children_crossing:` | Improve user experience / usability |
-| 🏗️ | `:building_construction:` | Make architectural changes |
-| 📱 | `:iphone:` | Work on responsive design |
-| 🤡 | `:clown_face:` | Mock things |
-| 🥚 | `:egg:` | Add or update an easter egg |
-| 🙈 | `:see_no_evil:` | Add or update a .gitignore file |
-| 📸 | `:camera_flash:` | Add or update snapshots |
-| ⚗️ | `:alembic:` | Perform experiments |
-| 🔍️ | `:mag:` | Improve SEO |
-| 🏷️ | `:label:` | Add or update types |
-| 🌱 | `:seedling:` | Add or update seed files |
-| 🚩 | `:triangular_flag_on_post:` | Add, update, or remove feature flags |
-| 🥅 | `:goal_net:` | Catch errors |
-| 💫 | `:dizzy:` | Add or update animations and transitions |
-| 🗑️ | `:wastebasket:` | Deprecate code that needs to be cleaned up |
-| 🛂 | `:passport_control:` | Work on code related to authorization/roles |
-| 🩹 | `:adhesive_bandage:` | Simple fix for a non-critical issue |
-| 🧐 | `:monocle_face:` | Data exploration/inspection |
-| ⚰️ | `:coffin:` | Remove dead code |
-| 👔 | `:necktie:` | Add or update business logic |
-| 🩺 | `:stethoscope:` | Add or update healthcheck |
-| 🧱 | `:bricks:` | Infrastructure related changes |
-| 🧑‍💻 | `:technologist:` | Improve developer experience |
-| 💸 | `:money_with_wings:` | Add sponsorships or money related infrastructure |
-| 🧵 | `:thread:` | Concurrency or multithreading |
-| 🦺 | `:safety_vest:` | Validation checks |
-| 🦖 | `:t-rex:` | Backwards compatibility |
+For more specific scenarios, use these combinations:
+
+| Type | Emoji | Description |
+| :--- | :---: | :--- |
+| `chore(deps)` | `➕` / `➖` / `⬆️` | Add, remove, or upgrade dependencies |
+| `fix(security)` | `🔒️` | Fix security issues / secrets management |
+| `chore(db)` | `🗃️` | Database migrations / database related changes |
+| `chore(release)` | `🔖` | Release / Version tags |
+| `chore(wip)` | `🚧` | Work in progress |
+| `style(ui)` | `💄` | UI layout, CSS, and aesthetic design changes |
+| `refactor(cleanup)` | `🔥` | Remove dead code or files |
+| `chore(locales)` | `🌐` | Internationalization / translation updates |
+
+
 
 ## Workflow
 
-### 1. Analyze Diff
-
-```bash
-# If files are staged, use staged diff
-git diff --staged
-
-# If nothing staged, use working tree diff
-git diff
-
-# Also check status
-git status --porcelain
-```
-
-### 2. Stage Files (if needed)
-
-If nothing is staged or you want to group changes differently:
-
-```bash
-# Stage specific files
-git add path/to/file1 path/to/file2
-
-# Stage by pattern
-git add *.test.*
-git add src/components/*
-
-# Interactive staging
-git add -p
-```
-
-**Never commit secrets** (.env, credentials.json, private keys).
-
-### 3. Generate Commit Message
-
-Analyze the diff to determine:
-
-- **Gitmoji**: Select the most appropriate emoji or shortcode representing the change.
-- **Type**: What kind of change is this (must map to Conventional Commits)?
-- **Scope**: What area/module is affected? (Mandatory)
-- **Description**: One-line summary of what changed (present tense, imperative mood, <72 chars)
-
-Prepend the chosen Gitmoji to the conventional commit message (e.g. `✨ feat(auth): add login`).
-
-### 4. Execute Commit
-
-```bash
-# Single line (using Unicode Emoji)
-git commit -m "✨ feat(scope): <description>"
-
-# Single line (using shortcode if preferred or terminal issues)
-git commit -m ":sparkles: feat(scope): <description>"
-
-# Multi-line with body/footer
-git commit -m "$(cat <<'EOF'
-✨ feat(scope): <description>
-
-<optional body>
-
-<optional footer>
-EOF
-)"
-```
-
-## Best Practices
-
-- One logical change per commit
-- **Gitmoji is mandatory**: Every commit must begin with an emoji or shortcode.
-- **Scope is mandatory**: Always provide a scope in parentheses, e.g., `feat(auth): add login`
-- Present tense: "add" not "added"
-- Imperative mood: "fix bug" not "fixes bug"
-- Reference issues: `Closes #123`, `Refs #456`
-- Keep description under 72 characters
-
-## Git Safety Protocol
-
-- NEVER update git config
-- NEVER run destructive commands (--force, hard reset) without explicit request
-- NEVER skip hooks (--no-verify) unless user asks
-- NEVER force push to main/master
-- If commit fails due to hooks, fix and create NEW commit (don't amend)
+1. **Analyze changes**: Run `git diff` (or `git diff --staged`) and `git status --porcelain`.
+2. **Draft the message**:
+   - Determine the Conventional Commit `type` (e.g. `feat`, `fix`, `docs`).
+   - If a type is identified, prepend the corresponding Gitmoji from the table above.
+   - `scope` is **optional**. Use it only if it adds valuable context (e.g., `(db)`, `(auth)`).
+   - Write a short, imperative description (e.g., `add google login`, NOT `added google login`).
+3. **Execute commit**:
+   - Stage files: `git add <files>`
+   - Commit: `git commit -m "<emoji> <type>(scope): <description>"` (or without emoji/scope if not using conventional commit format).

--- a/.agents/skills/git-commit/SKILL.md
+++ b/.agents/skills/git-commit/SKILL.md
@@ -19,13 +19,26 @@ When a conventional commit type is present, format the message as:
 <emoji> <type>(scope): <description>
 
 [optional body]
+
+[optional footer(s)]
 ```
-*(Note: `scope` is optional)*
 
 ### Examples:
-- `✨ feat(auth): add google login` (with scope)
-- `🐛 fix: resolve deadlock on transaction` (without scope)
-- `docs: update installation steps` (no conventional emoji matched, or if emoji is not desired/applicable)
+
+- Single-line commit:
+  `✨ feat(auth): add google login`
+- Multi-line commit with body and footer:
+  ```
+  🐛 fix(db): resolve deadlock on transaction
+
+  The database was experiencing deadlocks when concurrent transactions tried to update the user balance. Wrapping the update query in a row lock resolves this issue.
+
+  Closes #42
+  ```
+- Reference commit (no conventional emoji matched, or emoji not used):
+  `docs(readme): update installation steps`
+
+
 
 ## Conventional Commit Types and Gitmojis
 
@@ -68,7 +81,7 @@ For more specific scenarios, use these combinations:
 2. **Draft the message**:
    - Determine the Conventional Commit `type` (e.g. `feat`, `fix`, `docs`).
    - If a type is identified, prepend the corresponding Gitmoji from the table above.
-   - `scope` is **optional**. Use it only if it adds valuable context (e.g., `(db)`, `(auth)`).
+   - Use scope if it adds valuable context (e.g., `(db)`, `(auth)`).
    - Write a short, imperative description (e.g., `add google login`, NOT `added google login`).
 3. **Execute commit**:
    - Stage files: `git add <files>`


### PR DESCRIPTION
### 1. Problem to Solve
- File skill `git-commit` trước đây có phần mô tả và workflow khá dài, nhiều chi tiết trùng lặp hoặc không cần thiết.

### 2. Proposed Solution
- Rút gọn mô tả skill, tập trung vào Conventional Commits + Gitmoji.
- Đơn giản hóa workflow: chỉ giữ các bước chính (analyze changes, draft message, commit).
- Gom bảng commit types và Gitmoji thành một phần duy nhất, dễ tra cứu.
- Loại bỏ các phần hướng dẫn lặp lại, ví dụ staging nâng cao, interactive commit.

### 3. Changes & Impact
- [`agents/skills/git-commit/SKILL.md`](agents/skills/git-commit/SKILL.md):  

### 4. Testing & Verification
- **Manual Verification**:  
