### PR TITLE
♻️ refactor(api): đơn giản hóa và đồng bộ hóa api contracts coaching và execution

### DIFF
--- a/docs/adr/03_coaching_service_contract.md
+++ b/docs/adr/03_coaching_service_contract.md
@@ -12,17 +12,20 @@ Tách biệt hoàn toàn hai cấu phần để đảm bảo ranh giới Bounded
 
 ---
 
-## 2. API Contract Thực Tế
+## 2. API & Commands Hệ Thống
 
-### Commands
+### API Public (Client gọi qua gRPC/HTTP)
 - `InitiateRoadmap`: Khởi tạo lộ trình 4 tuần ban đầu.
-- `SubmitPreWorkoutCheckIn`: Gửi câu trả lời check-in động (đóng gói trực tiếp trong request body, dùng `body: "*"`).
+- `SubmitPreWorkoutCheckIn`: Gửi câu trả lời check-in động (dùng `body: "*"`).
+- `GetActiveRoadmap`: Lấy nhanh Roadmap đang chạy kèm lịch tuần hiện tại (Endpoint `/active`).
+- `GetPreWorkoutCheckIn`: Lấy câu hỏi check-in động đã sinh sẵn.
+- `GetDailyWorkoutPlan`: Lấy giáo án tập luyện ngày.
+- `ListWorkoutRoadmaps` & `GetWorkoutRoadmap`: Xem lại lịch sử lộ trình cũ.
 
-### Queries
-- `GetActiveRoadmap`: Lấy nhanh Roadmap đang chạy kèm lịch tuần hiện tại (Endpoint `/active` được chấp thuận để tối ưu UX).
-- `GetPreWorkoutCheckIn`: Lấy bộ câu hỏi check-in động được AI sinh trước từ buổi tập cũ (giảm thiểu latency).
-- `GetDailyWorkoutPlan`: Lấy giáo án tập luyện ngày (đang để Unary, tương lai nâng cấp lên Server Stream theo ADR-01).
-- `ListWorkoutRoadmaps` & `GetWorkoutRoadmap`: Phục vụ xem lại lịch sử lộ trình cũ.
+### Commands Nội Bộ (Backend xử lý ngầm qua Event/Worker)
+- `GenerateNextWeeklySchedule`: Tự động sinh lịch tuần kế tiếp khi nhận event kết thúc buổi tập cuối tuần.
+- `GenerateDailyWorkoutPlanDraft`: Chạy background job sinh trước giáo án nháp (pre-caching) cho ngày hôm sau.
+- `RegenerateDailyWorkoutPlan`: Sinh lại giáo án JIT khi check-in báo chấn thương mới hoặc thiếu thiết bị.
 
 ---
 

--- a/docs/adr/03_coaching_service_contract.md
+++ b/docs/adr/03_coaching_service_contract.md
@@ -1,110 +1,33 @@
-# ADR 03: Ý Định Thiết Kế Contract Cho Coaching Service
+# ADR 03: Thiết Kế Contract Cho Coaching Service
 
 * **Trạng thái**: Accepted
 * **Tác giả**: Codex, Developer & Lead Architect
 
 ---
 
-## 1. Bối cảnh
-
-Context **Coaching & Planning** chịu trách nhiệm trả lời câu hỏi: *"Tôi nên tập gì? Khi nào điều chỉnh?"*.
-Theo thiết kế DDD hiện tại, context này quản lý ba Aggregate chính:
-
-- `WorkoutRoadmap`: lộ trình tập luyện 4 tuần.
-- `WeeklySchedule`: lịch tập/nghỉ theo từng tuần.
-- `DailyWorkoutPlan`: giáo án chi tiết sinh theo ngày, theo cơ chế Just-In-Time.
-
-Trong khi đó, `WorkoutService` hiện tại đang đại diện cho phần **Workout Execution**: bắt đầu buổi tập, log set, hoàn thành buổi tập.
-Nếu tiếp tục nhét cả lập kế hoạch, sinh lịch, sinh giáo án và adaptive review vào `WorkoutService`, contract sẽ bị trộn hai nghiệp vụ khác nhau:
-
-- **Coaching**: quyết định nên tập gì, khi nào sinh lịch, khi nào điều chỉnh.
-- **Workout Execution**: ghi nhận user đã tập như thế nào.
-
-Vì `contracts/` là Single Source of Truth cho API, gRPC, REST gateway và OpenAPI, ranh giới này cần được thể hiện trực tiếp trong proto.
+## 1. Bối cảnh & Quyết định
+Tách biệt hoàn toàn hai cấu phần để đảm bảo ranh giới Bounded Context (DDD):
+- **Coaching Service (`internal/coaching`)**: Lập lộ trình, quản lý lịch tuần, sinh giáo án ngày JIT, và xử lý adaptive check-in.
+- **Workout Execution Service (`internal/workout_execution`)**: Điều phối và ghi nhận log buổi tập thực tế.
 
 ---
 
-## 2. Ý Định Thiết Kế
+## 2. API Contract Thực Tế
 
-Tách **Coaching & Planning** thành bounded context riêng:
+### Commands
+- `InitiateRoadmap`: Khởi tạo lộ trình 4 tuần ban đầu.
+- `SubmitPreWorkoutCheckIn`: Gửi câu trả lời check-in động (đóng gói trực tiếp trong request body, dùng `body: "*"`).
 
-- Contract: `proto/contracts/core/coaching/v1`.
-- Go module: `internal/coaching`.
-- PostgreSQL schema: `coaching`.
-
-- `WorkoutExecutionService`: điều phối và ghi nhận buổi tập thực tế.
-- `CoachingService`: lập lộ trình, quản lý lịch tuần, sinh giáo án ngày JIT, và xử lý adaptive check-in.
-
-Cách tách này giữ domain, dữ liệu và contract của hai nghiệp vụ độc lập.
-
----
-
-## 3. Danh Sách Command Thực Tế
-
-| Command | Ý nghĩa |
-|---|---|
-| `InitiateRoadmap` | Khởi tạo roadmap và lịch tuần đầu tiên dựa trên thông tin khảo sát. |
-| `SubmitPreWorkoutCheckIn` | Gửi câu trả lời khảo sát check-in động trước buổi tập (báo mệt, đau khớp, thiếu dụng cụ). |
-
-Các hành động điều chỉnh khác như dời ngày tập, tạm dừng, deload... được thực thi trực tiếp qua các câu lệnh nghiệp vụ nội bộ ở backend hoặc do AI Agent tự động gọi Tool cập nhật DB, tránh phơi ra các API CRUD tĩnh phức tạp.
+### Queries
+- `GetActiveRoadmap`: Lấy nhanh Roadmap đang chạy kèm lịch tuần hiện tại (Endpoint `/active` được chấp thuận để tối ưu UX).
+- `GetPreWorkoutCheckIn`: Lấy bộ câu hỏi check-in động được AI sinh trước từ buổi tập cũ (giảm thiểu latency).
+- `GetDailyWorkoutPlan`: Lấy giáo án tập luyện ngày (đang để Unary, tương lai nâng cấp lên Server Stream theo ADR-01).
+- `ListWorkoutRoadmaps` & `GetWorkoutRoadmap`: Phục vụ xem lại lịch sử lộ trình cũ.
 
 ---
 
