### PR TITLE
✨ feat(workout_execution): define execution and motion API contracts

### DIFF
--- a/proto/contracts/core/workout_execution/v1/event/new_personal_record_achieved.proto
+++ b/proto/contracts/core/workout_execution/v1/event/new_personal_record_achieved.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package contracts.core.workout_execution.v1.event;
+
+option go_package = "github.com/viethung213/gym-companion/internal/gen/go/contracts/core/workout_execution/v1/event;workoutexecutionv1event";
+
+message NewPersonalRecordAchieved {
+  string user_id = 1;
+  string exercise_id = 2;
+  float one_rep_max = 3;
+  float weight = 4;
+  int32 reps = 5;
+  string achieved_at = 6; // Định dạng ISO8601
+}

--- a/proto/contracts/core/workout_execution/v1/event/new_personal_record_achieved.proto
+++ b/proto/contracts/core/workout_execution/v1/event/new_personal_record_achieved.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package contracts.core.workout_execution.v1.event;
 
+import "google/protobuf/timestamp.proto";
+
 option go_package = "github.com/viethung213/gym-companion/internal/gen/go/contracts/core/workout_execution/v1/event;workoutexecutionv1event";
 
 message NewPersonalRecordAchieved {
@@ -10,5 +12,5 @@ message NewPersonalRecordAchieved {
   float one_rep_max = 3;
   float weight = 4;
   int32 reps = 5;
-  string achieved_at = 6; // Định dạng ISO8601
+  google.protobuf.Timestamp achieved_at = 6;
 }

--- a/proto/contracts/core/workout_execution/v1/event/workout_session_aborted.proto
+++ b/proto/contracts/core/workout_execution/v1/event/workout_session_aborted.proto
@@ -4,12 +4,9 @@ package contracts.core.workout_execution.v1.event;
 
 option go_package = "github.com/viethung213/gym-companion/internal/gen/go/contracts/core/workout_execution/v1/event;workoutexecutionv1event";
 
-message WorkoutSessionCompleted {
+message WorkoutSessionAborted {
   string session_id = 1;
   string user_id = 2;
-  string completed_at = 3;
-  int32 total_sets = 4;
-  float total_volume = 5;
-  optional float average_form_score = 6; // optional hỗ trợ N/A cho bài tập Phi AI
-  float average_rpe = 7;
+  string aborted_at = 3; // Định dạng ISO8601
+  string reason = 4; // e.g. "timeout", "user_cancelled"
 }

--- a/proto/contracts/core/workout_execution/v1/event/workout_session_aborted.proto
+++ b/proto/contracts/core/workout_execution/v1/event/workout_session_aborted.proto
@@ -2,11 +2,13 @@ syntax = "proto3";
 
 package contracts.core.workout_execution.v1.event;
 
+import "google/protobuf/timestamp.proto";
+
 option go_package = "github.com/viethung213/gym-companion/internal/gen/go/contracts/core/workout_execution/v1/event;workoutexecutionv1event";
 
 message WorkoutSessionAborted {
   string session_id = 1;
   string user_id = 2;
-  string aborted_at = 3; // Định dạng ISO8601
+  google.protobuf.Timestamp aborted_at = 3;
   string reason = 4; // e.g. "timeout", "user_cancelled"
 }

--- a/proto/contracts/core/workout_execution/v1/event/workout_session_completed.proto
+++ b/proto/contracts/core/workout_execution/v1/event/workout_session_completed.proto
@@ -2,12 +2,14 @@ syntax = "proto3";
 
 package contracts.core.workout_execution.v1.event;
 
+import "google/protobuf/timestamp.proto";
+
 option go_package = "github.com/viethung213/gym-companion/internal/gen/go/contracts/core/workout_execution/v1/event;workoutexecutionv1event";
 
 message WorkoutSessionCompleted {
   string session_id = 1;
   string user_id = 2;
-  string completed_at = 3;
+  google.protobuf.Timestamp completed_at = 3;
   int32 total_sets = 4;
   float total_volume = 5;
   optional float average_form_score = 6; // optional hỗ trợ N/A cho bài tập Phi AI

--- a/proto/contracts/core/workout_execution/v1/event/workout_session_started.proto
+++ b/proto/contracts/core/workout_execution/v1/event/workout_session_started.proto
@@ -2,11 +2,13 @@ syntax = "proto3";
 
 package contracts.core.workout_execution.v1.event;
 
+import "google/protobuf/timestamp.proto";
+
 option go_package = "github.com/viethung213/gym-companion/internal/gen/go/contracts/core/workout_execution/v1/event;workoutexecutionv1event";
 
 message WorkoutSessionStarted {
   string session_id = 1;
   string user_id = 2;
   string plan_id = 3;
-  string started_at = 4; // Định dạng ISO8601
+  google.protobuf.Timestamp started_at = 4;
 }

--- a/proto/contracts/core/workout_execution/v1/event/workout_session_started.proto
+++ b/proto/contracts/core/workout_execution/v1/event/workout_session_started.proto
@@ -4,12 +4,9 @@ package contracts.core.workout_execution.v1.event;
 
 option go_package = "github.com/viethung213/gym-companion/internal/gen/go/contracts/core/workout_execution/v1/event;workoutexecutionv1event";
 
-message WorkoutSessionCompleted {
+message WorkoutSessionStarted {
   string session_id = 1;
   string user_id = 2;
-  string completed_at = 3;
-  int32 total_sets = 4;
-  float total_volume = 5;
-  optional float average_form_score = 6; // optional hỗ trợ N/A cho bài tập Phi AI
-  float average_rpe = 7;
+  string plan_id = 3;
+  string started_at = 4; // Định dạng ISO8601
 }

--- a/proto/contracts/core/workout_execution/v1/message/workout_execution_messages.proto
+++ b/proto/contracts/core/workout_execution/v1/message/workout_execution_messages.proto
@@ -73,6 +73,7 @@ message ErrorLog {
   string timestamp = 3; // Định dạng ISO8601 hoặc epoch
   int32 set_number = 4;
   int32 rep_number = 5; // Có thể bằng -1 nếu không gắn với rep cụ thể (ví dụ: tập Plank bị võng lưng)
+  string exercise_id = 6; // Mã bài tập phát sinh lỗi
 }
 
 // Request/Response cho SyncWorkoutLogs (Batch Async Sync)
@@ -135,6 +136,16 @@ message GetPersonalRecordsResponse {
 }
 
 
+
+// Request/Response cho GetWorkoutSessionErrors
+message GetWorkoutSessionErrorsRequest {
+  string session_id = 1;
+}
+
+message GetWorkoutSessionErrorsResponse {
+  string session_id = 1;
+  repeated ErrorLog errors = 2;
+}
 
 // Request/Response cho GetWorkoutHistory
 message GetWorkoutHistoryRequest {

--- a/proto/contracts/core/workout_execution/v1/message/workout_execution_messages.proto
+++ b/proto/contracts/core/workout_execution/v1/message/workout_execution_messages.proto
@@ -4,6 +4,7 @@ package contracts.core.workout_execution.v1.message;
 
 option go_package = "github.com/viethung213/gym-companion/internal/gen/go/contracts/core/workout_execution/v1/message;workoutexecutionv1message";
 
+// Request/Response cho StartWorkoutSession
 message StartWorkoutSessionRequest {
   string user_id = 1;
   string plan_id = 2;
@@ -14,20 +15,15 @@ message StartWorkoutSessionResponse {
   string started_at = 2;
 }
 
-message Keypoint3D {
-  float x = 1;
-  float y = 2;
-  float z = 3;
-  float score = 4;
-}
-
+// Log cho từng rep (được tính toán từ Client và gửi lên Server)
 message RepLog {
   int32 rep_number = 1;
   float rom_percentage = 2;
-  string error_status = 3;
-  repeated Keypoint3D skeleton_coords = 4;
+  repeated string error_codes = 3; // Ví dụ: ["ERR_BACK_ARCH", "ERR_KNEE_OVER_TOE"]
+  map<string, float> joint_angles = 4; // Map các góc khớp đã tính toán (ví dụ: {"knee_angle": 120.5})
 }
 
+// Request/Response cho LogWorkoutSet
 message LogWorkoutSetRequest {
   string session_id = 1;
   int32 set_number = 2;
@@ -35,16 +31,28 @@ message LogWorkoutSetRequest {
   int32 target_reps = 4;
   int32 actual_reps = 5;
   float weight = 6;
-  float form_score = 7;
-  float rpe = 8;
+  optional float form_score = 7; // Sử dụng optional để hỗ trợ N/A cho bài tập Phi AI
+  float rpe = 8; // Độ gắng sức (Rate of Perceived Exertion)
   repeated RepLog reps = 9;
+  string camera_angle = 10; // Góc quay camera thực tế lúc tập (ví dụ: "side", "front")
 }
 
 message LogWorkoutSetResponse {
   string set_log_id = 1;
-  bool is_successful = 2;
 }
 
+// Request/Response cho AbortWorkoutSession
+message AbortWorkoutSessionRequest {
+  string session_id = 1;
+  string reason = 2; // e.g. "timeout", "user_cancelled"
+}
+
+message AbortWorkoutSessionResponse {
+  string session_id = 1;
+  string aborted_at = 2;
+}
+
+// Request/Response cho CompleteWorkoutSession
 message CompleteWorkoutSessionRequest {
   string session_id = 1;
 }
@@ -54,13 +62,85 @@ message CompleteWorkoutSessionResponse {
   string completed_at = 2;
   int32 total_sets = 3;
   float total_volume = 4;
-  float average_form_score = 5;
+  optional float average_form_score = 5; // Sử dụng optional nếu toàn bài phi AI
   float average_rpe = 6;
 }
 
+// Nhật ký lỗi tư thế (được gom batch gửi định kỳ trong buổi tập)
+message ErrorLog {
+  string error_code = 1;
+  string severity = 2; // "severity_1" hoặc "severity_2"
+  string timestamp = 3; // Định dạng ISO8601 hoặc epoch
+  int32 set_number = 4;
+  int32 rep_number = 5; // Có thể bằng -1 nếu không gắn với rep cụ thể (ví dụ: tập Plank bị võng lưng)
+}
+
+// Request/Response cho SyncWorkoutLogs (Batch Async Sync)
+message SyncWorkoutLogsRequest {
+  string session_id = 1;
+  repeated ErrorLog errors = 2;
+}
+
+message SyncWorkoutLogsResponse {}
+
+
+
+// Cấu hình thoại tương thích HLV và lỗi tư thế
+message DialogueOption {
+  string text = 1;
+  string audio_url = 2;
+}
+
+message DialogueSeverities {
+  repeated DialogueOption severity_1 = 1;
+  repeated DialogueOption severity_2 = 2;
+}
+
+message DialogueEngineConfig {
+  string personality_id = 1;
+  map<string, float> cooldowns = 2; // Ví dụ: {"severity_2": 3.0}
+  map<string, DialogueSeverities> dialogue_map = 3; // key là error_code (ví dụ: "ERR_BACK_ARCH")
+}
+
+// Request/Response cho GetMotionSpecification
+message GetMotionSpecificationRequest {
+  string exercise_id = 1;
+  string coach_personality = 2; // drill_sergeant, best_friend, data_analyst
+}
+
+message GetMotionSpecificationResponse {
+  string exercise_id = 1;
+  string onnx_model_url = 2;
+  string local_rules_url = 3; // URL tải file JSON cấu hình luật (ví dụ: keypoint confidence, filters, priorities)
+  DialogueEngineConfig dialogue_engine = 4;
+  string recommended_camera_angle = 5; // Góc quay camera khuyến nghị (ví dụ: "side", "front")
+}
+
+// Cấu trúc và Request/Response cho GetPersonalRecords
+message PersonalRecord {
+  string exercise_id = 1;
+  float one_rep_max = 2;
+  float weight = 3;
+  int32 reps = 4;
+  string achieved_at = 5;
+}
+
+message GetPersonalRecordsRequest {
+  string user_id = 1;
+  repeated string exercise_ids = 2; // Để trống để lấy tất cả bài tập
+}
+
+message GetPersonalRecordsResponse {
+  repeated PersonalRecord records = 1;
+}
+
+
+
+// Request/Response cho GetWorkoutHistory
 message GetWorkoutHistoryRequest {
   string user_id = 1;
   int32 limit = 2;
+  int32 offset = 3; // Vị trí bắt đầu lấy bản ghi (mặc định là 0 nếu để trống)
 }
 
 message WorkoutSessionSummary {
@@ -68,7 +148,7 @@ message WorkoutSessionSummary {
   string date = 2;
   int32 total_sets = 3;
   float total_volume = 4;
-  float average_form_score = 5;
+  optional float average_form_score = 5; // Dạng optional (N/A nếu buổi tập phi AI)
 }
 
 message GetWorkoutHistoryResponse {

--- a/proto/contracts/core/workout_execution/v1/message/workout_execution_messages.proto
+++ b/proto/contracts/core/workout_execution/v1/message/workout_execution_messages.proto
@@ -4,6 +4,8 @@ package contracts.core.workout_execution.v1.message;
 
 option go_package = "github.com/viethung213/gym-companion/internal/gen/go/contracts/core/workout_execution/v1/message;workoutexecutionv1message";
 
+import "google/protobuf/timestamp.proto";
+
 // Request/Response cho StartWorkoutSession
 message StartWorkoutSessionRequest {
   string user_id = 1;
@@ -12,7 +14,7 @@ message StartWorkoutSessionRequest {
 
 message StartWorkoutSessionResponse {
   string session_id = 1;
-  string started_at = 2;
+  google.protobuf.Timestamp started_at = 2;
 }
 
 // Log cho từng rep (được tính toán từ Client và gửi lên Server)
@@ -49,7 +51,7 @@ message AbortWorkoutSessionRequest {
 
 message AbortWorkoutSessionResponse {
   string session_id = 1;
-  string aborted_at = 2;
+  google.protobuf.Timestamp aborted_at = 2;
 }
 
 // Request/Response cho CompleteWorkoutSession
@@ -59,7 +61,7 @@ message CompleteWorkoutSessionRequest {
 
 message CompleteWorkoutSessionResponse {
   string session_id = 1;
-  string completed_at = 2;
+  google.protobuf.Timestamp completed_at = 2;
   int32 total_sets = 3;
   float total_volume = 4;
   optional float average_form_score = 5; // Sử dụng optional nếu toàn bài phi AI
@@ -70,7 +72,7 @@ message CompleteWorkoutSessionResponse {
 message ErrorLog {
   string error_code = 1;
   string severity = 2; // "severity_1" hoặc "severity_2"
-  string timestamp = 3; // Định dạng ISO8601 hoặc epoch
+  google.protobuf.Timestamp timestamp = 3;
   int32 set_number = 4;
   int32 rep_number = 5; // Có thể bằng -1 nếu không gắn với rep cụ thể (ví dụ: tập Plank bị võng lưng)
   string exercise_id = 6; // Mã bài tập phát sinh lỗi
@@ -123,7 +125,7 @@ message PersonalRecord {
   float one_rep_max = 2;
   float weight = 3;
   int32 reps = 4;
-  string achieved_at = 5;
+  google.protobuf.Timestamp achieved_at = 5;
 }
 
 message GetPersonalRecordsRequest {
@@ -156,7 +158,7 @@ message GetWorkoutHistoryRequest {
 
 message WorkoutSessionSummary {
   string session_id = 1;
-  string date = 2;
+  google.protobuf.Timestamp date = 2;
   int32 total_sets = 3;
   float total_volume = 4;
   optional float average_form_score = 5; // Dạng optional (N/A nếu buổi tập phi AI)

--- a/proto/contracts/core/workout_execution/v1/service/workout_execution_service.proto
+++ b/proto/contracts/core/workout_execution/v1/service/workout_execution_service.proto
@@ -71,6 +71,13 @@ service WorkoutExecutionService {
     };
   }
 
+  // Lấy danh sách chi tiết các lỗi sai tư thế trong một buổi tập chỉ định
+  rpc GetWorkoutSessionErrors (contracts.core.workout_execution.v1.message.GetWorkoutSessionErrorsRequest) returns (contracts.core.workout_execution.v1.message.GetWorkoutSessionErrorsResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/execution/sessions/{session_id}/errors"
+    };
+  }
+
   // Lấy lịch sử các buổi tập của người dùng
   rpc GetWorkoutHistory (contracts.core.workout_execution.v1.message.GetWorkoutHistoryRequest) returns (contracts.core.workout_execution.v1.message.GetWorkoutHistoryResponse) {
     option (google.api.http) = {

--- a/proto/contracts/core/workout_execution/v1/service/workout_execution_service.proto
+++ b/proto/contracts/core/workout_execution/v1/service/workout_execution_service.proto
@@ -33,11 +33,41 @@ service WorkoutExecutionService {
     };
   }
 
+  // Hủy/Dừng đột xuất buổi tập (Anomalous Session)
+  rpc AbortWorkoutSession (contracts.core.workout_execution.v1.message.AbortWorkoutSessionRequest) returns (contracts.core.workout_execution.v1.message.AbortWorkoutSessionResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/execution/sessions/{session_id}/abort"
+      body: "*"
+    };
+  }
+
   // Kết thúc buổi tập và xuất báo cáo
   rpc CompleteWorkoutSession (contracts.core.workout_execution.v1.message.CompleteWorkoutSessionRequest) returns (contracts.core.workout_execution.v1.message.CompleteWorkoutSessionResponse) {
     option (google.api.http) = {
       post: "/api/v1/execution/sessions/{session_id}/complete"
       body: "*"
+    };
+  }
+
+  // Đồng bộ batch log lỗi và reps trong quá trình tập
+  rpc SyncWorkoutLogs (contracts.core.workout_execution.v1.message.SyncWorkoutLogsRequest) returns (contracts.core.workout_execution.v1.message.SyncWorkoutLogsResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/execution/sessions/{session_id}/logs"
+      body: "*"
+    };
+  }
+
+  // Lấy cấu hình thuật toán và kịch bản thoại AI cho một bài tập
+  rpc GetMotionSpecification (contracts.core.workout_execution.v1.message.GetMotionSpecificationRequest) returns (contracts.core.workout_execution.v1.message.GetMotionSpecificationResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/execution/exercises/{exercise_id}/motion-spec"
+    };
+  }
+
+  // Lấy danh sách kỷ lục cá nhân (1RM) của người dùng
+  rpc GetPersonalRecords (contracts.core.workout_execution.v1.message.GetPersonalRecordsRequest) returns (contracts.core.workout_execution.v1.message.GetPersonalRecordsResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/execution/users/{user_id}/personal-records"
     };
   }
 


### PR DESCRIPTION
## PR Description

### 1. Problem to Solve
- Định nghĩa và chuẩn hóa hợp đồng API (Protobuf contracts) cho module **Workout Execution & AI Motion** (nằm trong thư mục `proto/contracts/core/workout_execution/v1`).
- Đảm bảo hỗ trợ tốt hai luồng tập luyện: Luồng tập camera AI và luồng tập tự ghi chép phi AI, đồng thời loại bỏ việc lưu trữ tọa độ khớp thô ở server để bảo mật và tối ưu băng thông.

closes #49 

### 2. Proposed Solution
- Loại bỏ hoàn toàn cấu trúc `Keypoint3D` và việc lưu trữ tọa độ khớp xương thô ở phía Server.
- Cấu trúc lại `RepLog` để nhận danh sách các góc khớp dạng `map<string, float> joint_angles` và mã lỗi `repeated string error_codes` do Client tự tính toán gửi lên.
- Đơn giản hóa cấu trúc `GetMotionSpecificationResponse` bằng trường `local_rules_url` chứa đường dẫn file JSON cấu hình Edge AI từ CDN để dễ dàng nâng cấp thuật toán mà không cần sửa đổi API contract.
- Thiết kế các response (`LogWorkoutSetResponse`, `SyncWorkoutLogsResponse`) tối giản, loại bỏ trường `is_successful` do đã được phản ánh qua HTTP/gRPC status codes.
- Thêm các sự kiện Domain (Event) phục vụ cơ chế Event-Driven: `WorkoutSessionStarted`, `WorkoutSessionAborted`, `NewPersonalRecordAchieved`.

### 3. Changes & Impact
- `[proto/contracts/core/workout_execution/v1/message/workout_execution_messages.proto](proto/contracts/core/workout_execution/v1/message/workout_execution_messages.proto)`: Định nghĩa các message logs, cấu hình Edge AI, lịch sử PR và phân trang cho lịch sử tập luyện.
- `[proto/contracts/core/workout_execution/v1/service/workout_execution_service.proto](proto/contracts/core/workout_execution/v1/service/workout_execution_service.proto)`: Đăng ký các RPC cho việc lưu set, hủy buổi tập, đồng bộ log, tải cấu hình bài tập, lấy kỷ lục và lịch sử tập luyện.
- `[proto/contracts/core/workout_execution/v1/event/workout_session_started.proto](proto/contracts/core/workout_execution/v1/event/workout_session_started.proto)`: [NEW] Sự kiện bắt đầu buổi tập.
- `[proto/contracts/core/workout_execution/v1/event/workout_session_aborted.proto](proto/contracts/core/workout_execution/v1/event/workout_session_aborted.proto)`: [NEW] Sự kiện huỷ buổi tập.
- `[proto/contracts/core/workout_execution/v1/event/new_personal_record_achieved.proto](proto/contracts/core/workout_execution/v1/event/new_personal_record_achieved.proto)`: [NEW] Sự kiện đạt kỷ lục 1RM mới.
- `[proto/contracts/core/workout_execution/v1/event/workout_session_completed.proto](proto/contracts/core/workout_execution/v1/event/workout_session_completed.proto)`: Điều chỉnh `average_form_score` thành dạng `optional`.

### 4. Testing & Verification
- **Automated Tests**: Chạy thành công `make proto-lint` để kiểm tra cú pháp và `make proto-gen` để sinh stubs.
- **Manual Verification**: Kiểm tra mã nguồn Go stubs sinh ra tại `internal/gen/go/contracts` và kiểm tra tài liệu Swagger tại `unified_api.swagger.yaml` thấy hoạt động chính xác.

---
