### PR TITLE
:bug: fix(ci): support unicode emoji icons and fix CRLF in commit linter

### DIFF
--- a/scripts/verify-commit-msg.sh
+++ b/scripts/verify-commit-msg.sh
@@ -4,26 +4,23 @@
 # Pattern: <emoji> <type>(scope): <description>
 # Or: :shortcode: <type>(scope): <description>
 
-# Exit on any error
 set -e
 
 # Regex pattern:
-# - ^([^[:space:][:alnum:]]+|:[a-zA-Z0-9_-]+:) matches the emoji character or a shortcode like :sparkles:
-# - [[:space:]]+ matches the whitespace between emoji and conventional commit type
-# - [a-zA-Z0-9_-]+ matches type (feat, fix, etc.)
+# - ^(:[a-zA-Z0-9_-]+:|[^a-zA-Z[:space:]][^[:space:]]*) matches any shortcode or unicode icon/emoji
+# - [[:space:]]+ matches whitespace between emoji and type
+# - [a-zA-Z0-9_-]+ matches type (feat, fix, docs, style, etc.)
 # - (\([^)]+\))? matches optional scope
 # - !? matches optional breaking change indicator
-# - :[[:space:]]+ matches the colon and whitespace
-# - .+$ matches the description
-REGEX="^([^[:space:][:alnum:]]+|:[a-zA-Z0-9_-]+:)[[:space:]]+[a-zA-Z0-9_-]+(\([^)]+\))?!?:[[:space:]]+.+$"
+# - :[[:space:]]+ matches colon and whitespace
+# - .+$ matches description
+REGEX="^(:[a-zA-Z0-9_-]+:|[^a-zA-Z[:space:]][^[:space:]]*)[[:space:]]+[a-zA-Z0-9_-]+(\([^)]+\))?!?:[[:space:]]+.+$"
 
 validate_msg() {
   local msg="$1"
-  # Trim leading/trailing whitespace
-  msg=$(echo "$msg" | xargs)
+  # Trim leading/trailing whitespace safely without breaking on quotes/apostrophes
+  msg=$(echo "$msg" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
 
-  # Check if message matches the regex
-  # We use grep with ERE (Extended Regular Expressions)
   if echo "$msg" | grep -Eq "$REGEX"; then
     return 0
   else
@@ -36,10 +33,10 @@ validate_msg() {
   fi
 }
 
-# Mode 1: Check a single commit message file (Git commit-msg hook)
+# Mode 1: Check a commit message file (Git commit-msg hook)
 if [ -n "$1" ] && [ -f "$1" ]; then
-  COMMIT_MSG=$(cat "$1")
-  # Ignore empty messages
+  # Extract first non-comment, non-empty line (the commit subject)
+  COMMIT_MSG=$(grep -v '^[[:space:]]*#' "$1" | sed '/^[[:space:]]*$/d' | head -n 1 || echo "")
   if [ -z "$COMMIT_MSG" ]; then
     exit 0
   fi
@@ -47,8 +44,7 @@ if [ -n "$1" ] && [ -f "$1" ]; then
   exit $?
 fi
 
-# Mode 2: Check range of commits (CI environment or manual run)
-# Use BASE_REF or check HEAD by default
+# Mode 2: Check range of commits or HEAD
 RANGE=""
 if [ -n "$COMMIT_RANGE" ]; then
   RANGE="$COMMIT_RANGE"
@@ -58,10 +54,8 @@ fi
 
 if [ -n "$RANGE" ]; then
   echo "Checking commits in range: $RANGE"
-  # Get commit subjects in range
   FAILED=0
   while IFS= read -r msg; do
-    # Skip empty lines
     [ -z "$msg" ] && continue
     if ! validate_msg "$msg"; then
       FAILED=1
@@ -76,7 +70,6 @@ if [ -n "$RANGE" ]; then
     exit 0
   fi
 else
-  # Default: Check the last commit (HEAD)
   LAST_COMMIT_MSG=$(git log -1 --format=%s HEAD 2>/dev/null || echo "")
   if [ -z "$LAST_COMMIT_MSG" ]; then
     echo "No commits found to validate."


### PR DESCRIPTION
### 1. Vấn đề cần giải quyết
- Khi thực hiện git commit trên môi trường Git Bash / Windows, hook kiểm tra commit (`verify-commit-msg.sh`) từ chối các commit message hợp lệ có sử dụng Icon/Emoji Unicode (chẳng hạn như ✨, 🐛, 📝, 🏋️‍♂️...). Nguyên nhân do biểu thức POSIX `[^[:space:][:alnum:]]+` trong regex cũ không tương thích với các ký tự UTF-8 nhiều byte hoặc có variation selectors trên hệ thống Windows.
- File script bị lưu dưới định dạng line endings CRLF (`\r\n`), gây ra lỗi cú pháp (`$'\r': command not found`) và làm sai lệch biến regex khi thực thi trên bash.
- Khi Git tự động chèn các dòng chú thích hướng dẫn (`# Please enter the commit message...`), script cũ gộp toàn bộ nội dung file thành 1 dòng duy nhất, làm lỗi xác thực đối với các commit có cấu trúc nhiều dòng (có Body / Footer).

### 2. Giải pháp đề xuất
- **Cập nhật Regex nhận diện Icon/Emoji**: Thay thế bằng biểu thức chính quy `^(:[a-zA-Z0-9_-]+:|[^a-zA-Z[:space:]][^[:space:]]*)`, cho phép chấp nhận mọi loại Icon/Emoji Unicode và Gitmoji Shortcodes (`:memo:`), đồng thời vẫn chặn chuẩn xác các commit không chứa icon/shortcode ở đầu câu.
- **Chuẩn hóa Line Endings & Xử lý commit nhiều dòng**: Chuyển đổi định dạng file về chuẩn LF (`\n`). Cập nhật logic lọc bỏ dòng comment `#` và chỉ lấy duy nhất dòng tiêu đề (subject) đầu tiên để xác thực.

### 3. Thay đổi & Tác động
- [scripts/verify-commit-msg.sh](scripts/verify-commit-msg.sh): Nâng cấp regex `REGEX`, tối ưu bộ lọc chuỗi commit message và chuẩn hóa xuống dòng LF. Đảm bảo quy trình kiểm tra commit (tại CI và local git hooks) hoạt động chính xác, ổn định trên mọi môi trường.

### 4. Kiểm thử & Xác nhận
- **Kiểm thử tự động**:
  - Thực thi kiểm tra với các chuỗi Unicode Emojis: `✨ feat(auth): add google login`, `📝 docs(ddd): refine tactical design`, `🏋️‍♂️ feat(workout): add skeleton tracking`. Tất cả đều pass thành công (`✨ All commit messages in range are valid!`).
  - Thực thi kiểm tra trực tiếp qua git commit với shortcode `:bug: fix(ci): ...`. Hook xác nhận hợp lệ và tạo commit thành công (`fddca55`).
- **Kiểm thử thủ công**:
  - Giả lập commit message sai định dạng (thiếu icon hoặc không tuân thủ conventional commits). Hook chặn chính xác và in hướng dẫn mẫu.
  - Giả lập kiểm tra file `.git/COMMIT_EDITMSG` chứa nhiều dòng comment `#`. Hook nhận diện đúng tiêu đề và bỏ qua các dòng comment.