### PR TITLE
🐛 fix(exercise): wrap outbox event payload inside standard CloudEvents envelope

### DIFF
--- a/internal/exercise/application/command/event.go
+++ b/internal/exercise/application/command/event.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -57,11 +58,27 @@ func newEvent(
 		return nil, fmt.Errorf("generate event id: %w", err)
 	}
 
+	// Wrap payload inside CloudEvents envelope to align with AGENTS.md conventions
+	cloudEvent := map[string]any{
+		"specversion":     "1.0",
+		"id":              id,
+		"source":          "services/exercise-service",
+		"type":            eventType,
+		"time":            now.Format(time.RFC3339),
+		"datacontenttype": "application/json",
+		"data":            json.RawMessage(payloadBytes),
+	}
+
+	envelopeBytes, err := json.Marshal(cloudEvent)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", domain.ErrInvalidOutboxPayload, err)
+	}
+
 	return &domain.Event{
 		ID:           id,
 		Type:         eventType,
 		PartitionKey: info.ID,
-		Payload:      payloadBytes,
+		Payload:      envelopeBytes,
 		CreatedAt:    now,
 	}, nil
 }

--- a/internal/exercise/application/command/event.go
+++ b/internal/exercise/application/command/event.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 

--- a/internal/exercise/application/command/event.go
+++ b/internal/exercise/application/command/event.go
@@ -1,49 +1,16 @@
 package command
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/viethung213/gym-companion/internal/exercise/application/port"
 	"github.com/viethung213/gym-companion/internal/exercise/domain"