-## 4. Danh Sách Query Thực Tế
-
-| Query | Ý nghĩa |
-|---|---|
-| `ListWorkoutRoadmaps` | Lấy danh sách lịch sử các roadmap cũ (đã COMPLETED hoặc CANCELLED). |
-| `GetWorkoutRoadmap` | Lấy chi tiết một roadmap cũ theo ID. |
-| `GetActiveRoadmap` | Lấy nhanh duy nhất 1 roadmap đang hoạt động (ACTIVE) kèm theo lịch tuần hiện tại. |
-| `GetPreWorkoutCheckIn` | Lấy bộ câu hỏi check-in động (trắc nghiệm + tự điền) được AI sinh trước cho hôm nay. |
-| `GetDailyWorkoutPlan` | Lấy giáo án tập luyện của ngày hôm nay. |
-
-*Lưu ý về endpoint `/active`*: Endpoint `GET /api/v1/users/{user_id}/workout-roadmaps/active` được chấp thuận như một ngoại lệ thiết kế hợp lý nhằm tối ưu hóa trải nghiệm (UX-driven API design), giúp Client lấy nhanh dữ liệu trang chủ chỉ với 1 lượt gọi.
-
----
-
-## 5. Cơ Chế Thích Ứng Động (Dynamic Adaptive Check-In)
-
-Quy tắc thích ứng (BR-AC-04 đến BR-AC-08) được vận hành động thông qua 2 cơ chế tương tác:
-
-1. **Khảo sát động trước buổi tập (Pre-generated Check-In)**:
-   - Cuối mỗi buổi tập trước, hệ thống chạy background job gọi AI Agent sinh sẵn bộ câu hỏi check-in động cá nhân hóa cho buổi tiếp theo (ví dụ hỏi thăm chấn thương cũ).
-   - Khi mở app, Client lấy bộ câu hỏi từ DB lên hiển thị lập tức (0ms latency).
-   - Người dùng trả lời, hệ thống cập nhật DB và tự động kích hoạt AI sửa lại giáo án ngày (JIT) nếu phát hiện chấn thương mới hoặc thiếu thiết bị.
-2. **Tương tác qua Chat tự do với AI Coach**:
-   - AI Coach tự động phát hiện các sự kiện bất thường (ví dụ: bùng tập 3 buổi liên tiếp) và bắt đầu hội thoại hỏi han.
-   - Người dùng chat trả lời, AI Agent tự trích xuất intent và gọi Tool Backend (`UpdateWorkoutContext`) để trực tiếp thay đổi lịch tập hoặc cơ cấu lại bài tập dưới database.
-
----
-
-## 6. Vì Sao Không Dùng `Update` / `Delete` Chung Chung
-
-Các thao tác thay đổi phải là command nghiệp vụ rõ nghĩa để đảm bảo tính audit lịch sử và giữ vững ranh giới nghiệp vụ, thay vì cho phép client tự sửa dữ liệu DB trực tiếp bằng API generic `PUT/DELETE`.
-
----
-
-## 7. Vì Sao Event Payload Phải Tối Thiểu
-
-Event trong hệ thống tuân theo CloudEvents. Phần `data` chỉ chứa dữ liệu nghiệp vụ tối thiểu để tránh dư thừa. Thông tin định tuyến (ví dụ: `user_id`) nằm ở envelope và được dùng làm Kafka partition key.
-
----
-
-## 8. Quy Ước Thời Gian
-
-- `google.type.Date`: ngày nghiệp vụ (không kèm giờ), ví dụ: `start_date`, `end_date`, `scheduled_date`.
-- `google.protobuf.Timestamp`: thời điểm chính xác hệ thống ghi nhận, ví dụ: `generated_at`, `initiated_at`.
-
----
-
-## 9. Hệ Quả Triển Khai
-
-- Dùng command/query rõ ràng, không viết manual route.
-- Backend Go là nơi chịu trách nhiệm tính toán số liệu tải trọng an toàn (set, rep, tạ, volume) theo công thức Epley/Rule Engine.
-- AI Agent đóng vai trò Reasoning Layer: chỉ hỗ trợ chọn bài tập, sắp xếp bài tập và giải thích điều chỉnh dựa trên ngữ cảnh an toàn do Backend cung cấp.
-
----
-
-## 10. Kết Luận
-
-Tách biệt rõ ràng **Coaching** (Lập kế hoạch) và **Execution** (Thực thi) giúp hệ thống giữ vững Bounded Context, tối giản cấu trúc API gRPC/REST, và đảm bảo an toàn tuyệt đối cho người tập nhờ cơ chế kiểm soát kép giữa Backend Go và AI Agent.
+## 3. Các Nguyên Tắc Thiết Kế Cốt Lõi
+- **Kiểm soát thông số an toàn**: Backend Go chịu trách nhiệm tính toán tải trọng (sets, reps, weight) bằng thuật toán/Rule Engine. AI Agent chỉ đóng vai trò hỗ trợ chọn bài tập theo ngữ cảnh an toàn từ DB.
+- **Không dùng API CRUD chung chung**: Các thay đổi dữ liệu phải thông qua các Command nghiệp vụ rõ nghĩa, không dùng API generic `PUT/DELETE`.
+- **Event payload tối thiểu**: Event tuân theo CloudEvents. Payload chỉ chứa dữ liệu nghiệp vụ tối thiểu để tránh dư thừa (routing và user ownership nằm ở envelope).
+- **Quy ước thời gian**: Dùng `google.type.Date` cho ngày nghiệp vụ (start_date, scheduled_date) và `google.protobuf.Timestamp` cho thời điểm hệ thống ghi nhận (generated_at).

--- a/docs/adr/03_coaching_service_contract.md
+++ b/docs/adr/03_coaching_service_contract.md
@@ -26,73 +26,47 @@ Vì `contracts/` là Single Source of Truth cho API, gRPC, REST gateway và Open
 
 ## 2. Ý Định Thiết Kế
 
-Tạo `CoachingService` riêng trong cùng bounded context `core/workout/v1`.
+Tách **Coaching & Planning** thành bounded context riêng:
 
-Mục tiêu không phải là tách sang package mới `core/coaching/v1`, mà là tách rõ trách nhiệm ở mức service contract:
+- Contract: `proto/contracts/core/coaching/v1`.
+- Go module: `internal/coaching`.
+- PostgreSQL schema: `coaching`.
 
-- `WorkoutService`: điều phối buổi tập thực tế.
+- `WorkoutExecutionService`: điều phối và ghi nhận buổi tập thực tế.
 - `CoachingService`: lập lộ trình, sinh lịch tuần, sinh giáo án ngày, và xử lý adaptive review.
 
-Cách này giữ đúng mapping vật lý hiện tại: `Coaching & Planning` và `Workout Execution & Motion` vẫn nằm trong module `workout`, nhưng API contract không còn lẫn command của hai nghiệp vụ.
+Cách tách này giữ domain, dữ liệu và contract của hai nghiệp vụ độc lập.
 
 ---
 
-## 3. Vì Sao Cần Các API Planning
+## 3. Danh Sách Command
 
-### `InitiateRoadmap`
-
-API này cần có vì `WorkoutRoadmap` không phải dữ liệu do user tự tạo thủ công.
-Nó được sinh sau khi hồ sơ sức khỏe đạt điều kiện kích hoạt AI Coach.
-
-Command này đại diện cho UC-02.1:
-
-- đọc profile, mục tiêu, injury, khung giờ tập;
-- tạo roadmap 4 tuần;
-- tạo `WeeklySchedule` tuần đầu;
-- chạy `OverloadValidator` để đảm bảo volume ban đầu hợp lệ;
-- phát event `RoadmapInitiated` và `WeeklyScheduleGenerated`.
-
-### `GenerateNextWeeklySchedule`
-
-API này cần có vì lịch tuần sau không nên được tạo trước toàn bộ.
-Nó phụ thuộc vào dữ liệu tuần vừa rồi: completion, volume thực tế, RPE, form score, session bất thường.
-
-Command này đại diện cho UC-02.3:
-
-- đọc roadmap active;
-- đọc performance tuần trước;
-- sinh lịch tuần kế tiếp;
-- đảm bảo progressive overload không vượt quá 10%;
-- lưu `WeeklySchedule` mới.
-
-### `GenerateDailyWorkoutPlan`
-
-API này cần có vì giáo án chi tiết được sinh JIT.
-Không nên lock toàn bộ bài tập, set, rep, tạ cho cả 4 tuần ngay từ đầu.
-
-Command này đại diện cho UC-02.2:
-
-- nhận ngày tập dự kiến;
-- nhận check-in input nếu có;
-- xử lý injury mới, recovery, missed session;
-- chọn bài tập phù hợp;
-- để Backend Go tính set, rep, tạ, volume theo ADR 02;
-- tạo `DailyWorkoutPlan` sẵn sàng cho `WorkoutService.StartWorkoutSession`.
+| Command | Ý nghĩa |
+|---|---|
+| `InitiateRoadmap` | Nội bộ: tạo roadmap và lịch tuần đầu sau `ProfileCompleted`. |
+| `GenerateNextWeeklySchedule` | Nội bộ: sinh lịch tuần kế tiếp từ kết quả tập thực tế. |
+| `GenerateDailyWorkoutPlan` | Public: sinh giáo án JIT từ check-in của user. |
+| `RegenerateDailyWorkoutPlan` | Public: thay plan chưa sử dụng khi ngữ cảnh thay đổi. |
+| `RespondAdaptiveRecommendation` | Public: nhận lựa chọn của user cho đề xuất thích ứng. |
+| `ResumeRoadmap` | Public: cho user tiếp tục roadmap đang tạm dừng. |
+| `PauseRoadmap` | Nội bộ: tạm dừng roadmap theo adaptive recommendation. |
+| `SkipScheduledDay` | Nội bộ: đánh dấu bỏ buổi, không tự dồn lịch. |
+| `RescheduleScheduleDay` | Nội bộ: dời ngày tập sau khi user xác nhận. |
+| `RunAdaptiveReview` | Nội bộ: đánh giá CR và các signal B1–B4. |
+| `CompleteRoadmap` | Nội bộ: hoàn thành roadmap khi kết thúc chu kỳ. |
 
 ---
 
