### PR TITLE
📝 docs(skills): refine git-commit skill instructions

### DIFF
--- a/.agents/skills/git-commit/SKILL.md
+++ b/.agents/skills/git-commit/SKILL.md
@@ -12,7 +12,7 @@ source: https://github.com/github/awesome-copilot/blob/main/skills/git-commit/SK
 
 Create standardized, semantic git commits using the Conventional Commits specification. Analyze the actual diff to determine appropriate type, scope, and message.
 
-## Conventional Commit with Gitmoji Format
+## Commit Format
 
 Every commit message must begin with a Gitmoji followed by a space, then the conventional commit prefix:
 
@@ -24,88 +24,53 @@ Every commit message must begin with a Gitmoji followed by a space, then the con
 [optional footer(s)]
 ```
 
-Or using Gitmoji shortcodes (e.g. for environment compatibility):
-
-```
-:shortcode: <type>(scope): <description>
-```
-
 ### Examples:
-- `✨ feat(auth): add google login`
-- `🐛 fix(db): resolve deadlock on transaction`
-- `:pencil2: docs(readme): fix typos in installation steps`
 
-## Commit Types and Gitmojis
+- Single-line commit:
+  `✨ feat(auth): add google login`
+- Multi-line commit with body and footer:
+  ```
+  🐛 fix(db): resolve deadlock on transaction
 