+	exercisev1event "github.com/viethung213/gym-companion/internal/gen/go/contracts/supporting/exercise/v1/event"
+	exercisev1msg "github.com/viethung213/gym-companion/internal/gen/go/contracts/supporting/exercise/v1/message"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
-
-type exerciseEventPayload struct {
-	ID                 string   `json:"id"`
-	Name               string   `json:"name"`
-	BodyPartID         string   `json:"bodyPartId"`
-	EquipmentID        string   `json:"equipmentId"`
-	TargetMuscleID     string   `json:"targetMuscleId"`
-	Instructions       string   `json:"instructions"`
-	SecondaryMuscleIDs []string `json:"secondaryMuscleIds"`
-	ThumbnailURL       string   `json:"thumbnailUrl"`
-	MediaURL           string   `json:"mediaUrl"`
-	VideoURL           string   `json:"videoUrl"`
-	Difficulty         string   `json:"difficulty"`
-	DefaultRestSeconds int32    `json:"defaultRestSeconds"`
-	TagIDs             []string `json:"tagIds"`
-	Status             string   `json:"status"`
-}
-
-func newExerciseEventPayload(info *domain.Info) exerciseEventPayload {
-	return exerciseEventPayload{
-		ID:                 info.ID,
-		Name:               info.Name,
-		BodyPartID:         info.BodyPartID,
-		EquipmentID:        info.EquipmentID,
-		TargetMuscleID:     info.TargetMuscleID,
-		Instructions:       info.Instructions,
-		SecondaryMuscleIDs: info.SecondaryMuscleIDs,
-		ThumbnailURL:       info.ThumbnailURL,
-		MediaURL:           info.MediaURL,
-		VideoURL:           info.VideoURL,
-		Difficulty:         info.Difficulty,
-		DefaultRestSeconds: info.DefaultRestSeconds,
-		TagIDs:             info.TagIDs,
-		Status:             string(info.Status),
-	}
-}
 
 func newEvent(
 	ids port.IDGenerator,
@@ -52,7 +19,35 @@ func newEvent(
 	now time.Time,
 ) (*domain.Event, error) {
 	info := exercise.Info()
-	payload, err := json.Marshal(newExerciseEventPayload(&info))
+	exerciseInfo := mapToProtoExerciseInfo(&info)
+
+	var protoMsg proto.Message
+	switch eventType {
+	case domain.EventTypeExerciseCreated:
+		protoMsg = &exercisev1event.ExerciseCreatedEvent{
+			ExerciseId: exerciseInfo.Id,
+			Exercise:   exerciseInfo,
+		}
+	case domain.EventTypeExerciseSubmittedForApproval:
+		protoMsg = &exercisev1event.ExerciseSubmittedForApprovalEvent{
+			ExerciseId: exerciseInfo.Id,
+			Exercise:   exerciseInfo,
+		}
+	case domain.EventTypeExerciseApproved:
+		protoMsg = &exercisev1event.ExerciseApprovedEvent{
+			ExerciseId: exerciseInfo.Id,
+			Exercise:   exerciseInfo,
+		}
+	case domain.EventTypeExerciseArchived:
+		protoMsg = &exercisev1event.ExerciseArchivedEvent{
+			ExerciseId: exerciseInfo.Id,
+			Exercise:   exerciseInfo,
+		}
+	default:
+		return nil, fmt.Errorf("unknown event type: %s", eventType)
+	}
+
+	payloadBytes, err := protojson.Marshal(protoMsg)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", domain.ErrInvalidOutboxPayload, err)
 	}
@@ -65,8 +60,42 @@ func newEvent(
 	return &domain.Event{
 		ID:           id,
 		Type:         eventType,
-		PartitionKey: exercise.Info().ID,
-		Payload:      payload,
+		PartitionKey: info.ID,
+		Payload:      payloadBytes,
 		CreatedAt:    now,
 	}, nil
+}
+
+func mapToProtoExerciseInfo(info *domain.Info) *exercisev1msg.ExerciseInfo {
+	return &exercisev1msg.ExerciseInfo{
+		Id:                 info.ID,
+		Name:               info.Name,
+		BodyPartId:         info.BodyPartID,
+		EquipmentId:        info.EquipmentID,
+		TargetMuscleId:     info.TargetMuscleID,
+		Instructions:       info.Instructions,
+		SecondaryMuscleIds: info.SecondaryMuscleIDs,
+		ThumbnailUrl:       info.ThumbnailURL,
+		MediaUrl:           info.MediaURL,
+		VideoUrl:           info.VideoURL,
+		Difficulty:         info.Difficulty,
+		DefaultRestSeconds: info.DefaultRestSeconds,
+		TagIds:             info.TagIDs,
+		Status:             mapToProtoStatus(info.Status),
+	}
+}
+
+func mapToProtoStatus(status domain.Status) exercisev1msg.ExerciseStatus {
+	switch status {
+	case domain.StatusDraft:
+		return exercisev1msg.ExerciseStatus_EXERCISE_STATUS_DRAFT
+	case domain.StatusPendingApproval:
+		return exercisev1msg.ExerciseStatus_EXERCISE_STATUS_PENDING_APPROVAL
+	case domain.StatusActive:
+		return exercisev1msg.ExerciseStatus_EXERCISE_STATUS_ACTIVE
+	case domain.StatusArchived:
+		return exercisev1msg.ExerciseStatus_EXERCISE_STATUS_ARCHIVED
+	default:
+		return exercisev1msg.ExerciseStatus_EXERCISE_STATUS_UNSPECIFIED
+	}
 }

--- a/internal/exercise/application/command/event_test.go
+++ b/internal/exercise/application/command/event_test.go
@@ -1,0 +1,183 @@
+package command
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/viethung213/gym-companion/internal/exercise/domain"
+)
+
+type mockIDGenerator struct {
+	id  string
+	err error
+}
+
+func (m mockIDGenerator) NewID() (string, error) {
+	return m.id, m.err
+}
+
+func TestNewEvent_CloudEvents(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	info := domain.Info{
+		ID:                 "exercise-123",
+		Name:               "Bench Press",
+		BodyPartID:         "chest",
+		EquipmentID:        "barbell",
+		TargetMuscleID:     "pecs",
+		SecondaryMuscleIDs: []string{"triceps"},
+		Instructions:       "Lie down and press.",
+		ThumbnailURL:       "thumb.png",
+		MediaURL:           "media.png",
+		VideoURL:           "video.mp4",
+		Difficulty:         "Intermediate",
+		DefaultRestSeconds: 90,
+		TagIDs:             []string{"power"},
+		Status:             domain.StatusDraft,
+	}
+
+	exercise, err := domain.NewExercise(info, now)
+	if err != nil {
+		t.Fatalf("failed to create exercise: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		generator  mockIDGenerator
+		eventType  string
+		wantErrIs  error
+		expectType string
+	}{
+		{
+			name: "success created event",
+			generator: mockIDGenerator{
+				id: "event-uuid-789",
+			},
+			eventType:  domain.EventTypeExerciseCreated,
+			expectType: "contracts.supporting.exercise.v1.exerciseCreated",
+		},
+		{
+			name: "success approved event",
+			generator: mockIDGenerator{
+				id: "event-uuid-abc",
+			},
+			eventType:  domain.EventTypeExerciseApproved,
+			expectType: "contracts.supporting.exercise.v1.exerciseApproved",
+		},
+		{
+			name: "generator error",
+			generator: mockIDGenerator{
+				err: errors.New("id generator error"),
+			},
+			eventType: domain.EventTypeExerciseCreated,
+			wantErrIs: domain.ErrInvalidOutboxPayload,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			event, createErr := newEvent(tt.generator, tt.eventType, exercise, now)
+			if tt.wantErrIs != nil {
+				if createErr == nil {
+					t.Fatalf("got nil error, want error")
+				}
+				return
+			}
+
+			if createErr != nil {
+				t.Fatalf("got error %v, want nil", createErr)
+			}
+
+			if got := event.ID; got != tt.generator.id {
+				t.Errorf("got event ID %q, want %q", got, tt.generator.id)
+			}
+			if got := event.Type; got != tt.eventType {
+				t.Errorf("got event type %q, want %q", got, tt.eventType)
+			}
+			if got := event.PartitionKey; got != info.ID {
+				t.Errorf("got event partition key %q, want %q", got, info.ID)
+			}
+
+			// Verify CloudEvents payload JSON structure
+			var envelope map[string]any
+			if unmarshalErr := json.Unmarshal(event.Payload, &envelope); unmarshalErr != nil {
+				t.Fatalf("failed to unmarshal envelope: %v", unmarshalErr)
+			}
+
+			if got := envelope["specversion"]; got != "1.0" {
+				t.Errorf("got specversion %v, want 1.0", got)
+			}
+			if got := envelope["id"]; got != tt.generator.id {
+				t.Errorf("got ID %v, want %s", got, tt.generator.id)
+			}
+			if got := envelope["source"]; got != "services/exercise-service" {
+				t.Errorf("got source %v, want services/exercise-service", got)
+			}
+			if got := envelope["type"]; got != tt.expectType {
+				t.Errorf("got type %v, want %s", got, tt.expectType)
+			}
+			if got := envelope["time"]; got != now.Format(time.RFC3339) {
+				t.Errorf("got time %v, want %s", got, now.Format(time.RFC3339))
+			}
+			if got := envelope["datacontenttype"]; got != "application/json" {
+				t.Errorf("got datacontenttype %v, want application/json", got)
+			}
+
+			// Verify nested data block
+			dataRaw, ok := envelope["data"]
+			if !ok {
+				t.Fatalf("missing data block in envelope")
+			}
+
+			dataBytes, marshalErr := json.Marshal(dataRaw)
+			if marshalErr != nil {
+				t.Fatalf("failed to marshal data block: %v", marshalErr)
+			}
+
+			var data map[string]any
+			if unmarshalErr := json.Unmarshal(dataBytes, &data); unmarshalErr != nil {
+				t.Fatalf("failed to unmarshal data block: %v", unmarshalErr)
+			}
+
+			exerciseIDVal, ok := data["exerciseId"]
+			if !ok {
+				t.Fatalf("missing exerciseId inside data payload")
+			}
+			exerciseIDStr, ok := exerciseIDVal.(string)
+			if !ok {
+				t.Fatalf("exerciseId is not a string")
+			}
+			if exerciseIDStr != info.ID {
+				t.Errorf("got exerciseId %v, want %s", exerciseIDStr, info.ID)
+			}
+
+			exerciseVal, ok := data["exercise"]
+			if !ok {
+				t.Fatalf("missing exercise info inside data payload")
+			}
+
+			exerciseMap, ok := exerciseVal.(map[string]any)
+			if !ok {
+				t.Fatalf("exercise is not a map[string]any")
+			}
+			if got := exerciseMap["id"]; got != info.ID {
+				t.Errorf("got nested exercise id %v, want %s", got, info.ID)
+			}
+			if got := exerciseMap["name"]; got != info.Name {
+				t.Errorf("got nested exercise name %v, want %s", got, info.Name)
+			}
+			if got := exerciseMap["bodyPartId"]; got != info.BodyPartID {
+				t.Errorf("got nested exercise bodyPartId %v, want %s", got, info.BodyPartID)
+			}
+			if got := exerciseMap["status"]; got != "EXERCISE_STATUS_DRAFT" {
+				t.Errorf("got nested exercise status %v, want EXERCISE_STATUS_DRAFT", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### 1. Problem to Solve
- The outbox events stored in the database (`exercise.outbox`) and published to Kafka in the `exercise` module only contained the raw event payload, lacking the standard CloudEvents envelope.
- This violated the system standard defined in `AGENTS.md`: "all event envelopes must adhere strictly to the CloudEvents specification (specversion, id, source, type, time, datacontenttype, data)".
- Closes #131

### 2. Proposed Solution
- Wrapped the Protobuf-serialized JSON event payload in a standard CloudEvents envelope map (`specversion`, `id`, `source`, `type`, `time`, `datacontenttype`, `data`) directly inside `newEvent`.
- Set the `data` field of the envelope as a `json.RawMessage` containing the Protobuf JSON bytes.
- Marshaled the entire envelope to JSON bytes (`envelopeBytes`) using the standard library `json.Marshal` and added clean error handling.

### 3. Changes & Impact
List of modified files:
- `[internal/exercise/application/command/event.go](internal/exercise/application/command/event.go)`:
  - Imported `"encoding/json"`.
  - Updated `newEvent` to generate a UUID using `ids.NewID()`, construct the CloudEvents envelope map, marshal it, and set the payload to the marshaled envelope bytes.
- `[internal/exercise/application/command/event_test.go](internal/exercise/application/command/event_test.go)`:
  - Created a new unit test suite `TestNewEvent_CloudEvents` to verify the generated envelope contains all required attributes and that `data` contains the correct nested Protobuf fields.

### 4. Testing & Verification
- **Automated Tests**:
  - Rebuilt the test environment Docker container image: `docker build --target tester -t fitai-app:test .`
  - Ran unit tests inside the container: `docker run --rm fitai-app:test go test -v -race -tags=unit ./internal/exercise/...` (all tests, including the new CloudEvents validation tests, passed successfully).
  - Executed static analysis: `docker run --rm fitai-app:test go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5 run -v` (no errors were detected in our modified/new files).
- **Manual Verification**:
  - Verified that all envelope attributes conform strictly to the CloudEvents 1.0 standard and `AGENTS.md`.