-## 4. Vì Sao Cần Query API
+## 4. Danh Sách Query
 
-Các command `Generate...` chỉ tạo hoặc cập nhật dữ liệu.
-Client vẫn cần API đọc lại dữ liệu đã sinh.
-
-Do đó `CoachingService` cần có query rõ ràng:
-
-- `ListWorkoutRoadmaps`: lấy danh sách roadmap, có thể filter theo status.
-- `GetWorkoutRoadmap`: lấy chi tiết một roadmap.
-- `ListWeeklySchedules`: lấy lịch tuần theo roadmap hoặc khoảng ngày.
-- `GetWeeklySchedule`: lấy chi tiết một lịch tuần.
-- `GetDailyWorkoutPlan`: lấy giáo án ngày để hiển thị hoặc truyền sang luồng execution.
+| Query | Ý nghĩa |
+|---|---|
+| `ListWorkoutRoadmaps` | Lấy danh sách roadmap của user, có thể lọc theo trạng thái. |
+| `GetWorkoutRoadmap` | Lấy chi tiết một roadmap. |
+| `ListWeeklySchedules` | Lấy lịch tuần theo roadmap hoặc khoảng ngày. |
+| `GetWeeklySchedule` | Lấy chi tiết một lịch tuần. |
+| `GetDailyWorkoutPlan` | Lấy giáo án ngày để hiển thị hoặc bắt đầu buổi tập. |
+| `ListAdaptiveRecommendations` | Lấy đề xuất thích ứng đang chờ hoặc lịch sử. |
 
 Không dùng endpoint kiểu `/workout-roadmaps/active`.
 `active` là trạng thái của resource, không phải resource.

--- a/docs/adr/03_coaching_service_contract.md
+++ b/docs/adr/03_coaching_service_contract.md
@@ -1,7 +1,7 @@
 # ADR 03: Ý Định Thiết Kế Contract Cho Coaching Service
 
-* **Trạng thái**: Proposed
-* **Tác giả**: Codex & Developer
+* **Trạng thái**: Accepted
+* **Tác giả**: Codex, Developer & Lead Architect
 
 ---
 
@@ -33,190 +33,78 @@ Tách **Coaching & Planning** thành bounded context riêng:
 - PostgreSQL schema: `coaching`.
 
 - `WorkoutExecutionService`: điều phối và ghi nhận buổi tập thực tế.
-- `CoachingService`: lập lộ trình, sinh lịch tuần, sinh giáo án ngày, và xử lý adaptive review.
+- `CoachingService`: lập lộ trình, quản lý lịch tuần, sinh giáo án ngày JIT, và xử lý adaptive check-in.
 
 Cách tách này giữ domain, dữ liệu và contract của hai nghiệp vụ độc lập.
 
 ---
 
-## 3. Danh Sách Command
+## 3. Danh Sách Command Thực Tế
 
 | Command | Ý nghĩa |
 |---|---|
-| `InitiateRoadmap` | Nội bộ: tạo roadmap và lịch tuần đầu sau `ProfileCompleted`. |
-| `GenerateNextWeeklySchedule` | Nội bộ: sinh lịch tuần kế tiếp từ kết quả tập thực tế. |
-| `GenerateDailyWorkoutPlan` | Public: sinh giáo án JIT từ check-in của user. |
-| `RegenerateDailyWorkoutPlan` | Public: thay plan chưa sử dụng khi ngữ cảnh thay đổi. |
-| `RespondAdaptiveRecommendation` | Public: nhận lựa chọn của user cho đề xuất thích ứng. |
-| `ResumeRoadmap` | Public: cho user tiếp tục roadmap đang tạm dừng. |
-| `PauseRoadmap` | Nội bộ: tạm dừng roadmap theo adaptive recommendation. |
-| `SkipScheduledDay` | Nội bộ: đánh dấu bỏ buổi, không tự dồn lịch. |
-| `RescheduleScheduleDay` | Nội bộ: dời ngày tập sau khi user xác nhận. |
-| `RunAdaptiveReview` | Nội bộ: đánh giá CR và các signal B1–B4. |
-| `CompleteRoadmap` | Nội bộ: hoàn thành roadmap khi kết thúc chu kỳ. |
+| `InitiateRoadmap` | Khởi tạo roadmap và lịch tuần đầu tiên dựa trên thông tin khảo sát. |
+| `SubmitPreWorkoutCheckIn` | Gửi câu trả lời khảo sát check-in động trước buổi tập (báo mệt, đau khớp, thiếu dụng cụ). |
+
+Các hành động điều chỉnh khác như dời ngày tập, tạm dừng, deload... được thực thi trực tiếp qua các câu lệnh nghiệp vụ nội bộ ở backend hoặc do AI Agent tự động gọi Tool cập nhật DB, tránh phơi ra các API CRUD tĩnh phức tạp.
 
 ---
 
-## 4. Danh Sách Query
+## 4. Danh Sách Query Thực Tế
 
 | Query | Ý nghĩa |
 |---|---|
-| `ListWorkoutRoadmaps` | Lấy danh sách roadmap của user, có thể lọc theo trạng thái. |
-| `GetWorkoutRoadmap` | Lấy chi tiết một roadmap. |
-| `ListWeeklySchedules` | Lấy lịch tuần theo roadmap hoặc khoảng ngày. |
-| `GetWeeklySchedule` | Lấy chi tiết một lịch tuần. |
-| `GetDailyWorkoutPlan` | Lấy giáo án ngày để hiển thị hoặc bắt đầu buổi tập. |
-| `ListAdaptiveRecommendations` | Lấy đề xuất thích ứng đang chờ hoặc lịch sử. |
+| `ListWorkoutRoadmaps` | Lấy danh sách lịch sử các roadmap cũ (đã COMPLETED hoặc CANCELLED). |
+| `GetWorkoutRoadmap` | Lấy chi tiết một roadmap cũ theo ID. |
+| `GetActiveRoadmap` | Lấy nhanh duy nhất 1 roadmap đang hoạt động (ACTIVE) kèm theo lịch tuần hiện tại. |
+| `GetPreWorkoutCheckIn` | Lấy bộ câu hỏi check-in động (trắc nghiệm + tự điền) được AI sinh trước cho hôm nay. |
+| `GetDailyWorkoutPlan` | Lấy giáo án tập luyện của ngày hôm nay. |
 
-Không dùng endpoint kiểu `/workout-roadmaps/active`.
-`active` là trạng thái của resource, không phải resource.
-Thiết kế phù hợp hơn là:
-
-```http
-GET /api/v1/users/{user_id}/workout-roadmaps?status=ROADMAP_STATUS_ACTIVE
-GET /api/v1/users/{user_id}/workout-roadmaps/{roadmap_id}
-```
+*Lưu ý về endpoint `/active`*: Endpoint `GET /api/v1/users/{user_id}/workout-roadmaps/active` được chấp thuận như một ngoại lệ thiết kế hợp lý nhằm tối ưu hóa trải nghiệm (UX-driven API design), giúp Client lấy nhanh dữ liệu trang chủ chỉ với 1 lượt gọi.
 
 ---
 
-## 5. Vì Sao Cần Adaptive Review
+## 5. Cơ Chế Thích Ứng Động (Dynamic Adaptive Check-In)
 
-BR-AC-04 đến BR-AC-08 mô tả các rule điều chỉnh coaching sau khi có dữ liệu thực tế.
-Nếu chỉ có API generate roadmap/schedule/plan, hệ thống chưa đủ khả năng phản ứng với hành vi thật của user.
+Quy tắc thích ứng (BR-AC-04 đến BR-AC-08) được vận hành động thông qua 2 cơ chế tương tác:
 