-Below is the mapping between Conventional Commit types and their corresponding Gitmojis (from [gitmoji.dev](https://gitmoji.dev)):
+  The database was experiencing deadlocks when concurrent transactions tried to update the user balance. Wrapping the update query in a row lock resolves this issue.
 
-| Type | Primary Gitmoji | Direct Emoji | Shortcode | Purpose |
-| :--- | :---: | :---: | :---: | :--- |
-| `feat` | ✨ / 🚀 | `✨` / `🚀` | `:sparkles:` / `:rocket:` | New feature / Deploy stuff |
-| `fix` | 🐛 / 🚑️ | `🐛` / `🚑️` | `:bug:` / `:ambulance:` | Bug fix / Critical hotfix |
-| `docs` | 📝 | `📝` | `:memo:` | Documentation only |
-| `style` | 🎨 / 💄 | `🎨` / `💄` | `:art:` / `:lipstick:` | Format (no logic) / UI and styles |
-| `refactor` | ♻️ | `♻️` | `:recycle:` | Code refactor |
-| `perf` | ⚡️ | `⚡️` | `:zap:` | Performance improvement |
-| `test` | ✅ / 🧪 | `✅` / `🧪` | `:white_check_mark:` / `:test_tube:` | Add/update tests / Failing test |
-| `build` | 📦️ / 📌 | `📦️` / `📌` | `:package:` / `:pushpin:` | Build system/dependencies |
-| `ci` | 👷 / 💚 | `👷` / `💚` | `:construction_worker:` / `:green_heart:` | CI config / Fix CI build |
-| `chore` | 🔧 / 🔨 | `🔧` / `🔨` | `:wrench:` / `:hammer:` | Maintenance/config/scripts |
-| `revert` | ⏪️ | `⏪️` | `:rewind:` | Revert commit |
+  Closes #42
+  ```
+- Reference commit (no conventional emoji matched, or emoji not used):
+  `docs(readme): update installation steps`
 
-## Common Gitmoji Reference
+## Conventional Commit Types and Gitmojis
 
-| Emoji | Shortcode | Description |
-| :---: | :--- | :--- |
-| 🔒️ | `:lock:` | Fix security or privacy issues |
-| 🔐 | `:closed_lock_with_key:` | Add or update secrets |
-| 🔖 | `:bookmark:` | Release / Version tags |
-| 🚧 | `:construction:` | Work in progress |
-| ➕ | `:heavy_plus_sign:` | Add a dependency |
-| ➖ | `:heavy_minus_sign:` | Remove a dependency |
-| 🌐 | `:globe_with_meridians:` | Internationalization & localization |
-| 💩 | `:poop:` | Write bad code that needs to be improved |
-| 🔀 | `:twisted_rightwards_arrows:` | Merge branches |
-| 👽️ | `:alien:` | Update code due to external API changes |
-| 🚚 | `:truck:` | Move or rename resources/files |
-| 📄 | `:page_facing_up:` | Add or update license |
-| 💥 | `:boom:` | Introduce breaking changes |
-| 🍱 | `:bento:` | Add or update assets |
-| ♿️ | `:wheelchair:` | Improve accessibility |
-| 💡 | `:bulb:` | Add or update comments in source code |
-| 🍻 | `:beers:` | Write code drunkenly |
-| 💬 | `:speech_balloon:` | Add or update text and literals |
-| 🗃️ | `:card_file_box:` | Perform database related changes |
-| 🔊 | `:loud_sound:` | Add or update logs |
-| 🔇 | `:mute:` | Remove logs |
-| 👥 | `:busts_in_silhouette:` | Add or update contributor(s) |
-| 🚸 | `:children_crossing:` | Improve user experience / usability |
-| 🏗️ | `:building_construction:` | Make architectural changes |
-| 📱 | `:iphone:` | Work on responsive design |
-| 🤡 | `:clown_face:` | Mock things |
-| 🥚 | `:egg:` | Add or update an easter egg |
-| 🙈 | `:see_no_evil:` | Add or update a .gitignore file |
-| 📸 | `:camera_flash:` | Add or update snapshots |
-| ⚗️ | `:alembic:` | Perform experiments |
-| 🔍️ | `:mag:` | Improve SEO |
-| 🏷️ | `:label:` | Add or update types |
-| 🌱 | `:seedling:` | Add or update seed files |
-| 🚩 | `:triangular_flag_on_post:` | Add, update, or remove feature flags |
-| 🥅 | `:goal_net:` | Catch errors |
-| 💫 | `:dizzy:` | Add or update animations and transitions |
-| 🗑️ | `:wastebasket:` | Deprecate code that needs to be cleaned up |
-| 🛂 | `:passport_control:` | Work on code related to authorization/roles |
-| 🩹 | `:adhesive_bandage:` | Simple fix for a non-critical issue |
-| 🧐 | `:monocle_face:` | Data exploration/inspection |
-| ⚰️ | `:coffin:` | Remove dead code |
-| 👔 | `:necktie:` | Add or update business logic |
-| 🩺 | `:stethoscope:` | Add or update healthcheck |
-| 🧱 | `:bricks:` | Infrastructure related changes |
-| 🧑‍💻 | `:technologist:` | Improve developer experience |
-| 💸 | `:money_with_wings:` | Add sponsorships or money related infrastructure |
-| 🧵 | `:thread:` | Concurrency or multithreading |
-| 🦺 | `:safety_vest:` | Validation checks |
-| 🦖 | `:t-rex:` | Backwards compatibility |
+Below is the mapping for conventional types. If one of these types is used, prepend the primary emoji:
+
+| Type | Emoji | Description |
+| :--- | :---: | :--- |
+| `feat` | `✨` | New feature |
+| `fix` | `🐛` | Bug fix |
+| `docs` | `📝` | Documentation changes |
+| `style` | `🎨` | Formatting, UI, style changes (no logic changes) |
+| `refactor` | `♻️` | Code refactoring |
+| `perf` | `⚡️` | Performance improvements |
+| `test` | `✅` | Adding or updating tests |
+| `build` | `📦️` | Build system or external dependencies |
+| `ci` | `👷` | CI configuration and scripts |
+| `chore` | `🔧` | General maintenance, chores, config changes |
+| `revert` | `⏪️` | Reverting a previous commit |
+
+### Specific Scopes/Use-cases (Optional but Recommended)
+
+For more specific scenarios, use these combinations:
+
+| Type | Emoji | Description |
+| :--- | :---: | :--- |
+| `chore(deps)` | `➕` / `➖` / `⬆️` | Add, remove, or upgrade dependencies |
+| `fix(security)` | `🔒️` | Fix security issues / secrets management |
+| `chore(db)` | `🗃️` | Database migrations / database related changes |
+| `chore(release)` | `🔖` | Release / Version tags |
+| `chore(wip)` | `🚧` | Work in progress |
+| `style(ui)` | `💄` | UI layout, CSS, and aesthetic design changes |
+| `refactor(cleanup)` | `🔥` | Remove dead code or files |
+| `chore(locales)` | `🌐` | Internationalization / translation updates |
 
 ## Workflow
 

--- a/.agents/skills/git-commit/SKILL.md
+++ b/.agents/skills/git-commit/SKILL.md
@@ -34,7 +34,6 @@ Every commit message must begin with a Gitmoji followed by a space, then the con
 
   The database was experiencing deadlocks when concurrent transactions tried to update the user balance. Wrapping the update query in a row lock resolves this issue.
 
-  Closes #42
   ```
 - Reference commit (no conventional emoji matched, or emoji not used):
   `docs(readme): update installation steps`


### PR DESCRIPTION
### 1. Problem to Solve
- File hướng dẫn của kỹ năng `git-commit` trước đó chứa quá nhiều Gitmoji ít dùng hoặc không liên quan trực tiếp đến quy trình Conventional Commit tiêu chuẩn, làm loãng tài liệu và gây khó khăn cho việc tra cứu nhanh của Agent.

### 2. Proposed Solution
- Thực hiện tái cấu trúc lại tài liệu `git-commit/SKILL.md`:
  - Rút ngắn danh sách Gitmojis, chỉ giữ lại các Emoji phổ biến tương ứng với các loại Conventional Commits cốt lõi.
  - Thêm phần phân loại các scope/use-cases thường gặp như `chore(deps)`, `fix(security)`, `chore(db)`, v.v.
  - Tối giản hóa quy trình và ví dụ để Agent dễ dàng hiểu và áp dụng nhanh chóng.

### 3. Changes & Impact
- `[.agents/skills/git-commit/SKILL.md](.agents/skills/git-commit/SKILL.md)`:
  - Cập nhật lại cấu trúc phần "Commit Format".
  - Thay thế bảng Gitmoji dài dòng bằng hai bảng nhỏ gọn: "Conventional Commit Types and Gitmojis" và "Specific Scopes/Use-cases".
  - Giúp giảm đáng kể kích thước file tài liệu (giảm 82 dòng và thêm 47 dòng tối ưu hơn), nâng cao hiệu suất đọc hiểu của Agent khi tải skill.

### 4. Testing & Verification
- **Automated Tests**: Không áp dụng đối với tài liệu Markdown.
- **Manual Verification**: Đã kiểm tra cấu trúc markdown hiển thị chính xác và không có lỗi định dạng.