### PR TITLE
✨ feat(coaching): generate daily workout plans

### DIFF
--- a/internal/coaching/application/command/generate_daily_plan.go
+++ b/internal/coaching/application/command/generate_daily_plan.go
@@ -1,0 +1,146 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	"github.com/viethung213/gym-companion/internal/coaching/domain"
+)
+
+var (
+	ErrRestDay            = errors.New("daily plan cannot be generated for a rest day")
+	ErrInjurySafetyBlock  = errors.New("daily plan blocked because injury safety metadata is unavailable")
+	ErrNoMatchingExercise = errors.New("no matching exercises were found")
+)
+
+type GenerateDailyPlan struct {
+	UserID           string
+	WeeklyScheduleID string
+	ScheduledDate    time.Time
+	NewInjuryAreas   []string
+}
+
+type GenerateDailyPlanHandler struct {
+	repository port.Repository
+	searcher   port.ExerciseSearcher
+	clock      port.Clock
+	ids        port.IDGenerator
+	planner    domain.PrescriptionPlanner
+}
+
+func NewGenerateDailyPlanHandler(
+	repository port.Repository,
+	searcher port.ExerciseSearcher,
+	clock port.Clock,
+	ids port.IDGenerator,
+) *GenerateDailyPlanHandler {
+	return &GenerateDailyPlanHandler{
+		repository: repository,
+		searcher:   searcher,
+		clock:      clock,
+		ids:        ids,
+	}
+}
+
+func (h *GenerateDailyPlanHandler) Handle(
+	ctx context.Context,
+	command GenerateDailyPlan,
+) (*domain.DailyWorkoutPlan, error) {
+	schedule, err := h.repository.FindSchedule(ctx, command.UserID, command.WeeklyScheduleID)
+	if err != nil {
+		return nil, fmt.Errorf("find schedule: %w", err)
+	}
+	day, err := findScheduleDay(schedule, command.ScheduledDate)
+	if err != nil {
+		return nil, err
+	}
+	if day.Status == domain.ScheduleDayStatusRest {
+		return nil, ErrRestDay
+	}
+	roadmap, err := h.repository.FindRoadmap(ctx, command.UserID, schedule.RoadmapID)
+	if err != nil {
+		return nil, fmt.Errorf("find roadmap: %w", err)
+	}
+	if len(command.NewInjuryAreas) > 0 || len(roadmap.Input.ActiveInjuryAreas) > 0 {
+		return nil, ErrInjurySafetyBlock
+	}
+	if existing, findErr := h.repository.FindDailyPlanByDate(
+		ctx,
+		schedule.ID,
+		command.ScheduledDate,
+	); findErr == nil {
+		return existing, nil
+	} else if !errors.Is(findErr, domain.ErrNotFound) {
+		return nil, fmt.Errorf("find daily plan: %w", findErr)
+	}
+
+	candidates, err := h.searcher.Search(ctx, port.ExerciseSearchCriteria{
+		MuscleGroupIDs: day.MuscleGroups,
+		EquipmentIDs:   roadmap.Input.EquipmentIDs,
+		Difficulty:     string(roadmap.Input.ExperienceLevel),
+		Limit:          exerciseLimit(day),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("search exercises: %w", err)
+	}
+	if len(candidates) == 0 {
+		return nil, ErrNoMatchingExercise
+	}
+	exerciseIDs := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		exerciseIDs = append(exerciseIDs, candidate.ID)
+	}
+	exercises := h.planner.Plan(exerciseIDs, roadmap.Input.ExperienceLevel)
+	planID, err := h.ids.NewID()
+	if err != nil {
+		return nil, fmt.Errorf("generate daily plan id: %w", err)
+	}
+	generatedAt := h.clock.Now()
+	plan := domain.NewDailyWorkoutPlan(
+		planID,
+		command.UserID,
+		schedule.RoadmapID,
+		schedule.ID,
+		command.ScheduledDate,
+		exercises,
+		generatedAt,
+	)
+	if err := schedule.AttachDailyPlan(command.ScheduledDate, plan.ID); err != nil {
+		return nil, fmt.Errorf("attach daily plan: %w", err)
+	}
+	event := newEvent(
+		plan.ID,
+		command.UserID,
+		"contracts.coaching.coachingService.v1.dailyWorkoutPlanGenerated",
+		generatedAt,
+	)
+	if err := h.repository.SaveDailyPlan(ctx, schedule, plan, event); err != nil {
+		return nil, fmt.Errorf("persist daily plan: %w", err)
+	}
+	return plan, nil
+}
+
+func findScheduleDay(schedule *domain.WeeklySchedule, scheduledDate time.Time) (*domain.ScheduleDay, error) {
+	for index := range schedule.Days {
+		if sameDate(schedule.Days[index].Date, scheduledDate) {
+			return &schedule.Days[index], nil
+		}
+	}
+	return nil, domain.ErrNotFound
+}
+
+func sameDate(left time.Time, right time.Time) bool {
+	leftYear, leftMonth, leftDay := left.Date()
+	rightYear, rightMonth, rightDay := right.Date()
+	return leftYear == rightYear && leftMonth == rightMonth && leftDay == rightDay
+}
+
+func exerciseLimit(day *domain.ScheduleDay) int {
+	if len(day.MuscleGroups) > 1 {
+		return 4
+	}
+	return 3
+}

