### PR TITLE
✨ feat(coaching): add planning contract and domain model

### DIFF
--- a/internal/coaching/domain/daily_workout_plan.go
+++ b/internal/coaching/domain/daily_workout_plan.go
@@ -1,0 +1,43 @@
+package domain
+
+import "time"
+
+type DailyPlanStatus string
+
+const (
+	DailyPlanStatusGenerated DailyPlanStatus = "generated"
+	DailyPlanStatusUsed      DailyPlanStatus = "used"
+	DailyPlanStatusReplaced  DailyPlanStatus = "replaced"
+)
+
+type PrescribedExercise struct {
+	ExerciseID  string
+	Sets        int
+	Reps        int
+	RestSeconds int
+}
+
+type DailyWorkoutPlan struct {
+	ID               string
+	UserID           string
+	RoadmapID        string
+	WeeklyScheduleID string
+	ScheduledDate    time.Time
+	Status           DailyPlanStatus
+	Exercises        []PrescribedExercise
+	GeneratedAt      time.Time
+}
+
+func NewDailyWorkoutPlan(id string, userID string, roadmapID string, weeklyScheduleID string, scheduledDate time.Time, exercises []PrescribedExercise, generatedAt time.Time) *DailyWorkoutPlan {
+	copiedExercises := append([]PrescribedExercise(nil), exercises...)
+	return &DailyWorkoutPlan{
+		ID:               id,
+		UserID:           userID,
+		RoadmapID:        roadmapID,
+		WeeklyScheduleID: weeklyScheduleID,
+		ScheduledDate:    dateOnly(scheduledDate),
+		Status:           DailyPlanStatusGenerated,
+		Exercises:        copiedExercises,
+		GeneratedAt:      generatedAt,
+	}
+}

--- a/internal/coaching/domain/planner.go
+++ b/internal/coaching/domain/planner.go
@@ -1,0 +1,94 @@
+package domain
+
+import (
+	"errors"
+	"time"
+)
+
+var ErrPreferredWeekdaysInsufficient = errors.New("preferred weekdays are fewer than training days")
+
+type SchedulePlanner struct{}
+
+func (SchedulePlanner) PlanWeek(input PlanningInput, weekNumber int) ([]ScheduleDay, error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+
+	trainingDays := selectedWeekdays(input.PreferredWeekdays, input.TrainingDaysPerWeek)
+	if len(trainingDays) != input.TrainingDaysPerWeek {
+		return nil, ErrPreferredWeekdaysInsufficient
+	}
+
+	startDate := dateOnly(input.StartDate).AddDate(0, 0, (weekNumber-1)*7)
+	days := make([]ScheduleDay, 0, 7)
+	for offset := 0; offset < 7; offset++ {
+		date := startDate.AddDate(0, 0, offset)
+		day := ScheduleDay{Date: date, Status: ScheduleDayStatusRest}
+		if trainingDays[date.Weekday()] {
+			day.Status = ScheduleDayStatusTraining
+			day.MuscleGroups = muscleGroupsForTrainingDay(offset, input.TrainingDaysPerWeek)
+		}
+		days = append(days, day)
+	}
+
+	return days, nil
+}
+
+func selectedWeekdays(preferred []time.Weekday, required int) map[time.Weekday]bool {
+	selected := make(map[time.Weekday]bool, required)
+	for _, weekday := range preferred {
+		if len(selected) == required {
+			break
+		}
+		selected[weekday] = true
+	}
+	return selected
+}
+
+func muscleGroupsForTrainingDay(dayOffset int, trainingDays int) []string {
+	splits := [][]string{
+		{"chest", "triceps"},
+		{"back", "biceps"},
+		{"legs"},
+		{"shoulders", "core"},
+		{"chest", "back"},
+		{"legs", "core"},
+	}
+	return append([]string(nil), splits[dayOffset%trainingDays]...)
+}
+
+type PrescriptionPlanner struct{}
+
+func (PrescriptionPlanner) Plan(exerciseIDs []string, experienceLevel ExperienceLevel) []PrescribedExercise {
+	sets, reps := prescriptionTargets(experienceLevel)
+	exercises := make([]PrescribedExercise, 0, len(exerciseIDs))
+	for _, exerciseID := range exerciseIDs {
+		exercises = append(exercises, PrescribedExercise{
+			ExerciseID:  exerciseID,
+			Sets:        sets,
+			Reps:        reps,
+			RestSeconds: 60,
+		})
+	}
+	return exercises
+}
+
+func prescriptionTargets(experienceLevel ExperienceLevel) (int, int) {
+	switch experienceLevel {
+	case ExperienceLevelAdvanced:
+		return 4, 8
+	case ExperienceLevelIntermediate:
+		return 3, 10
+	default:
+		return 2, 12
+	}
+}
+
+type PlannedVolumeValidator struct{}
+
+func (PlannedVolumeValidator) Validate(previousVolume int, nextVolume int) bool {
+	if previousVolume <= 0 {
+		return true
+	}
+	return nextVolume <= previousVolume*110/100
+}

