### PR TITLE
👷 ci(proto): optimize and unify buf image generation workflow

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -36,9 +36,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate API stubs via Buf Docker Image
-        run: |
-          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace ghcr.io/viethung213/gym-companion/buf-generator:latest generate proto --template proto/buf.gen.yaml
+      - name: Generate API stubs via Make
+        run: make proto-gen
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/publish-buf-image.yml
+++ b/.github/workflows/publish-buf-image.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'buf.Dockerfile' # Chỉ kích hoạt build lại khi thay đổi Dockerfile này
+      - 'infra/buf/buf.Dockerfile' # Chỉ kích hoạt build lại khi thay đổi Dockerfile này
 
 env:
   REGISTRY: ghcr.io
@@ -41,7 +41,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./buf.Dockerfile
+          file: ./infra/buf/buf.Dockerfile
           push: true
           tags: |
             ${{ steps.prep.outputs.image_path }}:latest

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BUF_COMPOSE = docker compose -f infra/buf/docker-compose.yml
 # Bước 1: Build Docker image chứa Buf CLI và các plugins Go sinh stubs
 proto-docker-build:
 	@echo "Building Buf custom Docker image..."
-	$(BUF_COMPOSE) build
+	docker build -t ghcr.io/viethung213/gym-companion/buf-generator:latest -f infra/buf/buf.Dockerfile .
 
 # Bước 2: Sinh mã nguồn Go (stubs) và tài liệu Swagger OpenAPI từ các hợp đồng Proto
 proto-gen: clean

--- a/infra/buf/docker-compose.yml
+++ b/infra/buf/docker-compose.yml
@@ -2,10 +2,7 @@ version: '3.8'
 
 services:
   buf:
-    build:
-      context: ../../
-      dockerfile: infra/buf/buf.Dockerfile
-    image: fitai-buf-gen
+    image: ghcr.io/viethung213/gym-companion/buf-generator:latest
     volumes:
       - ../../:/workspace
     working_dir: /workspace


### PR DESCRIPTION
### 1. Problem to Solve
- Trước đây, tệp cấu hình `infra/buf/docker-compose.yml` quy định việc tự động build Docker image `fitai-buf-gen` từ `buf.Dockerfile`. Khi lập trình viên chạy lệnh `make proto-gen` ở môi trường local hoặc khi chạy CI, Docker Compose sẽ tốn nhiều phút để tải base image và biên dịch các plugin Go.
- Cấu hình CI `golangci-lint.yml` sử dụng lệnh `docker run` thủ công và dài dòng để kéo pre-built image từ GHCR, không đồng bộ với lệnh `make` ở local.
- Workflow `publish-buf-image.yml` trỏ sai đường dẫn `buf.Dockerfile` (ở thư mục gốc thay vì `infra/buf/buf.Dockerfile`), khiến trigger CI bị lỗi không thể kích hoạt đúng cách.

### 2. Proposed Solution
- Cập nhật `infra/buf/docker-compose.yml` để sử dụng trực tiếp image pre-built `ghcr.io/viethung213/gym-companion/buf-generator:latest` thay vì build cục bộ. Việc này giúp cải thiện đáng kể tốc độ gen ở local ở lần đầu tiên chạy.
- Đồng bộ hóa CI `golangci-lint.yml` để sử dụng lệnh `make proto-gen` thay vì gọi lệnh `docker run` thủ công.
- Cập nhật `Makefile` để target `proto-docker-build` biên dịch thủ công qua lệnh `docker build` trực tiếp chỉ khi cần thiết.
- Sửa lỗi đường dẫn tệp `buf.Dockerfile` trong workflow `publish-buf-image.yml` thành `infra/buf/buf.Dockerfile`.

### 3. Changes & Impact
- `[infra/buf/docker-compose.yml](infra/buf/docker-compose.yml)`: Loại bỏ build context, cập nhật sử dụng registry image `ghcr.io/viethung213/gym-companion/buf-generator:latest`.
- `[Makefile](Makefile)`: Cập nhật target `proto-docker-build` chạy `docker build` trực tiếp thay vì compose build.
- `[.github/workflows/golangci-lint.yml](.github/workflows/golangci-lint.yml)`: Thay thế câu lệnh docker run dài dòng bằng `make proto-gen`.
- `[.github/workflows/publish-buf-image.yml](.github/workflows/publish-buf-image.yml)`: Điều chỉnh đường dẫn trigger paths và file Dockerfile trỏ chính xác về thư mục `infra/buf/`.

### 4. Testing & Verification
- **Manual Verification**:
  - Đã chạy thử lệnh `make proto-gen` ở môi trường cục bộ để xác minh cú pháp lệnh Makefile không có lỗi (lệnh thực hiện gọi Docker thành công, tuy nhiên docker daemon cục bộ đang tắt nên xuất hiện thông báo lỗi connect của Docker daemon).