--- a/internal/coaching/application/command/generate_daily_plan_test.go
+++ b/internal/coaching/application/command/generate_daily_plan_test.go
@@ -1,0 +1,351 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	"github.com/viethung213/gym-companion/internal/coaching/domain"
+)
+
+func TestGenerateDailyPlan(t *testing.T) {
+	t.Parallel()
+
+	startDate := time.Date(2026, time.July, 20, 0, 0, 0, 0, time.UTC)
+	repository := newDailyPlanRepository(t, startDate, nil)
+	searcher := &exerciseSearcherStub{candidates: []port.ExerciseCandidate{
+		{ID: "push-up"},
+		{ID: "triceps-extension"},
+	}}
+	handler := NewGenerateDailyPlanHandler(
+		repository,
+		searcher,
+		fixedClock{value: startDate.Add(time.Hour)},
+		&idGeneratorStub{ids: []string{"daily-plan-1"}},
+	)
+
+	plan, err := handler.Handle(context.Background(), GenerateDailyPlan{
+		UserID:           "user-1",
+		WeeklyScheduleID: "schedule-1",
+		ScheduledDate:    startDate,
+	})
+	if err != nil {
+		t.Fatalf("generate daily plan: %v", err)
+	}
+	if plan.ID != "daily-plan-1" || len(plan.Exercises) != 2 {
+		t.Fatalf("unexpected plan: %#v", plan)
+	}
+	if plan.Exercises[0].Sets != 2 || plan.Exercises[0].Reps != 12 {
+		t.Fatalf("unexpected beginner prescription: %#v", plan.Exercises[0])
+	}
+	if repository.savedPlan != plan {
+		t.Fatal("daily plan was not persisted")
+	}
+	if repository.schedule.Days[0].DailyPlanID != plan.ID {
+		t.Fatal("daily plan was not attached to its schedule day")
+	}
+	if searcher.criteria.Limit != 4 {
+		t.Fatalf("expected four exercises for a multi-group day, got %d", searcher.criteria.Limit)
+	}
+}
+
+func TestGenerateDailyPlanReturnsExistingPlan(t *testing.T) {
+	t.Parallel()
+
+	startDate := time.Date(2026, time.July, 20, 0, 0, 0, 0, time.UTC)
+	existing := domain.NewDailyWorkoutPlan(
+		"daily-plan-existing",
+		"user-1",
+		"roadmap-1",
+		"schedule-1",
+		startDate,
+		nil,
+		startDate,
+	)
+	repository := newDailyPlanRepository(t, startDate, existing)
+	searcher := &exerciseSearcherStub{}
+	handler := NewGenerateDailyPlanHandler(
+		repository,
+		searcher,
+		fixedClock{value: startDate},
+		&idGeneratorStub{t: t},
+	)
+
+	plan, err := handler.Handle(context.Background(), GenerateDailyPlan{
+		UserID:           "user-1",
+		WeeklyScheduleID: "schedule-1",
+		ScheduledDate:    startDate,
+	})
+	if err != nil {
+		t.Fatalf("get idempotent daily plan: %v", err)
+	}
+	if plan != existing {
+		t.Fatal("expected the existing plan")
+	}
+	if searcher.calls != 0 || repository.savedPlan != nil {
+		t.Fatal("idempotent retry must not search or persist a second plan")
+	}
+}
+
+func TestGenerateDailyPlanRejectsRestDay(t *testing.T) {
+	t.Parallel()
+
+	startDate := time.Date(2026, time.July, 20, 0, 0, 0, 0, time.UTC)
+	repository := newDailyPlanRepository(t, startDate, nil)
+	repository.schedule.Days[0].Status = domain.ScheduleDayStatusRest
+	handler := NewGenerateDailyPlanHandler(
+		repository,
+		&exerciseSearcherStub{},
+		fixedClock{},
+		&idGeneratorStub{t: t},
+	)
+
+	_, err := handler.Handle(context.Background(), GenerateDailyPlan{
+		UserID:           "user-1",
+		WeeklyScheduleID: "schedule-1",
+		ScheduledDate:    startDate,
+	})
+	if !errors.Is(err, ErrRestDay) {
+		t.Fatalf("expected rest-day error, got %v", err)
+	}
+}
+
+func TestGenerateDailyPlanBlocksInjuryWithoutSafetyMetadata(t *testing.T) {
+	t.Parallel()
+
+	startDate := time.Date(2026, time.July, 20, 0, 0, 0, 0, time.UTC)
+	repository := newDailyPlanRepository(t, startDate, nil)
+	searcher := &exerciseSearcherStub{}
+	handler := NewGenerateDailyPlanHandler(
+		repository,
+		searcher,
+		fixedClock{},
+		&idGeneratorStub{t: t},
+	)
+
+	_, err := handler.Handle(context.Background(), GenerateDailyPlan{
+		UserID:           "user-1",
+		WeeklyScheduleID: "schedule-1",
+		ScheduledDate:    startDate,
+		NewInjuryAreas:   []string{"shoulder"},
+	})
+	if !errors.Is(err, ErrInjurySafetyBlock) {
+		t.Fatalf("expected injury safety block, got %v", err)
+	}
+	if searcher.calls != 0 {
+		t.Fatal("injury safety block must happen before exercise search")
+	}
+}
+
+func TestGenerateDailyPlanRequiresMatchingExercise(t *testing.T) {
+	t.Parallel()
+
+	startDate := time.Date(2026, time.July, 20, 0, 0, 0, 0, time.UTC)
+	repository := newDailyPlanRepository(t, startDate, nil)
+	handler := NewGenerateDailyPlanHandler(
+		repository,
+		&exerciseSearcherStub{},
+		fixedClock{},
+		&idGeneratorStub{t: t},
+	)
+
+	_, err := handler.Handle(context.Background(), GenerateDailyPlan{
+		UserID:           "user-1",
+		WeeklyScheduleID: "schedule-1",
+		ScheduledDate:    startDate,
+	})
+	if !errors.Is(err, ErrNoMatchingExercise) {
+		t.Fatalf("expected no-matching-exercise error, got %v", err)
+	}
+}
+
+type dailyPlanRepositoryStub struct {
+	t            *testing.T
+	schedule     *domain.WeeklySchedule
+	roadmap      *domain.WorkoutRoadmap
+	existingPlan *domain.DailyWorkoutPlan
+	savedPlan    *domain.DailyWorkoutPlan
+}
+
+func newDailyPlanRepository(
+	t *testing.T,
+	startDate time.Time,
+	existingPlan *domain.DailyWorkoutPlan,
+) *dailyPlanRepositoryStub {
+	t.Helper()
+	input := domain.PlanningInput{
+		Goal:                domain.PlanningGoalGeneralFitness,
+		ExperienceLevel:     domain.ExperienceLevelBeginner,
+		TrainingDaysPerWeek: 3,
+		PreferredWeekdays:   []time.Weekday{time.Monday, time.Wednesday, time.Friday},
+		MaxSessionMinutes:   60,
+		EquipmentIDs:        []string{"bodyweight"},
+		Timezone:            "Asia/Ho_Chi_Minh",
+		StartDate:           startDate,
+	}
+	roadmap, err := domain.NewWorkoutRoadmap("roadmap-1", "user-1", input, "rules-v1")
+	if err != nil {
+		t.Fatalf("create roadmap fixture: %v", err)
+	}
+	days := []domain.ScheduleDay{
+		{Date: startDate, Status: domain.ScheduleDayStatusTraining, MuscleGroups: []string{"chest", "triceps"}},
+	}
+	for offset := 1; offset < 7; offset++ {
+		days = append(days, domain.ScheduleDay{
+			Date:   startDate.AddDate(0, 0, offset),
+			Status: domain.ScheduleDayStatusRest,
+		})
+	}
+	schedule, err := domain.NewWeeklySchedule("schedule-1", roadmap.ID, roadmap.UserID, 1, days)
+	if err != nil {
+		t.Fatalf("create schedule fixture: %v", err)
+	}
+	return &dailyPlanRepositoryStub{
+		t:            t,
+		schedule:     schedule,
+		roadmap:      roadmap,
+		existingPlan: existingPlan,
+	}
+}
+
+func (r *dailyPlanRepositoryStub) CreateRoadmapWithSchedule(
+	context.Context,
+	*domain.WorkoutRoadmap,
+	*domain.WeeklySchedule,
+	[]domain.Event,
+) error {
+	r.t.Fatal("unexpected CreateRoadmapWithSchedule call")
+	return nil
+}
+
+func (r *dailyPlanRepositoryStub) SaveSchedule(
+	context.Context,
+	*domain.WeeklySchedule,
+	domain.Event,
+) error {
+	r.t.Fatal("unexpected SaveSchedule call")
+	return nil
+}
+
+func (r *dailyPlanRepositoryStub) FindActiveRoadmapByUser(
+	context.Context,
+	string,
+) (*domain.WorkoutRoadmap, error) {
+	r.t.Fatal("unexpected FindActiveRoadmapByUser call")
+	return nil, domain.ErrNotFound
+}
+
+func (r *dailyPlanRepositoryStub) FindRoadmap(
+	context.Context,
+	string,
+	string,
+) (*domain.WorkoutRoadmap, error) {
+	return r.roadmap, nil
+}
+
+func (r *dailyPlanRepositoryStub) ListRoadmaps(
+	context.Context,
+	string,
+) ([]*domain.WorkoutRoadmap, error) {
+	r.t.Fatal("unexpected ListRoadmaps call")
+	return nil, nil
+}
+
+func (r *dailyPlanRepositoryStub) FindSchedule(
+	context.Context,
+	string,
+	string,
+) (*domain.WeeklySchedule, error) {
+	return r.schedule, nil
+}
+
+func (r *dailyPlanRepositoryStub) FindScheduleByWeek(
+	context.Context,
+	string,
+	int,
+) (*domain.WeeklySchedule, error) {
+	r.t.Fatal("unexpected FindScheduleByWeek call")
+	return nil, domain.ErrNotFound
+}
+
+func (r *dailyPlanRepositoryStub) ListSchedules(
+	context.Context,
+	string,
+	string,
+) ([]*domain.WeeklySchedule, error) {
+	r.t.Fatal("unexpected ListSchedules call")
+	return nil, nil
+}
+
+func (r *dailyPlanRepositoryStub) SaveDailyPlan(
+	_ context.Context,
+	schedule *domain.WeeklySchedule,
+	plan *domain.DailyWorkoutPlan,
+	_ domain.Event,
+) error {
+	r.schedule = schedule
+	r.savedPlan = plan
+	return nil
+}
+
+func (r *dailyPlanRepositoryStub) FindDailyPlan(
+	context.Context,
+	string,
+	string,
+) (*domain.DailyWorkoutPlan, error) {
+	r.t.Fatal("unexpected FindDailyPlan call")
+	return nil, domain.ErrNotFound
+}
+
+func (r *dailyPlanRepositoryStub) FindDailyPlanByDate(
+	context.Context,
+	string,
+	time.Time,
+) (*domain.DailyWorkoutPlan, error) {
+	if r.existingPlan != nil {
+		return r.existingPlan, nil
+	}
+	return nil, domain.ErrNotFound
+}
+
+type exerciseSearcherStub struct {
+	candidates []port.ExerciseCandidate
+	criteria   port.ExerciseSearchCriteria
+	calls      int
+}
+
+func (s *exerciseSearcherStub) Search(
+	_ context.Context,
+	criteria port.ExerciseSearchCriteria,
+) ([]port.ExerciseCandidate, error) {
+	s.calls++
+	s.criteria = criteria
+	return s.candidates, nil
+}
+
+type fixedClock struct {
+	value time.Time
+}
+
+func (c fixedClock) Now() time.Time {
+	return c.value
+}
+
+type idGeneratorStub struct {
+	t   *testing.T
+	ids []string
+}
+
+func (g *idGeneratorStub) NewID() (string, error) {
+	if len(g.ids) == 0 {
+		if g.t != nil {
+			g.t.Fatal("unexpected id generation")
+		}
+		return "", errors.New("no stub id available")
+	}
+	id := g.ids[0]
+	g.ids = g.ids[1:]
+	return id, nil
+}