-Adaptive review cần tồn tại vì:
-
-- user có thể bỏ tập nhiều ngày;
-- user có thể bỏ cùng một ngày trong tuần lặp lại;
-- user có thể tập quá tải;
-- user có thể bị plateau;
-- cuối chu kỳ cần tính completion rate để quyết định roadmap tiếp theo.
-
-Tuy nhiên, không phải adaptive signal nào cũng được tự động áp dụng.
-Một số signal cần tạo đề xuất và chờ user chọn.
-Vì vậy cần model `AdaptiveRecommendation`.
-
-Ví dụ:
-
-- BR-AC-05: không hoạt động 7 ngày → đề xuất tiếp tục, reset tuần, hoặc pause roadmap.
-- BR-AC-06: bỏ cùng ngày ≥ 3 lần → đề xuất dời lịch, chỉ áp dụng nếu user đồng ý.
-- BR-AC-08: plateau → đề xuất deload, đổi bài, hoặc tăng set.
-
-Ngược lại, BR-AC-07 về overtraining có tính an toàn cao hơn, nên hệ thống có thể bắt buộc chèn ngày nghỉ.
+1. **Khảo sát động trước buổi tập (Pre-generated Check-In)**:
+   - Cuối mỗi buổi tập trước, hệ thống chạy background job gọi AI Agent sinh sẵn bộ câu hỏi check-in động cá nhân hóa cho buổi tiếp theo (ví dụ hỏi thăm chấn thương cũ).
+   - Khi mở app, Client lấy bộ câu hỏi từ DB lên hiển thị lập tức (0ms latency).
+   - Người dùng trả lời, hệ thống cập nhật DB và tự động kích hoạt AI sửa lại giáo án ngày (JIT) nếu phát hiện chấn thương mới hoặc thiếu thiết bị.
+2. **Tương tác qua Chat tự do với AI Coach**:
+   - AI Coach tự động phát hiện các sự kiện bất thường (ví dụ: bùng tập 3 buổi liên tiếp) và bắt đầu hội thoại hỏi han.
+   - Người dùng chat trả lời, AI Agent tự trích xuất intent và gọi Tool Backend (`UpdateWorkoutContext`) để trực tiếp thay đổi lịch tập hoặc cơ cấu lại bài tập dưới database.
 
 ---
 
 ## 6. Vì Sao Không Dùng `Update` / `Delete` Chung Chung
 
-`WorkoutRoadmap`, `WeeklySchedule`, và `DailyWorkoutPlan` là dữ liệu nghiệp vụ do hệ thống sinh ra.
-Chúng cần audit được theo thời gian.
-
-Không nên có API generic như:
-
-```http
-PUT /workout-roadmaps/{id}
-DELETE /weekly-schedules/{id}
-```
-
-Các thao tác thay đổi phải là command nghiệp vụ rõ nghĩa:
-
-- `RespondAdaptiveRecommendation`
-- `RescheduleScheduleDay`
-- `SkipScheduledDay`
-- `RegenerateDailyWorkoutPlan`
-- `PauseRoadmap`
-- `ResumeRoadmap`
-
-Cách này giúp contract thể hiện đúng lý do thay đổi trạng thái, thay vì chỉ cho phép client sửa dữ liệu trực tiếp.
+Các thao tác thay đổi phải là command nghiệp vụ rõ nghĩa để đảm bảo tính audit lịch sử và giữ vững ranh giới nghiệp vụ, thay vì cho phép client tự sửa dữ liệu DB trực tiếp bằng API generic `PUT/DELETE`.
 
 ---
 
 ## 7. Vì Sao Event Payload Phải Tối Thiểu
 
-Event trong hệ thống phải đi theo CloudEvents.
-Envelope chứa các thông tin kỹ thuật như:
-
-- `id`
-- `source`
-- `type`
-- `time`
-- extension attributes, ví dụ `userid`
-
-Phần `data` chỉ nên chứa dữ liệu nghiệp vụ tối thiểu cần cho consumer.
-
-Vì vậy event mới của coaching không nên nhét `user_id` vào payload nếu user id đã nằm trong CloudEvents extension và được dùng làm Kafka partition key.
-
-Ví dụ payload tốt:
-
-```proto
-message WeeklyScheduleGenerated {
-  string weekly_schedule_id = 1;
-  string roadmap_id = 2;
-  int32 week_number = 3;
-  google.type.Date start_date = 4;
-  google.type.Date end_date = 5;
-  google.protobuf.Timestamp generated_at = 6;
-}
-```
-
-Payload này đủ để consumer biết lịch nào được sinh, thuộc roadmap nào, tuần mấy, có hiệu lực trong khoảng nào.
-Thông tin routing/user ownership nằm ở envelope.
+Event trong hệ thống tuân theo CloudEvents. Phần `data` chỉ chứa dữ liệu nghiệp vụ tối thiểu để tránh dư thừa. Thông tin định tuyến (ví dụ: `user_id`) nằm ở envelope và được dùng làm Kafka partition key.
 
 ---
 
 ## 8. Quy Ước Thời Gian
 
-Contract cần phân biệt rõ:
-
-- `google.type.Date`: ngày nghiệp vụ, không kèm giờ.
-- `google.protobuf.Timestamp`: thời điểm chính xác hệ thống ghi nhận.
-
-Áp dụng:
-
-- `start_date`, `end_date`, `scheduled_date` dùng `google.type.Date`.
-- `generated_at`, `created_at`, `responded_at`, `paused_at`, `resumed_at` dùng `google.protobuf.Timestamp`.
-
-Điều này tránh nhầm giữa "ngày dự kiến tập" và "thời điểm hệ thống sinh dữ liệu".
+- `google.type.Date`: ngày nghiệp vụ (không kèm giờ), ví dụ: `start_date`, `end_date`, `scheduled_date`.
+- `google.protobuf.Timestamp`: thời điểm chính xác hệ thống ghi nhận, ví dụ: `generated_at`, `initiated_at`.
 
 ---
 
 ## 9. Hệ Quả Triển Khai
 
-Khi triển khai proto cho `CoachingService`:
-
-- dùng command/query rõ ràng;
-- REST URL dùng danh từ số nhiều;
-- command có input ngoài path dùng `body: "payload"`;
-- query không có body;
-- khai báo security bằng OpenAPI annotation trong proto;
-- không viết manual route hoặc manual OpenAPI;
-- chạy `buf lint`, `buf breaking`, và `buf generate`.
-
-Backend Go phải là nơi tính toán số liệu an toàn:
-
-- set;
-- rep;
-- tạ;
-- volume;
-- progressive overload;
-- validation theo BR-AC-01 và BR-AC-02.
-
-Agent chỉ hỗ trợ chọn bài tập hoặc thay thế bài tập theo ngữ cảnh.
-Agent không được là nguồn quyết định cuối cùng cho các con số tải trọng.
+- Dùng command/query rõ ràng, không viết manual route.
+- Backend Go là nơi chịu trách nhiệm tính toán số liệu tải trọng an toàn (set, rep, tạ, volume) theo công thức Epley/Rule Engine.
+- AI Agent đóng vai trò Reasoning Layer: chỉ hỗ trợ chọn bài tập, sắp xếp bài tập và giải thích điều chỉnh dựa trên ngữ cảnh an toàn do Backend cung cấp.
 
 ---
 
 ## 10. Kết Luận
 
-`CoachingService` cần tồn tại để tách nghiệp vụ lập kế hoạch khỏi nghiệp vụ thực thi buổi tập.
-Các API planning tạo dữ liệu theo lifecycle của roadmap, weekly schedule và daily plan.
-Các API adaptive xử lý phản ứng sau khi có dữ liệu tập thực tế.
-
-Thiết kế này giúp contract:
-
-- bám đúng DDD boundary;
-- tránh endpoint mơ hồ như `/active`;
-- tránh `Update/Delete` chung chung;
-- giữ event payload tối thiểu;
-- tuân thủ contract-first và CloudEvents;
-- phù hợp với quyết định ADR 02: Backend Go tính toán an toàn, Agent chỉ hỗ trợ chọn bài.
+Tách biệt rõ ràng **Coaching** (Lập kế hoạch) và **Execution** (Thực thi) giúp hệ thống giữ vững Bounded Context, tối giản cấu trúc API gRPC/REST, và đảm bảo an toàn tuyệt đối cho người tập nhờ cơ chế kiểm soát kép giữa Backend Go và AI Agent.

