### PR TITLE
:sparkles: feat(exercise): add archived status contract

### DIFF
--- a/docs/03_ddd_tactical_design.md
+++ b/docs/03_ddd_tactical_design.md
@@ -181,7 +181,11 @@
 - **Repository**: `ExerciseRepository`
 - **Domain Events**:
   - `ExerciseCreated`: Bài tập tạo mới (trạng thái `Draft`).
+  - `ExerciseSubmittedForApproval`: Bài tập được gửi vào hàng chờ duyệt.
   - `ExerciseApproved`: Admin phê duyệt → trạng thái `Active`.
+  - `ExerciseArchived`: Admin lưu trữ bài tập, thay cho xóa vật lý.
 - **Invariants**:
-  - Lifecycle: `Draft` → `PendingApproval` → `Active`.
+  - Lifecycle kích hoạt: `Draft` → `PendingApproval` → `Active`.
+  - Lifecycle lưu trữ: `Draft` | `PendingApproval` | `Active` → `Archived`.
   - Chỉ bài tập `Active` mới được tham chiếu bởi các Context khác.
+  - Bài tập `Archived` không được trả về trong luồng User đọc/tìm kiếm và không được cập nhật nội dung.

--- a/proto/contracts/core/workout_execution/v1/message/workout_execution_messages.proto
+++ b/proto/contracts/core/workout_execution/v1/message/workout_execution_messages.proto
@@ -6,7 +6,6 @@ option go_package = "github.com/viethung213/gym-companion/internal/gen/go/contra
 
 import "google/protobuf/timestamp.proto";
 