--- a/internal/coaching/application/port/ports.go
+++ b/internal/coaching/application/port/ports.go
@@ -29,6 +29,38 @@ type Repository interface {
 		userID string,
 		roadmapID string,
 	) ([]*domain.WeeklySchedule, error)
+	SaveDailyPlan(
+		ctx context.Context,
+		schedule *domain.WeeklySchedule,
+		plan *domain.DailyWorkoutPlan,
+		event domain.Event,
+	) error
+	FindDailyPlan(ctx context.Context, userID string, planID string) (*domain.DailyWorkoutPlan, error)
+	FindDailyPlanByDate(
+		ctx context.Context,
+		scheduleID string,
+		scheduledDate time.Time,
+	) (*domain.DailyWorkoutPlan, error)
+}
+
+type ExerciseSearchCriteria struct {
+	MuscleGroupIDs []string
+	EquipmentIDs   []string
+	Difficulty     string
+	Limit          int
+}
+
+type ExerciseCandidate struct {
+	ID                 string
+	Name               string
+	TargetMuscleID     string
+	EquipmentID        string
+	Difficulty         string
+	DefaultRestSeconds int
+}
+
+type ExerciseSearcher interface {
+	Search(ctx context.Context, criteria ExerciseSearchCriteria) ([]ExerciseCandidate, error)
 }
 
 type Clock interface {

--- a/internal/coaching/application/query/queries.go
+++ b/internal/coaching/application/query/queries.go
@@ -62,3 +62,15 @@ func (h *Handler) ListSchedules(
 	}
 	return schedules, nil
 }