--- a/docs/adr/03_coaching_service_contract.md
+++ b/docs/adr/03_coaching_service_contract.md
@@ -1,18 +1,6 @@
 # ADR 03: Thiết Kế Contract Cho Coaching Service
 
-* **Trạng thái**: Accepted
-* **Tác giả**: Codex, Developer & Lead Architect
-
----
-
-## 1. Bối cảnh & Quyết định
-Tách biệt hoàn toàn hai cấu phần để đảm bảo ranh giới Bounded Context (DDD):
-- **Coaching Service (`internal/coaching`)**: Lập lộ trình, quản lý lịch tuần, sinh giáo án ngày JIT, và xử lý adaptive check-in.
-- **Workout Execution Service (`internal/workout_execution`)**: Điều phối và ghi nhận log buổi tập thực tế.
-
----
-
-## 2. API & Commands Hệ Thống
+## API & Commands Hệ Thống
 
 ### API Public (Client gọi qua gRPC/HTTP)
 - `InitiateRoadmap`: Khởi tạo lộ trình 4 tuần ban đầu.
@@ -26,11 +14,3 @@ Tách biệt hoàn toàn hai cấu phần để đảm bảo ranh giới Bounded
 - `GenerateNextWeeklySchedule`: Tự động sinh lịch tuần kế tiếp khi nhận event kết thúc buổi tập cuối tuần.
 - `GenerateDailyWorkoutPlanDraft`: Chạy background job sinh trước giáo án nháp (pre-caching) cho ngày hôm sau.
 - `RegenerateDailyWorkoutPlan`: Sinh lại giáo án JIT khi check-in báo chấn thương mới hoặc thiếu thiết bị.
-
----
-
-## 3. Các Nguyên Tắc Thiết Kế Cốt Lõi
-- **Kiểm soát thông số an toàn**: Backend Go chịu trách nhiệm tính toán tải trọng (sets, reps, weight) bằng thuật toán/Rule Engine. AI Agent chỉ đóng vai trò hỗ trợ chọn bài tập theo ngữ cảnh an toàn từ DB.
-- **Không dùng API CRUD chung chung**: Các thay đổi dữ liệu phải thông qua các Command nghiệp vụ rõ nghĩa, không dùng API generic `PUT/DELETE`.
-- **Event payload tối thiểu**: Event tuân theo CloudEvents. Payload chỉ chứa dữ liệu nghiệp vụ tối thiểu để tránh dư thừa (routing và user ownership nằm ở envelope).
-- **Quy ước thời gian**: Dùng `google.type.Date` cho ngày nghiệp vụ (start_date, scheduled_date) và `google.protobuf.Timestamp` cho thời điểm hệ thống ghi nhận (generated_at).

--- a/proto/contracts/core/coaching/v1/event/coaching_events.proto
+++ b/proto/contracts/core/coaching/v1/event/coaching_events.proto
@@ -9,72 +9,62 @@ import "google/type/date.proto";
 
 message RoadmapInitiated {
   string roadmap_id = 1;
-  google.type.Date start_date = 2;
-  google.type.Date end_date = 3;
-  google.protobuf.Timestamp initiated_at = 4;
+  string user_id = 2;
+  google.type.Date start_date = 3;
+  google.type.Date end_date = 4;
+  google.protobuf.Timestamp initiated_at = 5;
 }
 
 message WeeklyScheduleGenerated {
   string weekly_schedule_id = 1;
   string roadmap_id = 2;
-  int32 week_number = 3;
-  google.type.Date start_date = 4;
-  google.type.Date end_date = 5;
-  google.protobuf.Timestamp generated_at = 6;
+  string user_id = 3;
+  int32 week_number = 4;
+  google.type.Date start_date = 5;
+  google.type.Date end_date = 6;
+  google.protobuf.Timestamp generated_at = 7;
 }
 
 message DailyWorkoutPlanGenerated {
   string daily_workout_plan_id = 1;
   string weekly_schedule_id = 2;
   string roadmap_id = 3;
-  google.type.Date scheduled_date = 4;
-  google.protobuf.Timestamp generated_at = 5;
-}
-
-message RoadmapCycleEvaluated {
-  string roadmap_id = 1;
-  float completion_rate = 2;
-  google.type.Date cycle_start_date = 3;
-  google.type.Date cycle_end_date = 4;
-  google.protobuf.Timestamp evaluated_at = 5;
-}
-
-message AdaptiveRecommendationCreated {
-  string recommendation_id = 1;
-  string roadmap_id = 2;
-  string recommendation_type = 3;
-  google.protobuf.Timestamp created_at = 4;
-  google.protobuf.Timestamp expires_at = 5;
-}
-
-message AdaptiveRecommendationResponded {
-  string recommendation_id = 1;
-  string selected_option_id = 2;
-  bool accepted = 3;
-  google.protobuf.Timestamp responded_at = 4;
+  string user_id = 4;
+  google.type.Date scheduled_date = 5;
+  google.protobuf.Timestamp generated_at = 6;
 }
 
 message RoadmapAdjusted {
   string roadmap_id = 1;
-  string reason = 2;
-  google.protobuf.Timestamp adjusted_at = 3;
+  string user_id = 2;
+  string reason = 3;
+  google.protobuf.Timestamp adjusted_at = 4;
 }
 
 message RoadmapPaused {
   string roadmap_id = 1;
-  google.type.Date pause_start_date = 2;
-  google.type.Date pause_end_date = 3;
-  google.protobuf.Timestamp paused_at = 4;
+  string user_id = 2;
+  google.type.Date pause_start_date = 3;
+  google.type.Date pause_end_date = 4;
+  google.protobuf.Timestamp paused_at = 5;
 }
 
 message RoadmapResumed {
   string roadmap_id = 1;
-  google.protobuf.Timestamp resumed_at = 2;
+  string user_id = 2;
+  google.protobuf.Timestamp resumed_at = 3;
 }
 
 message ScheduleDayRescheduled {
   string weekly_schedule_id = 1;
-  google.type.Date from_date = 2;
-  google.type.Date to_date = 3;
-  google.protobuf.Timestamp rescheduled_at = 4;
+  string user_id = 2;
+  google.type.Date from_date = 3;
+  google.type.Date to_date = 4;
+  google.protobuf.Timestamp rescheduled_at = 5;
+}
+
+message PreWorkoutCheckInSubmitted {
+  string user_id = 1;
+  string check_in_id = 2;
+  google.protobuf.Timestamp submitted_at = 3;
 }

--- a/proto/contracts/core/coaching/v1/event/coaching_events.proto
+++ b/proto/contracts/core/coaching/v1/event/coaching_events.proto
@@ -41,26 +41,20 @@ message RoadmapAdjusted {
   google.protobuf.Timestamp adjusted_at = 4;
 }
 