--- a/internal/coaching/domain/planner_test.go
+++ b/internal/coaching/domain/planner_test.go
@@ -1,0 +1,77 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSchedulePlanner_PlanWeek(t *testing.T) {
+	tests := []struct {
+		name string
+		give PlanningInput
+		want int
+	}{
+		{
+			name: "creates requested training days with a rest day",
+			give: planningInputForTest(),
+			want: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			planner := SchedulePlanner{}
+			days, err := planner.PlanWeek(tt.give, 1)
+			if err != nil {
+				t.Fatalf("PlanWeek() error = %v", err)
+			}
+			if got := len(days); got != 7 {
+				t.Fatalf("len(days) = %d, want 7", got)
+			}
+
+			var trainingDays int
+			for _, day := range days {
+				if day.Status == ScheduleDayStatusTraining {
+					trainingDays++
+				}
+			}
+			if got := trainingDays; got != tt.want {
+				t.Fatalf("training days = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPlannedVolumeValidator_Validate(t *testing.T) {
+	tests := []struct {
+		name         string
+		givePrevious int
+		giveNext     int
+		want         bool
+	}{
+		{name: "accepts ten percent increase", givePrevious: 100, giveNext: 110, want: true},
+		{name: "rejects increase above ten percent", givePrevious: 100, giveNext: 111, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := PlannedVolumeValidator{}
+			if got := validator.Validate(tt.givePrevious, tt.giveNext); got != tt.want {
+				t.Fatalf("Validate() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func planningInputForTest() PlanningInput {
+	return PlanningInput{
+		Goal:                PlanningGoalMuscleGain,
+		ExperienceLevel:     ExperienceLevelBeginner,
+		TrainingDaysPerWeek: 3,
+		PreferredWeekdays:   []time.Weekday{time.Monday, time.Wednesday, time.Friday},
+		MaxSessionMinutes:   45,
+		EquipmentIDs:        []string{"dumbbell"},
+		Timezone:            "Asia/Ho_Chi_Minh",
+		StartDate:           time.Date(2026, time.July, 20, 0, 0, 0, 0, time.UTC),
+	}
+}

--- a/internal/coaching/domain/planning_input.go
+++ b/internal/coaching/domain/planning_input.go
@@ -1,0 +1,71 @@
+package domain
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+var (
+	ErrPlanningGoalRequired      = errors.New("planning goal is required")
+	ErrExperienceLevelRequired   = errors.New("experience level is required")
+	ErrTrainingDaysOutOfRange    = errors.New("training days must be between 1 and 6")
+	ErrSessionDurationOutOfRange = errors.New("session duration must be between 15 and 240 minutes")
+	ErrEquipmentRequired         = errors.New("at least one equipment id is required")
+	ErrTimezoneRequired          = errors.New("timezone is required")
+	ErrRoadmapStartDateRequired  = errors.New("roadmap start date is required")
+)
+
+type PlanningGoal string
+
+const (
+	PlanningGoalMuscleGain     PlanningGoal = "muscle_gain"
+	PlanningGoalFatLoss        PlanningGoal = "fat_loss"
+	PlanningGoalGeneralFitness PlanningGoal = "general_fitness"
+)
+
+type ExperienceLevel string
+
+const (
+	ExperienceLevelBeginner     ExperienceLevel = "beginner"
+	ExperienceLevelIntermediate ExperienceLevel = "intermediate"
+	ExperienceLevelAdvanced     ExperienceLevel = "advanced"
+)
+
+type PlanningInput struct {
+	Goal                PlanningGoal
+	ExperienceLevel     ExperienceLevel
+	TrainingDaysPerWeek int
+	PreferredWeekdays   []time.Weekday
+	MaxSessionMinutes   int
+	EquipmentIDs        []string
+	ActiveInjuryAreas   []string
+	Timezone            string
+	StartDate           time.Time
+}
+
+func (i PlanningInput) Validate() error {
+	if i.Goal == "" {
+		return ErrPlanningGoalRequired
+	}
+	if i.ExperienceLevel == "" {
+		return ErrExperienceLevelRequired
+	}
+	if i.TrainingDaysPerWeek < 1 || i.TrainingDaysPerWeek > 6 {
+		return ErrTrainingDaysOutOfRange
+	}
+	if i.MaxSessionMinutes < 15 || i.MaxSessionMinutes > 240 {
+		return ErrSessionDurationOutOfRange
+	}
+	if len(i.EquipmentIDs) == 0 {
+		return ErrEquipmentRequired
+	}
+	if strings.TrimSpace(i.Timezone) == "" {
+		return ErrTimezoneRequired
+	}
+	if i.StartDate.IsZero() {
+		return ErrRoadmapStartDateRequired
+	}
+
+	return nil
+}

--- a/internal/coaching/domain/roadmap.go
+++ b/internal/coaching/domain/roadmap.go
@@ -1,0 +1,58 @@
+package domain
+
+import (
+	"errors"
+	"time"
+)
+
+var ErrRoadmapIDRequired = errors.New("roadmap id is required")
+
+type RoadmapStatus string
+
+const (
+	RoadmapStatusActive    RoadmapStatus = "active"
+	RoadmapStatusPaused    RoadmapStatus = "paused"
+	RoadmapStatusCompleted RoadmapStatus = "completed"
+	RoadmapStatusCancelled RoadmapStatus = "cancelled"
+)
+
+type WorkoutRoadmap struct {
+	ID             string
+	UserID         string
+	Status         RoadmapStatus
+	StartDate      time.Time
+	EndDate        time.Time
+	Input          PlanningInput
+	PlannerVersion string
+}
+
+func NewWorkoutRoadmap(id string, userID string, input PlanningInput, plannerVersion string) (*WorkoutRoadmap, error) {
+	if id == "" {
+		return nil, ErrRoadmapIDRequired
+	}
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+
+	startDate := dateOnly(input.StartDate)
+	return &WorkoutRoadmap{
+		ID:             id,
+		UserID:         userID,
+		Status:         RoadmapStatusActive,
+		StartDate:      startDate,
+		EndDate:        startDate.AddDate(0, 0, 27),
+		Input:          copyPlanningInput(input),
+		PlannerVersion: plannerVersion,
+	}, nil
+}
+
+func dateOnly(value time.Time) time.Time {
+	return time.Date(value.Year(), value.Month(), value.Day(), 0, 0, 0, 0, value.Location())
+}
+
+func copyPlanningInput(input PlanningInput) PlanningInput {
+	input.PreferredWeekdays = append([]time.Weekday(nil), input.PreferredWeekdays...)
+	input.EquipmentIDs = append([]string(nil), input.EquipmentIDs...)
+	input.ActiveInjuryAreas = append([]string(nil), input.ActiveInjuryAreas...)
+	return input
+}

--- a/internal/coaching/domain/weekly_schedule.go
+++ b/internal/coaching/domain/weekly_schedule.go
@@ -1,0 +1,85 @@
+package domain
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	ErrScheduleMustContainSevenDays = errors.New("weekly schedule must contain seven days")
+	ErrScheduleMustContainRestDay   = errors.New("weekly schedule must contain at least one rest day")
+)
+
+type ScheduleDayStatus string
+
+const (
+	ScheduleDayStatusTraining    ScheduleDayStatus = "training"
+	ScheduleDayStatusRest        ScheduleDayStatus = "rest"
+	ScheduleDayStatusSkipped     ScheduleDayStatus = "skipped"
+	ScheduleDayStatusRescheduled ScheduleDayStatus = "rescheduled"
+)
+
+type ScheduleDay struct {
+	Date         time.Time
+	Status       ScheduleDayStatus
+	MuscleGroups []string
+	DailyPlanID  string
+}
+
+type WeeklySchedule struct {
+	ID         string
+	RoadmapID  string
+	UserID     string
+	WeekNumber int
+	StartDate  time.Time
+	EndDate    time.Time
+	Days       []ScheduleDay
+}
+
+func NewWeeklySchedule(id string, roadmapID string, userID string, weekNumber int, days []ScheduleDay) (*WeeklySchedule, error) {
+	if len(days) != 7 {
+		return nil, ErrScheduleMustContainSevenDays
+	}
+
+	var restDays int
+	for _, day := range days {
+		if day.Status == ScheduleDayStatusRest {
+			restDays++
+		}
+	}
+	if restDays == 0 {
+		return nil, ErrScheduleMustContainRestDay
+	}
+
+	copiedDays := copyScheduleDays(days)
+	return &WeeklySchedule{
+		ID:         id,
+		RoadmapID:  roadmapID,
+		UserID:     userID,
+		WeekNumber: weekNumber,
+		StartDate:  dateOnly(copiedDays[0].Date),
+		EndDate:    dateOnly(copiedDays[6].Date),
+		Days:       copiedDays,
+	}, nil
+}
+
+func (s *WeeklySchedule) AttachDailyPlan(scheduledDate time.Time, dailyPlanID string) error {
+	for index := range s.Days {
+		if !dateOnly(s.Days[index].Date).Equal(dateOnly(scheduledDate)) {
+			continue
+		}
+		s.Days[index].DailyPlanID = dailyPlanID
+		return nil
+	}
+
+	return errors.New("scheduled date does not belong to weekly schedule")
+}
+
+func copyScheduleDays(days []ScheduleDay) []ScheduleDay {
+	copiedDays := make([]ScheduleDay, len(days))
+	for index, day := range days {
+		day.MuscleGroups = append([]string(nil), day.MuscleGroups...)
+		copiedDays[index] = day
+	}
+	return copiedDays
+}

--- a/proto/contracts/core/coaching/v1/message/coaching_messages.proto
+++ b/proto/contracts/core/coaching/v1/message/coaching_messages.proto
@@ -15,6 +15,20 @@ enum RoadmapStatus {
   ROADMAP_STATUS_CANCELLED = 4;
 }
 
+enum PlanningGoal {
+  PLANNING_GOAL_UNSPECIFIED = 0;
+  PLANNING_GOAL_MUSCLE_GAIN = 1;
+  PLANNING_GOAL_FAT_LOSS = 2;
+  PLANNING_GOAL_GENERAL_FITNESS = 3;
+}
+
+enum ExperienceLevel {
+  EXPERIENCE_LEVEL_UNSPECIFIED = 0;
+  EXPERIENCE_LEVEL_BEGINNER = 1;
+  EXPERIENCE_LEVEL_INTERMEDIATE = 2;
+  EXPERIENCE_LEVEL_ADVANCED = 3;
+}
+
 enum ScheduleDayStatus {
   SCHEDULE_DAY_STATUS_UNSPECIFIED = 0;
   SCHEDULE_DAY_STATUS_TRAINING = 1;
@@ -68,6 +82,20 @@ message InitiateRoadmapRequest {
 
 message InitiateRoadmapPayload {
   string profile_snapshot_id = 1;
+  PlanningProfileSnapshot planning_profile = 2;
+}
+
+// Temporary planning input until Profile context provides immutable snapshots.
+message PlanningProfileSnapshot {
+  PlanningGoal goal = 1;
+  ExperienceLevel experience_level = 2;
+  int32 training_days_per_week = 3;
+  repeated string preferred_weekdays = 4;
+  int32 max_session_minutes = 5;
+  repeated string equipment_ids = 6;
+  repeated string active_injury_areas = 7;
+  string timezone = 8;
+  google.type.Date start_date = 9;
 }
 
 message InitiateRoadmapResponse {

--- a/proto/contracts/core/coaching/v1/service/coaching_service.proto
+++ b/proto/contracts/core/coaching/v1/service/coaching_service.proto
@@ -93,26 +93,4 @@ service CoachingService {
     };
   }
 
-  // Run BR-AC-04..08 adaptive review for a roadmap.
-  rpc RunAdaptiveReview (contracts.core.coaching.v1.message.RunAdaptiveReviewRequest) returns (contracts.core.coaching.v1.message.RunAdaptiveReviewResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/users/{user_id}/workout-roadmaps/{roadmap_id}/adaptive-reviews:run"
-      body: "payload"
-    };
-  }
-
-  // List pending or historical adaptive recommendations.
-  rpc ListAdaptiveRecommendations (contracts.core.coaching.v1.message.ListAdaptiveRecommendationsRequest) returns (contracts.core.coaching.v1.message.ListAdaptiveRecommendationsResponse) {
-    option (google.api.http) = {
-      get: "/api/v1/users/{user_id}/workout-roadmaps/{roadmap_id}/adaptive-recommendations"
-    };
-  }
-
-  // Apply or reject a user-facing adaptive recommendation.
-  rpc RespondAdaptiveRecommendation (contracts.core.coaching.v1.message.RespondAdaptiveRecommendationRequest) returns (contracts.core.coaching.v1.message.RespondAdaptiveRecommendationResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/users/{user_id}/adaptive-recommendations/{recommendation_id}:respond"
-      body: "payload"
-    };
-  }
 }


### PR DESCRIPTION
### 1. Problem to Solve

Coaching planning APIs lacked a temporary profile input contract and an executable domain foundation for roadmap, weekly schedule, and daily plan behavior.

### 2. Proposed Solution

Add the inline planning snapshot contract, narrow the published service to Planning MVP RPCs, and introduce deterministic domain aggregates and planners with planned-volume protection.

### 3. Changes & Impact

- proto/contracts/core/coaching/v1: adds planning input enums/snapshot and defers adaptive RPCs.
- internal/coaching/domain: adds roadmap, weekly schedule, daily plan, planning input, planners, and tests.

### 4. Testing & Verification

- PASS: Coaching-only Buf lint
- PASS: Buf code generation
- PASS: go test ./internal/coaching/...
- PASS: go vet ./internal/coaching/...
- Known pre-existing blocker: full Buf lint fails on Auth RPC response naming at uth_service.proto:86.