+
+func (h *Handler) GetDailyPlan(
+	ctx context.Context,
+	userID string,
+	planID string,
+) (*domain.DailyWorkoutPlan, error) {
+	plan, err := h.repository.FindDailyPlan(ctx, userID, planID)
+	if err != nil {
+		return nil, fmt.Errorf("find daily plan: %w", err)
+	}
+	return plan, nil
+}

--- a/internal/coaching/infrastructure/exercise/searcher.go
+++ b/internal/coaching/infrastructure/exercise/searcher.go
@@ -1,0 +1,129 @@
+package exercise
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	coachingport "github.com/viethung213/gym-companion/internal/coaching/application/port"
+	exerciseport "github.com/viethung213/gym-companion/internal/exercise/application/port"
+	exercisequery "github.com/viethung213/gym-companion/internal/exercise/application/query"
+)
+
+var _ coachingport.ExerciseSearcher = (*Searcher)(nil)
+
+type Searcher struct {
+	handler *exercisequery.SearchExercisesHandler
+}
+
+func NewSearcher(handler *exercisequery.SearchExercisesHandler) *Searcher {
+	return &Searcher{handler: handler}
+}
+
+func (s *Searcher) Search(
+	ctx context.Context,
+	criteria coachingport.ExerciseSearchCriteria,
+) ([]coachingport.ExerciseCandidate, error) {
+	if len(criteria.MuscleGroupIDs) == 0 || criteria.Limit <= 0 {
+		return nil, nil
+	}
+
+	equipmentIDs := criteria.EquipmentIDs
+	if len(equipmentIDs) == 0 {
+		equipmentIDs = []string{""}
+	}
+	quota := (criteria.Limit + len(criteria.MuscleGroupIDs) - 1) / len(criteria.MuscleGroupIDs)
+	candidates := make([]coachingport.ExerciseCandidate, 0, criteria.Limit)
+	seen := make(map[string]struct{}, criteria.Limit)
+	for _, muscleGroupID := range criteria.MuscleGroupIDs {
+		groupCandidates, err := s.searchGroup(
+			ctx,
+			muscleGroupID,
+			equipmentIDs,
+			difficultyForExercise(criteria.Difficulty),
+			quota,
+		)
+		if err != nil {
+			return nil, err
+		}
+		for _, candidate := range groupCandidates {
+			if _, exists := seen[candidate.ID]; exists {
+				continue
+			}
+			seen[candidate.ID] = struct{}{}
+			candidates = append(candidates, candidate)
+			if len(candidates) == criteria.Limit {
+				return candidates, nil
+			}
+		}
+	}
+	return candidates, nil
+}
+
+func (s *Searcher) searchGroup(
+	ctx context.Context,
+	muscleGroupID string,
+	equipmentIDs []string,
+	difficulty string,
+	limit int,
+) ([]coachingport.ExerciseCandidate, error) {
+	candidates := make([]coachingport.ExerciseCandidate, 0, limit)
+	for _, equipmentID := range equipmentIDs {
+		remaining := limit - len(candidates)
+		if remaining == 0 {
+			break
+		}
+		items, err := s.search(ctx, &exerciseport.SearchFilters{
+			BodyPartID:  muscleGroupID,
+			EquipmentID: equipmentID,
+			Difficulty:  difficulty,
+			Limit:       int32(remaining),
+		})
+		if err != nil {
+			return nil, err
+		}
+		if len(items) == 0 {
+			items, err = s.search(ctx, &exerciseport.SearchFilters{
+				TargetMuscleID: muscleGroupID,
+				EquipmentID:    equipmentID,
+				Difficulty:     difficulty,
+				Limit:          int32(remaining),
+			})
+			if err != nil {
+				return nil, err
+			}
+		}
+		candidates = append(candidates, items...)
+	}
+	return candidates, nil
+}
+
+func (s *Searcher) search(
+	ctx context.Context,
+	filters *exerciseport.SearchFilters,
+) ([]coachingport.ExerciseCandidate, error) {
+	exercises, err := s.handler.Handle(ctx, exercisequery.SearchExercisesQuery{Filters: filters})
+	if err != nil {
+		return nil, fmt.Errorf("search exercises application query: %w", err)
+	}
+	candidates := make([]coachingport.ExerciseCandidate, 0, len(exercises))
+	for _, item := range exercises {
+		info := item.Info()
+		candidates = append(candidates, coachingport.ExerciseCandidate{
+			ID:                 info.ID,
+			Name:               info.Name,
+			TargetMuscleID:     info.TargetMuscleID,
+			EquipmentID:        info.EquipmentID,
+			Difficulty:         info.Difficulty,
+			DefaultRestSeconds: int(info.DefaultRestSeconds),
+		})
+	}
+	return candidates, nil
+}
+
+func difficultyForExercise(experienceLevel string) string {
+	if experienceLevel == "" {
+		return ""
+	}
+	return strings.ToUpper(experienceLevel[:1]) + strings.ToLower(experienceLevel[1:])
+}