-message RoadmapPaused {
+message RoadmapCompleted {
   string roadmap_id = 1;
   string user_id = 2;
-  google.type.Date pause_start_date = 3;
-  google.type.Date pause_end_date = 4;
-  google.protobuf.Timestamp paused_at = 5;
+  google.protobuf.Timestamp completed_at = 3;
 }
 
-message RoadmapResumed {
-  string roadmap_id = 1;
-  string user_id = 2;
-  google.protobuf.Timestamp resumed_at = 3;
-}
-
-message ScheduleDayRescheduled {
-  string weekly_schedule_id = 1;
-  string user_id = 2;
-  google.type.Date from_date = 3;
-  google.type.Date to_date = 4;
-  google.protobuf.Timestamp rescheduled_at = 5;
+message DailyWorkoutPlanRegenerated {
+  string daily_workout_plan_id = 1;
+  string weekly_schedule_id = 2;
+  string roadmap_id = 3;
+  string user_id = 4;
+  google.type.Date scheduled_date = 5;
+  string reason = 6; // Ví dụ: "injury_reported", "equipment_missing"
+  google.protobuf.Timestamp regenerated_at = 7;
 }
 
 message PreWorkoutCheckInSubmitted {

--- a/proto/contracts/core/coaching/v1/message/coaching_messages.proto
+++ b/proto/contracts/core/coaching/v1/message/coaching_messages.proto
@@ -15,50 +15,20 @@ enum RoadmapStatus {
   ROADMAP_STATUS_CANCELLED = 4;
 }
 
-enum ScheduleDayStatus {
-  SCHEDULE_DAY_STATUS_UNSPECIFIED = 0;
-  SCHEDULE_DAY_STATUS_TRAINING = 1;
-  SCHEDULE_DAY_STATUS_REST = 2;
-  SCHEDULE_DAY_STATUS_SKIPPED = 3;
-  SCHEDULE_DAY_STATUS_RESCHEDULED = 4;
+enum WorkoutDayStatus {
+  WORKOUT_DAY_STATUS_UNSPECIFIED = 0;
+  WORKOUT_DAY_STATUS_TRAINING = 1;     // Ngày có lịch tập
+  WORKOUT_DAY_STATUS_REST = 2;         // Ngày nghỉ phục hồi
+  WORKOUT_DAY_STATUS_SKIPPED = 3;      // Lịch là tập nhưng bỏ lỡ (không tập)
+  WORKOUT_DAY_STATUS_RESCHEDULED = 4;  // Chủ động dời lịch sang ngày khác
 }
 
 enum DailyPlanStatus {
   DAILY_PLAN_STATUS_UNSPECIFIED = 0;
-  DAILY_PLAN_STATUS_GENERATED = 1;
-  DAILY_PLAN_STATUS_USED = 2;
-  DAILY_PLAN_STATUS_SKIPPED = 3;
-  DAILY_PLAN_STATUS_REPLACED = 4;
-}
-
-enum AdaptiveRecommendationType {
-  ADAPTIVE_RECOMMENDATION_TYPE_UNSPECIFIED = 0;
-  ADAPTIVE_RECOMMENDATION_TYPE_CYCLE_COMPLETION = 1;
-  ADAPTIVE_RECOMMENDATION_TYPE_INACTIVITY = 2;
-  ADAPTIVE_RECOMMENDATION_TYPE_SCHEDULE_MISMATCH = 3;
-  ADAPTIVE_RECOMMENDATION_TYPE_OVERTRAINING = 4;
-  ADAPTIVE_RECOMMENDATION_TYPE_PLATEAU = 5;
-}
-
-enum AdaptiveRecommendationStatus {
-  ADAPTIVE_RECOMMENDATION_STATUS_UNSPECIFIED = 0;
-  ADAPTIVE_RECOMMENDATION_STATUS_PENDING = 1;
-  ADAPTIVE_RECOMMENDATION_STATUS_ACCEPTED = 2;
-  ADAPTIVE_RECOMMENDATION_STATUS_DECLINED = 3;
-  ADAPTIVE_RECOMMENDATION_STATUS_APPLIED = 4;
-  ADAPTIVE_RECOMMENDATION_STATUS_EXPIRED = 5;
-}
-
-enum AdaptiveRecommendationOptionType {
-  ADAPTIVE_RECOMMENDATION_OPTION_TYPE_UNSPECIFIED = 0;
-  ADAPTIVE_RECOMMENDATION_OPTION_TYPE_CONTINUE_FROM_LAST_MISSED = 1;
-  ADAPTIVE_RECOMMENDATION_OPTION_TYPE_RESET_CURRENT_WEEK = 2;
-  ADAPTIVE_RECOMMENDATION_OPTION_TYPE_PAUSE_ROADMAP = 3;
-  ADAPTIVE_RECOMMENDATION_OPTION_TYPE_RESCHEDULE_DAY = 4;
-  ADAPTIVE_RECOMMENDATION_OPTION_TYPE_DELOAD_WEEK = 5;
-  ADAPTIVE_RECOMMENDATION_OPTION_TYPE_CHANGE_EXERCISE = 6;
-  ADAPTIVE_RECOMMENDATION_OPTION_TYPE_INCREASE_SETS = 7;
-  ADAPTIVE_RECOMMENDATION_OPTION_TYPE_KEEP_CURRENT_PLAN = 8;
+  DAILY_PLAN_STATUS_DRAFT = 1;
+  DAILY_PLAN_STATUS_ACTIVE = 2;
+  DAILY_PLAN_STATUS_COMPLETED = 3;
+  DAILY_PLAN_STATUS_SKIPPED = 4;
 }
 
 message InitiateRoadmapRequest {
@@ -96,114 +66,42 @@ message GetWorkoutRoadmapResponse {
   WorkoutRoadmap roadmap = 1;
 }
 
-message GenerateNextWeeklyScheduleRequest {
+message GetActiveRoadmapRequest {
   string user_id = 1;
-  string roadmap_id = 2;
-  GenerateNextWeeklySchedulePayload payload = 3;
 }
 
-message GenerateNextWeeklySchedulePayload {
-  string previous_weekly_schedule_id = 1;
+message GetActiveRoadmapResponse {
+  WorkoutRoadmap roadmap = 1;
+  WeeklySchedule current_weekly_schedule = 2;
 }
 
-message GenerateNextWeeklyScheduleResponse {
-  WeeklySchedule weekly_schedule = 1;
-}
-
-message ListWeeklySchedulesRequest {
+message GetPreWorkoutCheckInRequest {
   string user_id = 1;
-  string roadmap_id = 2;
-  google.type.Date start_date = 3;
-  google.type.Date end_date = 4;
-  int32 page_size = 5;
-  string page_token = 6;
 }
 
-message ListWeeklySchedulesResponse {
-  repeated WeeklySchedule weekly_schedules = 1;
-  string next_page_token = 2;
+message GetPreWorkoutCheckInResponse {
+  string check_in_id = 1;
+  repeated CheckInQuestion questions = 2;
 }
 
-message GetWeeklyScheduleRequest {
+message SubmitPreWorkoutCheckInRequest {
   string user_id = 1;
-  string weekly_schedule_id = 2;
+  string check_in_id = 2;
+  repeated CheckInAnswer answers = 3;
 }
 
-message GetWeeklyScheduleResponse {
-  WeeklySchedule weekly_schedule = 1;
-}
-
-message GenerateDailyWorkoutPlanRequest {
-  string user_id = 1;
-  string weekly_schedule_id = 2;
-  GenerateDailyWorkoutPlanPayload payload = 3;
-}
-
-message GenerateDailyWorkoutPlanPayload {
-  google.type.Date scheduled_date = 1;
-  DailyCheckIn check_in = 2;
-  MissedSessionDecision missed_session_decision = 3;
-}
-
-message GenerateDailyWorkoutPlanResponse {
-  DailyWorkoutPlan daily_workout_plan = 1;
+message SubmitPreWorkoutCheckInResponse {
+  bool requires_regeneration = 1;
+  string coach_feedback = 2;
 }
 
 message GetDailyWorkoutPlanRequest {
   string user_id = 1;
-  string daily_workout_plan_id = 2;
+  google.type.Date scheduled_date = 2;
 }
 
 message GetDailyWorkoutPlanResponse {
   DailyWorkoutPlan daily_workout_plan = 1;
-}
-
-message RunAdaptiveReviewRequest {
-  string user_id = 1;
-  string roadmap_id = 2;
-  RunAdaptiveReviewPayload payload = 3;
-}
-
-message RunAdaptiveReviewPayload {
-  google.type.Date review_date = 1;
-}
-
-message RunAdaptiveReviewResponse {
-  repeated AdaptiveRecommendation recommendations = 1;
-  repeated WeeklySchedule generated_weekly_schedules = 2;
-  repeated WorkoutRoadmap generated_roadmaps = 3;
-}
-
-message ListAdaptiveRecommendationsRequest {
-  string user_id = 1;
-  string roadmap_id = 2;
-  AdaptiveRecommendationStatus status = 3;
-  int32 page_size = 4;
-  string page_token = 5;
-}
-
-message ListAdaptiveRecommendationsResponse {
-  repeated AdaptiveRecommendation recommendations = 1;
-  string next_page_token = 2;
-}
-
-message RespondAdaptiveRecommendationRequest {
-  string user_id = 1;
-  string recommendation_id = 2;
-  RespondAdaptiveRecommendationPayload payload = 3;
-}
-
-message RespondAdaptiveRecommendationPayload {
-  string selected_option_id = 1;
-  bool accepted = 2;
-  string note = 3;
-}
-
-message RespondAdaptiveRecommendationResponse {
-  AdaptiveRecommendation recommendation = 1;
-  WorkoutRoadmap roadmap = 2;
-  WeeklySchedule weekly_schedule = 3;
-  DailyWorkoutPlan daily_workout_plan = 4;
 }
 
 message WorkoutRoadmap {
@@ -212,20 +110,6 @@ message WorkoutRoadmap {
   RoadmapStatus status = 3;
   google.type.Date start_date = 4;
   google.type.Date end_date = 5;
-  repeated RoadmapPhase phases = 6;
-  CompletionRate completion_rate = 7;
-}
-
-message RoadmapPhase {
-  int32 week_number = 1;
-  string name = 2;
-  string focus = 3;
-  float target_overload_percent = 4;
-}
-
-message CompletionRate {
-  float value = 1;
-  string band = 2;
 }
 
 message WeeklySchedule {
@@ -235,22 +119,15 @@ message WeeklySchedule {
   int32 week_number = 4;
   google.type.Date start_date = 5;
   google.type.Date end_date = 6;
-  MuscleSplit muscle_split = 7;
+  string muscle_split_type = 7;
   repeated ScheduleDay schedule_days = 8;
-  repeated string daily_workout_plan_ids = 9;
-}
-
-message MuscleSplit {
-  string split_type = 1;
-  repeated string primary_muscle_groups = 2;
-  repeated string secondary_muscle_groups = 3;
 }
 
 message ScheduleDay {
   google.type.Date scheduled_date = 1;
   string day_of_week = 2;
-  ScheduleDayStatus status = 3;
-  repeated string muscle_groups = 4;
+  WorkoutDayStatus status = 3;
+  repeated string target_muscle_groups = 4;
   string daily_workout_plan_id = 5;
 }
 
@@ -262,13 +139,15 @@ message DailyWorkoutPlan {
   google.type.Date scheduled_date = 5;
   DailyPlanStatus status = 6;
   WorkoutPrescription workout_prescription = 7;
-  google.protobuf.Timestamp generated_at = 8;
+  string reasoning_explanation = 8;
+  string adjustment_explanation = 9;
+  google.protobuf.Timestamp generated_at = 10;
 }
 
 message WorkoutPrescription {
-  repeated PrescribedExercise exercises = 1;
-  repeated AccessoryExercise warm_up_items = 2;
-  repeated AccessoryExercise cool_down_items = 3;
+  repeated PrescribedExercise warm_ups = 1;
+  repeated PrescribedExercise main_exercises = 2;
+  repeated PrescribedExercise cool_downs = 3;
 }
 
 message PrescribedExercise {
@@ -277,42 +156,25 @@ message PrescribedExercise {
   int32 target_sets = 3;
   int32 target_reps = 4;
   float target_weight = 5;
-  string notes = 6;
+  int32 duration_seconds = 6;
+  string notes = 7;
 }
 
-message AccessoryExercise {
-  string exercise_id = 1;
-  string exercise_name = 2;
-  int32 duration_seconds = 3;
-  string notes = 4;
+message CheckInQuestion {
+  string question_id = 1;
+  string question_text = 2;
+  repeated CheckInOption options = 3;
+  bool allow_custom_text = 4;
+  string custom_text_placeholder = 5;
 }
 
-message DailyCheckIn {
-  int32 recovery_score = 1;
-  int32 fatigue_score = 2;
-  repeated string new_injury_areas = 3;
-  string note = 4;
-}
-
-message MissedSessionDecision {
-  string missed_daily_workout_plan_id = 1;
-  AdaptiveRecommendationOptionType decision = 2;
-}
-
-message AdaptiveRecommendation {
-  string recommendation_id = 1;
-  string roadmap_id = 2;
-  AdaptiveRecommendationType type = 3;
-  AdaptiveRecommendationStatus status = 4;
-  string reason = 5;
-  repeated AdaptiveRecommendationOption options = 6;
-  google.protobuf.Timestamp created_at = 7;
-  google.protobuf.Timestamp expires_at = 8;
-}
-
-message AdaptiveRecommendationOption {
+message CheckInOption {
   string option_id = 1;
-  AdaptiveRecommendationOptionType type = 2;
-  string label = 3;
-  string description = 4;
+  string option_text = 2;
+}
+
+message CheckInAnswer {
+  string question_id = 1;
+  repeated string selected_option_ids = 2;
+  string custom_text = 3;
 }

--- a/proto/contracts/core/coaching/v1/message/coaching_messages.proto
+++ b/proto/contracts/core/coaching/v1/message/coaching_messages.proto
@@ -10,9 +10,7 @@ import "google/type/date.proto";
 enum RoadmapStatus {
   ROADMAP_STATUS_UNSPECIFIED = 0;
   ROADMAP_STATUS_ACTIVE = 1;
-  ROADMAP_STATUS_PAUSED = 2;
-  ROADMAP_STATUS_COMPLETED = 3;
-  ROADMAP_STATUS_CANCELLED = 4;
+  ROADMAP_STATUS_COMPLETED = 2;
 }
 
 enum WorkoutDayStatus {

--- a/proto/contracts/core/coaching/v1/service/coaching_service.proto
+++ b/proto/contracts/core/coaching/v1/service/coaching_service.proto
@@ -56,63 +56,35 @@ service CoachingService {
     };
   }
 
-  // Generate the next weekly schedule for a roadmap.
-  rpc GenerateNextWeeklySchedule (contracts.core.coaching.v1.message.GenerateNextWeeklyScheduleRequest) returns (contracts.core.coaching.v1.message.GenerateNextWeeklyScheduleResponse) {
+  // Get the single active roadmap for a user.
+  rpc GetActiveRoadmap (contracts.core.coaching.v1.message.GetActiveRoadmapRequest) returns (contracts.core.coaching.v1.message.GetActiveRoadmapResponse) {
     option (google.api.http) = {
-      post: "/api/v1/users/{user_id}/workout-roadmaps/{roadmap_id}/weekly-schedules:generate-next"
-      body: "payload"
+      get: "/api/v1/users/{user_id}/workout-roadmaps/active"
     };
   }
 
-  // List weekly schedules in a roadmap.
-  rpc ListWeeklySchedules (contracts.core.coaching.v1.message.ListWeeklySchedulesRequest) returns (contracts.core.coaching.v1.message.ListWeeklySchedulesResponse) {
+  // Get pre-workout check-in questions dynamically generated for today's session.
+  rpc GetPreWorkoutCheckIn (contracts.core.coaching.v1.message.GetPreWorkoutCheckInRequest) returns (contracts.core.coaching.v1.message.GetPreWorkoutCheckInResponse) {
     option (google.api.http) = {
-      get: "/api/v1/users/{user_id}/workout-roadmaps/{roadmap_id}/weekly-schedules"
+      get: "/api/v1/users/{user_id}/pre-workout-checkin"
     };
   }
 
-  // Get one weekly schedule by id.
-  rpc GetWeeklySchedule (contracts.core.coaching.v1.message.GetWeeklyScheduleRequest) returns (contracts.core.coaching.v1.message.GetWeeklyScheduleResponse) {
+  // Submit answers for the pre-workout check-in.
+  rpc SubmitPreWorkoutCheckIn (contracts.core.coaching.v1.message.SubmitPreWorkoutCheckInRequest) returns (contracts.core.coaching.v1.message.SubmitPreWorkoutCheckInResponse) {
     option (google.api.http) = {
-      get: "/api/v1/users/{user_id}/weekly-schedules/{weekly_schedule_id}"
+      post: "/api/v1/users/{user_id}/pre-workout-checkin:submit"
+      body: "*"
     };
   }
 
-  // Generate the detailed just-in-time workout plan for a scheduled day.
-  rpc GenerateDailyWorkoutPlan (contracts.core.coaching.v1.message.GenerateDailyWorkoutPlanRequest) returns (contracts.core.coaching.v1.message.GenerateDailyWorkoutPlanResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/users/{user_id}/weekly-schedules/{weekly_schedule_id}/daily-workout-plans:generate"
-      body: "payload"
-    };
-  }
-
-  // Get one daily workout plan by id.
+  // Get today's detailed workout plan.
+  // TODO: In the future, this RPC will be refactored into a Server Streaming RPC to support Warm-up Rendering
+  // and progressive JIT streaming (as defined in ADR-01):
+  // rpc GetDailyWorkoutPlan (GetDailyWorkoutPlanRequest) returns (stream GetDailyWorkoutPlanResponse);
   rpc GetDailyWorkoutPlan (contracts.core.coaching.v1.message.GetDailyWorkoutPlanRequest) returns (contracts.core.coaching.v1.message.GetDailyWorkoutPlanResponse) {
     option (google.api.http) = {
-      get: "/api/v1/users/{user_id}/daily-workout-plans/{daily_workout_plan_id}"
-    };
-  }
-
-  // Run BR-AC-04..08 adaptive review for a roadmap.
-  rpc RunAdaptiveReview (contracts.core.coaching.v1.message.RunAdaptiveReviewRequest) returns (contracts.core.coaching.v1.message.RunAdaptiveReviewResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/users/{user_id}/workout-roadmaps/{roadmap_id}/adaptive-reviews:run"
-      body: "payload"
-    };
-  }
-
-  // List pending or historical adaptive recommendations.
-  rpc ListAdaptiveRecommendations (contracts.core.coaching.v1.message.ListAdaptiveRecommendationsRequest) returns (contracts.core.coaching.v1.message.ListAdaptiveRecommendationsResponse) {
-    option (google.api.http) = {
-      get: "/api/v1/users/{user_id}/workout-roadmaps/{roadmap_id}/adaptive-recommendations"
-    };
-  }
-
-  // Apply or reject a user-facing adaptive recommendation.
-  rpc RespondAdaptiveRecommendation (contracts.core.coaching.v1.message.RespondAdaptiveRecommendationRequest) returns (contracts.core.coaching.v1.message.RespondAdaptiveRecommendationResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/users/{user_id}/adaptive-recommendations/{recommendation_id}:respond"
-      body: "payload"
+      get: "/api/v1/users/{user_id}/daily-workout-plans/today"
     };
   }
 }

--- a/proto/contracts/core/workout_execution/v1/event/workout_session_aborted.proto
+++ b/proto/contracts/core/workout_execution/v1/event/workout_session_aborted.proto
@@ -11,4 +11,5 @@ message WorkoutSessionAborted {
   string user_id = 2;
   google.protobuf.Timestamp aborted_at = 3;
   string reason = 4; // e.g. "timeout", "user_cancelled"
+  string plan_id = 5; // Liên kết sang DailyWorkoutPlan để đồng bộ trạng thái
 }

--- a/proto/contracts/core/workout_execution/v1/event/workout_session_completed.proto
+++ b/proto/contracts/core/workout_execution/v1/event/workout_session_completed.proto
@@ -14,4 +14,5 @@ message WorkoutSessionCompleted {
   float total_volume = 5;
   optional float average_form_score = 6; // optional hỗ trợ N/A cho bài tập Phi AI
   float average_rpe = 7;
+  string plan_id = 8;                    // Liên kết sang DailyWorkoutPlan để đồng bộ trạng thái
 }

--- a/proto/contracts/core/workout_execution/v1/message/workout_execution_messages.proto
+++ b/proto/contracts/core/workout_execution/v1/message/workout_execution_messages.proto
@@ -29,7 +29,7 @@ message LogWorkoutSetRequest {
   string session_id = 1;
   int32 set_number = 2;
   string exercise_id = 3;
-  int32 target_reps = 4;
+  optional int32 target_reps = 4; // Chuyển thành optional, Server tự động map từ giáo án gốc
   int32 actual_reps = 5;
   float weight = 6;
   optional float form_score = 7; // Sử dụng optional để hỗ trợ N/A cho bài tập Phi AI
@@ -64,6 +64,8 @@ message CompleteWorkoutSessionResponse {
   float total_volume = 4;
   optional float average_form_score = 5; // Sử dụng optional nếu toàn bài phi AI
   float average_rpe = 6;
+  string ai_coach_report = 7;           // Nhận xét, vinh danh cá nhân hóa từ AI Coach
+  string nutrition_recommendation = 8; // Gợi ý thực đơn dinh dưỡng phục hồi
 }
 
 message ErrorLog {

--- a/proto/contracts/core/workout_execution/v1/message/workout_execution_messages.proto
+++ b/proto/contracts/core/workout_execution/v1/message/workout_execution_messages.proto
@@ -29,7 +29,7 @@ message LogWorkoutSetRequest {
   string session_id = 1;
   int32 set_number = 2;
   string exercise_id = 3;
-  optional int32 target_reps = 4; // Chuyển thành optional, Server tự động map từ giáo án gốc
+  int32 target_reps = 4;
   int32 actual_reps = 5;
   float weight = 6;
   optional float form_score = 7; // Sử dụng optional để hỗ trợ N/A cho bài tập Phi AI
@@ -64,8 +64,6 @@ message CompleteWorkoutSessionResponse {
   float total_volume = 4;
   optional float average_form_score = 5; // Sử dụng optional nếu toàn bài phi AI
   float average_rpe = 6;
-  string ai_coach_report = 7;           // Nhận xét, vinh danh cá nhân hóa từ AI Coach
-  string nutrition_recommendation = 8; // Gợi ý thực đơn dinh dưỡng phục hồi
 }
 
 message ErrorLog {


### PR DESCRIPTION
## Mô tả
Pull Request này thực hiện cải tiến, đơn giản hóa và đồng bộ hóa các API contracts và Events của module **Coaching** (Lập kế hoạch) tại thư mục `proto/contracts/core/coaching/v1/`. Các thay đổi giúp khớp cấu trúc dữ liệu với luồng nghiệp vụ thực tế và phân tách trách nhiệm giữa AI Agent (Gemini) và Go Backend.

### Các thay đổi chính

#### 1. Cấu phần Coaching (`proto/contracts/core/coaching/v1`)
*   **Tái cấu trúc Check-in trước tập**: Chuyển đổi luồng check-in trước buổi tập từ dạng form tĩnh sang khảo sát động hỗn hợp (`CheckInQuestion` và `CheckInAnswer`). AI Coach sẽ tự nghĩ các câu hỏi trắc nghiệm kèm tự điền tùy theo lịch sử tập của user và lưu vào DB. Client chỉ cần tải về hiển thị (0ms latency lúc bắt đầu tập).
*   **Tối giản và làm sạch `WorkoutRoadmap`**: 
    - Xóa bỏ hoàn toàn message `RoadmapPhase` (over-engineering) và trường `completion_rate` (trường thống kê gây ô nhiễm dữ liệu kế hoạch) để giữ cho Roadmap tinh gọn.
    - Loại bỏ hoàn toàn các trạng thái `PAUSED` và `CANCELLED` trong `RoadmapStatus` enum. Việc tạm dừng hoặc đóng băng lộ trình sẽ được AI PT tự động thực hiện thông qua dời lịch ngầm (JIT), giúp tối giản máy trạng thái và giao diện Client.
*   **Cải tiến lịch tuần**: Đổi tên `ScheduleDayStatus` thành `WorkoutDayStatus` để làm rõ phạm vi và thêm comment giải thích ngắn gọn, súc tích.
*   **Đơn giản hóa Request**: Xóa bỏ struct payload trung gian `SubmitPreWorkoutCheckInPayload` trong `SubmitPreWorkoutCheckInRequest` để Client submit dữ liệu trực tiếp, chuyển body mapping sang `*` ở gateway.
*   **Đồng bộ hóa & Làm sạch Events**:
    - Xóa bỏ các event dư thừa: `RoadmapPaused`, `RoadmapResumed`, `ScheduleDayRescheduled`.
    - Thêm event `RoadmapCompleted` để AI PT làm báo cáo tổng kết 4 tuần và đề xuất lộ trình mới.
    - Thêm event `DailyWorkoutPlanRegenerated` để báo hiệu khi AI sinh lại giáo án ngày thành công (ví dụ sau check-in), giúp Client cập nhật giao diện (JIT refresh).

#### 2. Cấu phần Workout Execution (`proto/contracts/core/workout_execution/v1`)
*   **Đồng bộ trạng thái giáo án**: Thêm trường `plan_id` vào event `WorkoutSessionCompleted` (tag 8) và `WorkoutSessionAborted` (tag 5) giúp module `coaching` nhận biết và tự động đồng bộ trạng thái giáo án sang `COMPLETED` hoặc `DRAFT` một cách bất đồng bộ mà không vi phạm ranh giới DB (Schema Isolation).

### Xác minh (Verification)
*   Chạy `buf lint` kiểm tra cú pháp và style protobuf thành công.
*   Chạy `buf generate` cập nhật Go stubs và OpenAPI docs thành công.
*   Chạy `go test -tags=unit ./...` thành công 100% (pass toàn bộ test).