-// Request/Response cho StartWorkoutSession
 message StartWorkoutSessionRequest {
   string user_id = 1;
   string plan_id = 2;
@@ -17,19 +16,13 @@ message StartWorkoutSessionResponse {
   google.protobuf.Timestamp started_at = 2;
 }
 
-// Log cho từng rep (được tính toán từ Client và gửi lên Server)
-// Log cho từng rep (được tính toán từ Client và gửi lên Server)
 message RepLog {
   int32 rep_number = 1;
   float rom_percentage = 2;
-  repeated string error_codes = 3; // Ví dụ: ["ERR_BACK_ARCH", "ERR_KNEE_OVER_TOE"]
-  map<string, float> joint_angles = 4; // Map các góc khớp đã tính toán (ví dụ: {"knee_angle": 120.5})
-  repeated string error_codes = 3; // Ví dụ: ["ERR_BACK_ARCH", "ERR_KNEE_OVER_TOE"]
-  map<string, float> joint_angles = 4; // Map các góc khớp đã tính toán (ví dụ: {"knee_angle": 120.5})
+  repeated string error_codes = 3;
+  map<string, float> joint_angles = 4;
 }
 
-// Request/Response cho LogWorkoutSet
-// Request/Response cho LogWorkoutSet
 message LogWorkoutSetRequest {
   string session_id = 1;
   int32 set_number = 2;
@@ -37,23 +30,19 @@ message LogWorkoutSetRequest {
   int32 target_reps = 4;
   int32 actual_reps = 5;
   float weight = 6;
-  optional float form_score = 7; // Sử dụng optional để hỗ trợ N/A cho bài tập Phi AI
-  float rpe = 8; // Độ gắng sức (Rate of Perceived Exertion)
-  optional float form_score = 7; // Sử dụng optional để hỗ trợ N/A cho bài tập Phi AI
-  float rpe = 8; // Độ gắng sức (Rate of Perceived Exertion)
+  optional float form_score = 7;
+  float rpe = 8;
   repeated RepLog reps = 9;
-  string camera_angle = 10; // Góc quay camera thực tế lúc tập (ví dụ: "side", "front")
-  string camera_angle = 10; // Góc quay camera thực tế lúc tập (ví dụ: "side", "front")
+  string camera_angle = 10;
 }
 
 message LogWorkoutSetResponse {
   string set_log_id = 1;
 }
 
-// Request/Response cho AbortWorkoutSession
 message AbortWorkoutSessionRequest {
   string session_id = 1;
-  string reason = 2; // e.g. "timeout", "user_cancelled"
+  string reason = 2;
 }
 
 message AbortWorkoutSessionResponse {
@@ -61,8 +50,6 @@ message AbortWorkoutSessionResponse {
   google.protobuf.Timestamp aborted_at = 2;
 }
 
-// Request/Response cho CompleteWorkoutSession
-// Request/Response cho CompleteWorkoutSession
 message CompleteWorkoutSessionRequest {
   string session_id = 1;
 }
@@ -72,22 +59,19 @@ message CompleteWorkoutSessionResponse {
   google.protobuf.Timestamp completed_at = 2;
   int32 total_sets = 3;
   float total_volume = 4;
-  optional float average_form_score = 5; // Sử dụng optional nếu toàn bài phi AI
-  optional float average_form_score = 5; // Sử dụng optional nếu toàn bài phi AI
+  optional float average_form_score = 5;
   float average_rpe = 6;
 }
 
-// Nhật ký lỗi tư thế (được gom batch gửi định kỳ trong buổi tập)
 message ErrorLog {
   string error_code = 1;
-  string severity = 2; // "severity_1" hoặc "severity_2"
+  string severity = 2;
   google.protobuf.Timestamp timestamp = 3;
   int32 set_number = 4;
-  int32 rep_number = 5; // Có thể bằng -1 nếu không gắn với rep cụ thể (ví dụ: tập Plank bị võng lưng)
-  string exercise_id = 6; // Mã bài tập phát sinh lỗi
+  int32 rep_number = 5;
+  string exercise_id = 6;
 }
 
-// Request/Response cho SyncWorkoutLogs (Batch Async Sync)
 message SyncWorkoutLogsRequest {
   string session_id = 1;
   repeated ErrorLog errors = 2;
@@ -95,9 +79,6 @@ message SyncWorkoutLogsRequest {
 
 message SyncWorkoutLogsResponse {}
 
-
-
-// Cấu hình thoại tương thích HLV và lỗi tư thế
 message DialogueOption {
   string text = 1;
   string audio_url = 2;
@@ -110,25 +91,23 @@ message DialogueSeverities {
 
 message DialogueEngineConfig {
   string personality_id = 1;
-  map<string, float> cooldowns = 2; // Ví dụ: {"severity_2": 3.0}
-  map<string, DialogueSeverities> dialogue_map = 3; // key là error_code (ví dụ: "ERR_BACK_ARCH")
+  map<string, float> cooldowns = 2;
+  map<string, DialogueSeverities> dialogue_map = 3;
 }
 
-// Request/Response cho GetMotionSpecification
 message GetMotionSpecificationRequest {
   string exercise_id = 1;
-  string coach_personality = 2; // drill_sergeant, best_friend, data_analyst
+  string coach_personality = 2;
 }
 
 message GetMotionSpecificationResponse {
   string exercise_id = 1;
   string onnx_model_url = 2;
-  string local_rules_url = 3; // URL tải file JSON cấu hình luật (ví dụ: keypoint confidence, filters, priorities)
+  string local_rules_url = 3;
   DialogueEngineConfig dialogue_engine = 4;
-  string recommended_camera_angle = 5; // Góc quay camera khuyến nghị (ví dụ: "side", "front")
+  string recommended_camera_angle = 5;
 }
 
-// Cấu trúc và Request/Response cho GetPersonalRecords
 message PersonalRecord {
   string exercise_id = 1;
   float one_rep_max = 2;
@@ -139,16 +118,13 @@ message PersonalRecord {
 
 message GetPersonalRecordsRequest {
   string user_id = 1;
-  repeated string exercise_ids = 2; // Để trống để lấy tất cả bài tập
+  repeated string exercise_ids = 2;
 }
 
 message GetPersonalRecordsResponse {
   repeated PersonalRecord records = 1;
 }
 
-
-
-// Request/Response cho GetWorkoutSessionErrors
 message GetWorkoutSessionErrorsRequest {
   string session_id = 1;
 }
@@ -158,12 +134,10 @@ message GetWorkoutSessionErrorsResponse {
   repeated ErrorLog errors = 2;
 }
 
-// Request/Response cho GetWorkoutHistory
 message GetWorkoutHistoryRequest {
   string user_id = 1;
   int32 limit = 2;
-  int32 offset = 3; // Vị trí bắt đầu lấy bản ghi (mặc định là 0 nếu để trống)
-  int32 offset = 3; // Vị trí bắt đầu lấy bản ghi (mặc định là 0 nếu để trống)
+  int32 offset = 3;
 }
 
 message WorkoutSessionSummary {
@@ -171,8 +145,7 @@ message WorkoutSessionSummary {
   google.protobuf.Timestamp date = 2;
   int32 total_sets = 3;
   float total_volume = 4;
-  optional float average_form_score = 5; // Dạng optional (N/A nếu buổi tập phi AI)
-  optional float average_form_score = 5; // Dạng optional (N/A nếu buổi tập phi AI)
+  optional float average_form_score = 5;
 }
 
 message GetWorkoutHistoryResponse {

--- a/proto/contracts/supporting/exercise/v1/event/exercise_events.proto
+++ b/proto/contracts/supporting/exercise/v1/event/exercise_events.proto
@@ -9,11 +9,23 @@ import "contracts/supporting/exercise/v1/message/exercise_messages.proto";
 // Event payload when a new exercise is created in Draft state
 message ExerciseCreatedEvent {
   string exercise_id = 1;
-  contracts.supporting.exercise.v1.message.Exercise exercise = 2;
+  contracts.supporting.exercise.v1.message.ExerciseInfo exercise = 2;
+}
+
+// Event payload when an exercise is submitted for approval
+message ExerciseSubmittedForApprovalEvent {
+  string exercise_id = 1;
+  contracts.supporting.exercise.v1.message.ExerciseInfo exercise = 2;
 }
 
 // Event payload when an exercise is approved and goes Active
 message ExerciseApprovedEvent {
   string exercise_id = 1;
-  contracts.supporting.exercise.v1.message.Exercise exercise = 2;
+  contracts.supporting.exercise.v1.message.ExerciseInfo exercise = 2;
+}
+
+// Event payload when an exercise is archived
+message ExerciseArchivedEvent {
+  string exercise_id = 1;
+  contracts.supporting.exercise.v1.message.ExerciseInfo exercise = 2;
 }

--- a/proto/contracts/supporting/exercise/v1/message/exercise_messages.proto
+++ b/proto/contracts/supporting/exercise/v1/message/exercise_messages.proto
@@ -9,6 +9,7 @@ enum ExerciseStatus {
   EXERCISE_STATUS_DRAFT = 1;
   EXERCISE_STATUS_PENDING_APPROVAL = 2;
   EXERCISE_STATUS_ACTIVE = 3;
+  EXERCISE_STATUS_ARCHIVED = 4;
 }
 
 message ExerciseInfo {
@@ -61,7 +62,7 @@ message UpdateExerciseRequest {
   string difficulty = 11;
   int32 default_rest_seconds = 12;
   repeated string tag_ids = 13;
-  ExerciseStatus status = 14;
+  ExerciseStatus status = 14 [deprecated = true];
 }
 
 message UpdateExerciseResponse {
@@ -74,6 +75,22 @@ message DeleteExerciseRequest {
 
 message DeleteExerciseResponse {
   bool success = 1;
+}
+
+message SubmitExerciseForApprovalRequest {
+  string id = 1;
+}
+
+message SubmitExerciseForApprovalResponse {
+  ExerciseInfo exercise = 1;
+}
+
+message ApproveExerciseRequest {
+  string id = 1;
+}
+
+message ApproveExerciseResponse {
+  ExerciseInfo exercise = 1;
 }
 
 message GetExerciseRequest {

--- a/proto/contracts/supporting/exercise/v1/service/exercise_service.proto
+++ b/proto/contracts/supporting/exercise/v1/service/exercise_service.proto
@@ -5,7 +5,33 @@ package contracts.supporting.exercise.v1.service;
 option go_package = "github.com/viethung213/gym-companion/internal/gen/go/contracts/supporting/exercise/v1/service;exercisev1service";
 
 import "google/api/annotations.proto";
+import "protoc-gen-openapiv2/options/annotations.proto";
 import "contracts/supporting/exercise/v1/message/exercise_messages.proto";
+
+option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
+  info: {
+    title: "Exercise Catalog API"
+    version: "1.0"
+    description: "API quản lý thư viện bài tập và luồng phê duyệt bài tập."
+  }
+  security_definitions: {
+    security: {
+      key: "BearerAuth"
+      value: {
+        type: TYPE_API_KEY
+        in: IN_HEADER
+        name: "Authorization"
+        description: "Bearer access token (Format: Bearer <token>)"
+      }
+    }
+  }
+  security: {
+    security_requirement: {
+      key: "BearerAuth"
+      value: {}
+    }
+  }
+};
 
 service ExerciseService {
   // Tìm kiếm bài tập trong thư viện (User & Coach)
@@ -40,6 +66,20 @@ service ExerciseService {
   rpc UpdateExercise (contracts.supporting.exercise.v1.message.UpdateExerciseRequest) returns (contracts.supporting.exercise.v1.message.UpdateExerciseResponse) {
     option (google.api.http) = {
       put: "/api/v1/admin/exercises/{id}"
+      body: "*"
+    };
+  }
+
+  rpc SubmitExerciseForApproval (contracts.supporting.exercise.v1.message.SubmitExerciseForApprovalRequest) returns (contracts.supporting.exercise.v1.message.SubmitExerciseForApprovalResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/admin/exercises/{id}/submit"
+      body: "*"
+    };
+  }
+
+  rpc ApproveExercise (contracts.supporting.exercise.v1.message.ApproveExerciseRequest) returns (contracts.supporting.exercise.v1.message.ApproveExerciseResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/admin/exercises/{id}/approve"
       body: "*"
     };
   }

--- a/scripts/postgres-init/02-create-exercise-tables.sql
+++ b/scripts/postgres-init/02-create-exercise-tables.sql
@@ -40,15 +40,20 @@ CREATE TABLE IF NOT EXISTS exercise.exercises (
     video_url VARCHAR(1024),
     difficulty VARCHAR(50) DEFAULT 'Beginner',
     default_rest_seconds INT DEFAULT 60,
-    status VARCHAR(50) DEFAULT 'ACTIVE',
+    status VARCHAR(50) DEFAULT 'DRAFT',
+    archived_at TIMESTAMP WITH TIME ZONE,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_exercises_status CHECK (
+        status IN ('DRAFT', 'PENDING_APPROVAL', 'ACTIVE', 'ARCHIVED')
+    )
 );
 
 -- Indexing for Exercises Foreign Keys
 CREATE INDEX IF NOT EXISTS idx_exercises_body_part ON exercise.exercises(body_part_id);
 CREATE INDEX IF NOT EXISTS idx_exercises_equipment ON exercise.exercises(equipment_id);
 CREATE INDEX IF NOT EXISTS idx_exercises_target_muscle ON exercise.exercises(target_muscle_id);
+CREATE INDEX IF NOT EXISTS idx_exercises_status ON exercise.exercises(status);
 
 -- 6. Table: exercise_secondary_muscles (Many-to-Many)
 CREATE TABLE IF NOT EXISTS exercise.exercise_secondary_muscles (


### PR DESCRIPTION
## 1. Problem to Solve
- Exercise lifecycle docs/contracts did not represent archived exercises.
- Delete behavior needed to be modeled as archive instead of physical deletion.

## 2. Proposed Solution
- Add EXERCISE_STATUS_ARCHIVED to Exercise contracts.
- Add submit/approve workflow RPCs and archive event payload.
- Update exercise schema with ARCHIVED, rchived_at, and status constraint.
- Document Exercise archived lifecycle in DDD tactical design.
- Remove duplicate tags in workout execution proto so Buf codegen/lint can run.

## 3. Changes & Impact
- proto/contracts/supporting/exercise/v1/message/exercise_messages.proto: adds archived status and workflow messages.
- proto/contracts/supporting/exercise/v1/service/exercise_service.proto: adds BearerAuth and workflow RPCs.
- proto/contracts/supporting/exercise/v1/event/exercise_events.proto: fixes ExerciseInfo event payloads and adds submit/archive events.
- scripts/postgres-init/02-create-exercise-tables.sql: changes default to DRAFT, adds archived_at and status constraint.
- docs/03_ddd_tactical_design.md: documents archived lifecycle semantics.

## 4. Testing & Verification
- docker compose -f infra/buf/docker-compose.yml run --rm buf lint proto passed.