--- a/internal/coaching/infrastructure/persistence/postgres_repository.go
+++ b/internal/coaching/infrastructure/persistence/postgres_repository.go
@@ -52,6 +52,19 @@ type outboxRecord struct {
 
 func (outboxRecord) TableName() string { return "coaching.outbox_events" }
 
+type dailyPlanRecord struct {
+	ID               string         `gorm:"column:id;primaryKey"`
+	UserID           string         `gorm:"column:user_id;not null"`
+	RoadmapID        string         `gorm:"column:roadmap_id;not null"`
+	WeeklyScheduleID string         `gorm:"column:weekly_schedule_id;not null"`
+	ScheduledDate    time.Time      `gorm:"column:scheduled_date;not null"`
+	Status           string         `gorm:"column:status;not null"`
+	Exercises        datatypes.JSON `gorm:"column:exercises;type:jsonb;not null"`
+	GeneratedAt      time.Time      `gorm:"column:generated_at;not null"`
+}
+
+func (dailyPlanRecord) TableName() string { return "coaching.daily_workout_plans" }
+
 type PostgresRepository struct {
 	db *gorm.DB
 }
@@ -201,6 +214,60 @@ func (r *PostgresRepository) ListSchedules(
 	return schedules, nil
 }
 
+func (r *PostgresRepository) SaveDailyPlan(
+	ctx context.Context,
+	schedule *domain.WeeklySchedule,
+	plan *domain.DailyWorkoutPlan,
+	event domain.Event,
+) error {
+	scheduleRow, err := toScheduleRecord(schedule)
+	if err != nil {
+		return err
+	}
+	planRow, err := toDailyPlanRecord(plan)
+	if err != nil {
+		return err
+	}
+	outboxRows, err := toOutboxRecords([]domain.Event{event})
+	if err != nil {
+		return err
+	}
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Save(&scheduleRow).Error; err != nil {
+			return fmt.Errorf("update schedule: %w", err)
+		}
+		if err := tx.Create(&planRow).Error; err != nil {
+			return fmt.Errorf("insert daily plan: %w", err)
+		}
+		if err := tx.Create(&outboxRows[0]).Error; err != nil {
+			return fmt.Errorf("insert outbox event: %w", err)
+		}
+		return nil
+	})
+}
+
+func (r *PostgresRepository) FindDailyPlan(
+	ctx context.Context,
+	userID string,
+	planID string,
+) (*domain.DailyWorkoutPlan, error) {
+	var row dailyPlanRecord
+	err := r.db.WithContext(ctx).Where("id = ? AND user_id = ?", planID, userID).First(&row).Error
+	return mapDailyPlanResult(row, err)
+}
+
+func (r *PostgresRepository) FindDailyPlanByDate(
+	ctx context.Context,
+	scheduleID string,
+	scheduledDate time.Time,
+) (*domain.DailyWorkoutPlan, error) {
+	var row dailyPlanRecord
+	err := r.db.WithContext(ctx).
+		Where("weekly_schedule_id = ? AND scheduled_date = ?", scheduleID, scheduledDate).
+		First(&row).Error
+	return mapDailyPlanResult(row, err)
+}
+
 func toRoadmapRecord(roadmap *domain.WorkoutRoadmap) (roadmapRecord, error) {
 	payload, err := json.Marshal(roadmap.Input)
 	if err != nil {
@@ -241,6 +308,18 @@ func toOutboxRecords(events []domain.Event) ([]outboxRecord, error) {
 	return rows, nil
 }
 
+func toDailyPlanRecord(plan *domain.DailyWorkoutPlan) (dailyPlanRecord, error) {
+	payload, err := json.Marshal(plan.Exercises)
+	if err != nil {
+		return dailyPlanRecord{}, fmt.Errorf("marshal prescribed exercises: %w", err)
+	}
+	return dailyPlanRecord{
+		ID: plan.ID, UserID: plan.UserID, RoadmapID: plan.RoadmapID,
+		WeeklyScheduleID: plan.WeeklyScheduleID, ScheduledDate: plan.ScheduledDate,
+		Status: string(plan.Status), Exercises: payload, GeneratedAt: plan.GeneratedAt,
+	}, nil
+}
+
 func mapRoadmapResult(row roadmapRecord, err error) (*domain.WorkoutRoadmap, error) {
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, domain.ErrNotFound
@@ -259,6 +338,25 @@ func mapScheduleResult(row scheduleRecord, err error) (*domain.WeeklySchedule, e
 		return nil, fmt.Errorf("query schedule: %w", err)
 	}
 	return row.toDomain()
+}
+
+func mapDailyPlanResult(row dailyPlanRecord, err error) (*domain.DailyWorkoutPlan, error) {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, domain.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query daily plan: %w", err)
+	}
+	var exercises []domain.PrescribedExercise
+	if err := json.Unmarshal(row.Exercises, &exercises); err != nil {
+		return nil, fmt.Errorf("unmarshal prescribed exercises: %w", err)
+	}
+	return &domain.DailyWorkoutPlan{
+		ID: row.ID, UserID: row.UserID, RoadmapID: row.RoadmapID,
+		WeeklyScheduleID: row.WeeklyScheduleID, ScheduledDate: row.ScheduledDate,
+		Status: domain.DailyPlanStatus(row.Status), Exercises: exercises,
+		GeneratedAt: row.GeneratedAt,
+	}, nil
 }
 
 func (row roadmapRecord) toDomain() (*domain.WorkoutRoadmap, error) {

--- a/scripts/postgres-init/04_init_coaching_schema.sql
+++ b/scripts/postgres-init/04_init_coaching_schema.sql
@@ -36,6 +36,23 @@ CREATE TABLE IF NOT EXISTS coaching.weekly_schedules (
 CREATE INDEX IF NOT EXISTS coaching_schedules_user_roadmap
     ON coaching.weekly_schedules (user_id, roadmap_id, week_number);
 
+CREATE TABLE IF NOT EXISTS coaching.daily_workout_plans (
+    id VARCHAR(255) PRIMARY KEY,
+    user_id VARCHAR(255) NOT NULL,
+    roadmap_id VARCHAR(255) NOT NULL
+        REFERENCES coaching.workout_roadmaps(id) ON DELETE CASCADE,
+    weekly_schedule_id VARCHAR(255) NOT NULL
+        REFERENCES coaching.weekly_schedules(id) ON DELETE CASCADE,
+    scheduled_date DATE NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    exercises JSONB NOT NULL,
+    generated_at TIMESTAMPTZ NOT NULL,
+    UNIQUE (weekly_schedule_id, scheduled_date)
+);
+
+CREATE INDEX IF NOT EXISTS coaching_daily_plans_user_date
+    ON coaching.daily_workout_plans (user_id, scheduled_date);
+
 CREATE TABLE IF NOT EXISTS coaching.outbox_events (
     id VARCHAR(255) PRIMARY KEY,
     event_type VARCHAR(255) NOT NULL,


### PR DESCRIPTION
## Summary
- add JIT daily workout plan generation with rest-day and injury safety guards
- use the Exercise module public SearchExercises query through an ExerciseSearcher adapter
- persist the plan, schedule-day reference, and outbox event atomically
- cover success, idempotency, rest day, injury, and no-match behavior

## Verification
- go test ./internal/coaching/...
- go vet ./internal/coaching/...
- git diff --check

## Stack
Depends on #140.