### PR TITLE
♻️ refactor(exercise): use protobuf stubs for outbox event payload

### DIFF
--- a/internal/exercise/application/command/event.go
+++ b/internal/exercise/application/command/event.go
@@ -1,49 +1,16 @@
 package command
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/viethung213/gym-companion/internal/exercise/application/port"
 	"github.com/viethung213/gym-companion/internal/exercise/domain"
+	exercisev1event "github.com/viethung213/gym-companion/internal/gen/go/contracts/supporting/exercise/v1/event"
+	exercisev1msg "github.com/viethung213/gym-companion/internal/gen/go/contracts/supporting/exercise/v1/message"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
-
-type exerciseEventPayload struct {
-	ID                 string   `json:"id"`
-	Name               string   `json:"name"`
-	BodyPartID         string   `json:"bodyPartId"`
-	EquipmentID        string   `json:"equipmentId"`
-	TargetMuscleID     string   `json:"targetMuscleId"`
-	Instructions       string   `json:"instructions"`
-	SecondaryMuscleIDs []string `json:"secondaryMuscleIds"`
-	ThumbnailURL       string   `json:"thumbnailUrl"`
-	MediaURL           string   `json:"mediaUrl"`
-	VideoURL           string   `json:"videoUrl"`
-	Difficulty         string   `json:"difficulty"`
-	DefaultRestSeconds int32    `json:"defaultRestSeconds"`
-	TagIDs             []string `json:"tagIds"`
-	Status             string   `json:"status"`
-}
-
-func newExerciseEventPayload(info *domain.Info) exerciseEventPayload {
-	return exerciseEventPayload{
-		ID:                 info.ID,
-		Name:               info.Name,
-		BodyPartID:         info.BodyPartID,
-		EquipmentID:        info.EquipmentID,
-		TargetMuscleID:     info.TargetMuscleID,
-		Instructions:       info.Instructions,
-		SecondaryMuscleIDs: info.SecondaryMuscleIDs,
-		ThumbnailURL:       info.ThumbnailURL,
-		MediaURL:           info.MediaURL,
-		VideoURL:           info.VideoURL,
-		Difficulty:         info.Difficulty,
-		DefaultRestSeconds: info.DefaultRestSeconds,
-		TagIDs:             info.TagIDs,
-		Status:             string(info.Status),
-	}
-}
 
 func newEvent(
 	ids port.IDGenerator,
@@ -52,7 +19,35 @@ func newEvent(
 	now time.Time,
 ) (*domain.Event, error) {
 	info := exercise.Info()
-	payload, err := json.Marshal(newExerciseEventPayload(&info))
+	exerciseInfo := mapToProtoExerciseInfo(&info)
+
+	var protoMsg proto.Message
+	switch eventType {
+	case domain.EventTypeExerciseCreated:
+		protoMsg = &exercisev1event.ExerciseCreatedEvent{
+			ExerciseId: exerciseInfo.Id,
+			Exercise:   exerciseInfo,
+		}
+	case domain.EventTypeExerciseSubmittedForApproval:
+		protoMsg = &exercisev1event.ExerciseSubmittedForApprovalEvent{
+			ExerciseId: exerciseInfo.Id,
+			Exercise:   exerciseInfo,
+		}
+	case domain.EventTypeExerciseApproved:
+		protoMsg = &exercisev1event.ExerciseApprovedEvent{
+			ExerciseId: exerciseInfo.Id,
+			Exercise:   exerciseInfo,
+		}
+	case domain.EventTypeExerciseArchived:
+		protoMsg = &exercisev1event.ExerciseArchivedEvent{
+			ExerciseId: exerciseInfo.Id,
+			Exercise:   exerciseInfo,
+		}
+	default:
+		return nil, fmt.Errorf("unknown event type: %s", eventType)
+	}
+
+	payloadBytes, err := protojson.Marshal(protoMsg)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", domain.ErrInvalidOutboxPayload, err)
 	}
@@ -65,8 +60,42 @@ func newEvent(
 	return &domain.Event{
 		ID:           id,
 		Type:         eventType,
-		PartitionKey: exercise.Info().ID,
-		Payload:      payload,
+		PartitionKey: info.ID,
+		Payload:      payloadBytes,
 		CreatedAt:    now,
 	}, nil
+}
+
+func mapToProtoExerciseInfo(info *domain.Info) *exercisev1msg.ExerciseInfo {
+	return &exercisev1msg.ExerciseInfo{
+		Id:                 info.ID,
+		Name:               info.Name,
+		BodyPartId:         info.BodyPartID,
+		EquipmentId:        info.EquipmentID,
+		TargetMuscleId:     info.TargetMuscleID,
+		Instructions:       info.Instructions,
+		SecondaryMuscleIds: info.SecondaryMuscleIDs,
+		ThumbnailUrl:       info.ThumbnailURL,
+		MediaUrl:           info.MediaURL,
+		VideoUrl:           info.VideoURL,
+		Difficulty:         info.Difficulty,
+		DefaultRestSeconds: info.DefaultRestSeconds,
+		TagIds:             info.TagIDs,
+		Status:             mapToProtoStatus(info.Status),
+	}
+}
+
+func mapToProtoStatus(status domain.Status) exercisev1msg.ExerciseStatus {
+	switch status {
+	case domain.StatusDraft:
+		return exercisev1msg.ExerciseStatus_EXERCISE_STATUS_DRAFT
+	case domain.StatusPendingApproval:
+		return exercisev1msg.ExerciseStatus_EXERCISE_STATUS_PENDING_APPROVAL
+	case domain.StatusActive:
+		return exercisev1msg.ExerciseStatus_EXERCISE_STATUS_ACTIVE
+	case domain.StatusArchived:
+		return exercisev1msg.ExerciseStatus_EXERCISE_STATUS_ARCHIVED
+	default:
+		return exercisev1msg.ExerciseStatus_EXERCISE_STATUS_UNSPECIFIED
+	}
 }


### PR DESCRIPTION
### 1. Problem to Solve
- In the `exercise` module, the `newEvent` function inside `internal/exercise/application/command/event.go` was using a local custom struct `exerciseEventPayload` and serializing using the standard `json.Marshal` library.
- This violated the **Contract-First** and **SSOT** principles of the project because the resulting JSON format was flat and did not match the Protobuf message schemas (`ExerciseCreatedEvent`, `ExerciseSubmittedForApprovalEvent`, etc.).
- Closes #130

### 2. Proposed Solution
- Replaced the local flat struct `exerciseEventPayload` with mapping functions to generated Protobuf stubs (`exercisev1msg.ExerciseInfo` and the respective event types like `ExerciseCreatedEvent`).
- Used `protojson.Marshal` from the Google protobuf library to serialize the Protobuf structs to camelCase JSON byte arrays, ensuring full contract compatibility.
- Decoupled event factory creation by switching on the specific `eventType` to instantiate concrete event type stubs, adhering to Go's type-safety requirements and the Open/Closed Principle.

### 3. Changes & Impact
List of modified files:
- `[internal/exercise/application/command/event.go](internal/exercise/application/command/event.go)`:
  - Deleted the custom struct `exerciseEventPayload` and its mapper.
  - Implemented `mapToProtoExerciseInfo` and `mapToProtoStatus` helper functions with correct casing corresponding to the generated protobuf stubs.
  - Updated `newEvent` to switch on event types, build the appropriate protobuf message, and serialize it using `protojson.Marshal`.

### 4. Testing & Verification
- **Automated Tests**:
  - Rebuilt the test environment Docker container image: `docker build --target tester -t fitai-app:test .`
  - Ran unit tests inside the container: `docker run --rm fitai-app:test go test -v -race -tags=unit ./internal/exercise/...` (all tests passed successfully).
  - Executed static analysis: `docker run --rm fitai-app:test go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5 run -v` (no errors were detected in our modified files).
- **Manual Verification**:
  - Verified field mapping and type safety against `AGENTS.md` and `go-style-rules`.
