### PR TITLE
♻️ refactor(coaching): simplify 4-week roadmap generation in docs and proto

### DIFF
--- a/docs/02_bounded_context.md
+++ b/docs/02_bounded_context.md
@@ -35,7 +35,7 @@
 ### 2. Coaching & Planning Context
 - **Trách nhiệm**: Lập lộ trình 4 tuần, lịch tuần, giáo án JIT chi tiết; thực thi thích ứng (Signal B1–B4, CR cuối chu kỳ); quản lý phong cách Coach và nhắc lịch. [FR-AC-01 → FR-AC-07, FR-UM-04]
 - **Không trách nhiệm**: Không ghi nhận thực tế buổi tập, không đếm rep, không tính 1RM.
-- **Aggregates**: `WorkoutRoadmap`, `WeeklySchedule`, `DailyWorkoutPlan`
+- **Aggregates**: `WorkoutRoadmap` (Aggregate Root quản lý 4 `WeeklySchedule` và 28 ngày tập), `DailyWorkoutPlan`
 - **Domain Services**: `AdaptiveCoachEngine`, `OverloadValidator`
 - **Quy tắc nghiệp vụ**:
   - BR-AC-01: Tối đa 6 buổi/tuần, ≥ 1 ngày nghỉ.

--- a/docs/02_bounded_context.md
+++ b/docs/02_bounded_context.md
@@ -35,18 +35,18 @@
 ### 2. Coaching & Planning Context
 - **Trách nhiệm**: Lập lộ trình 4 tuần, lịch tuần, giáo án JIT chi tiết; thực thi thích ứng (Signal B1–B4, CR cuối chu kỳ); quản lý phong cách Coach và nhắc lịch. [FR-AC-01 → FR-AC-07, FR-UM-04]
 - **Không trách nhiệm**: Không ghi nhận thực tế buổi tập, không đếm rep, không tính 1RM.
-- **Aggregates**: `WorkoutRoadmap` (Aggregate Root quản lý 4 `WeeklySchedule` và 28 ngày tập), `DailyWorkoutPlan`
+- **Aggregates**: `Roadmap` (Aggregate Root quản lý 4 `WeekPlan`, 28 `DayPlan` và các `SessionPlan`)
 - **Domain Services**: `AdaptiveCoachEngine`, `OverloadValidator`
 - **Quy tắc nghiệp vụ**:
-  - BR-AC-01: Tối đa 6 buổi/tuần, ≥ 1 ngày nghỉ.
-  - BR-AC-02: Progressive Overload ≤ 10% volume/tuần.
-  - BR-AC-03: Buổi bỏ tập = "Bỏ qua", không tự dồn bù.
-  - BR-AC-04: Quy tắc CR cuối chu kỳ (4 mức: <40%, 40–70%, 70–90%, ≥90%).
-  - BR-AC-05: Signal B1 — Không hoạt động 7 ngày.
-  - BR-AC-06: Signal B2 — Lịch không tương thích.
-  - BR-AC-07: Signal B3 — Overtraining (≥ 2 buổi/ngày hoặc RPE ≥ 8.5 liên tục ≥ 5 buổi).
-  - BR-AC-08: Signal B4 — Plateau (1RM + Form không tăng 3 tuần liên tiếp với CR ≥ 70%).
-  - BR-AC-09: Lộ trình 4 tuần chuyên khoa tuân thủ 4 giai đoạn: Tuần 1 (Accumulation - Tích lũy RPE 6–7), Tuần 2 (Overload - Tăng tải RPE 7–8), Tuần 3 (Peak - Chạm đỉnh RPE 8–9), và Tuần 4 (Supercompensation/Deload - Giảm 40–50% volume, RPE 5–6).
+  - BR-AC-01
+  - BR-AC-02
+  - BR-AC-03
+  - BR-AC-04
+  - BR-AC-05
+  - BR-AC-06
+  - BR-AC-07
+  - BR-AC-08
+  - BR-AC-09
 - **Context liên quan**:
   - Đọc `BiologicalMetrics`, `Injury`, `PrimaryGoal`, `AvailableEquipment`, `PreferredMuscleGroups`, `AvailableSlots` từ `User Profile`.
   - Đọc thông tin bài tập được quản lý bởi `Workout Execution & Motion`.

--- a/docs/03_ddd_tactical_design.md
+++ b/docs/03_ddd_tactical_design.md
@@ -41,51 +41,35 @@
 ## 2. Context AI Coaching & Planning
 
 #### Aggregate Root: `WorkoutRoadmap`
-- **Nhiệm vụ**: Kiểm soát lộ trình tập luyện 4 tuần và trạng thái chu kỳ.
-- **Value Objects**:
-  - `RoadmapPhase`: Giai đoạn hiện tại và Progressive Overload target.
-  - `CompletionRate`: Tỷ lệ hoàn thành tính cuối chu kỳ (CR).
+- **Nhiệm vụ**: Quản lý toàn bộ Lộ trình 4 tuần (28 ngày tập), 4 tuần `WeeklySchedule` và 28 `DailyWorkoutPlan` chi tiết.
+- **Entities & Value Objects**:
+  - `WeeklySchedule` (Entity): Đại diện cho 1 tuần tập (chứa 7 `ScheduleDay` và `MuscleSplit`).
+  - `ScheduleDay` (Value Object): Trạng thái ngày tập (`Training`, `Rest`, `Skipped`), nhóm cơ mục tiêu và ID tham chiếu `DailyWorkoutPlan`.
+  - `DailyWorkoutPlan` (Entity): Giáo án chi tiết một buổi tập (`WorkoutPrescription` gồm bài tập, set, rep, tạ gợi ý, rest time, target RPE, warm-up/cool-down).
+  - `RoadmapPhase`: Giai đoạn hiện tại (`Accumulation`, `Overload`, `Peak`, `Deload`) và RPE target.
+  - `CompletionRate`: Tỷ lệ hoàn thành tính vào ngày 28 (cuối chu kỳ 4 tuần).
 - **Repository**: `WorkoutRoadmapRepository`
 - **Domain Events**:
-  - `RoadmapInitiated`: Khởi tạo lộ trình đầu tiên.
-  - `RoadmapAdjusted`: Điều chỉnh lộ trình (Trigger A).
+  - `RoadmapInitiated`: Khởi tạo lộ trình 4 tuần và 28 giáo án chi tiết.
+  - `RoadmapAdjusted`: Điều chỉnh các giáo án chưa thực thi khi đổi profile/chấn thương.
   - `RoadmapPaused`: Tạm dừng lộ trình (Signal B1, tối đa 4 tuần).
   - `RoadmapResumed`: Tiếp tục lộ trình sau khi tạm dừng.
+  - `DailyWorkoutPlanExecuted`: Giáo án của ngày hôm nay đã được thực thi.
 - **Invariants**:
   - Lifecycle: `Active` → `Paused` → `Resumed` → `Completed`.
-  - `RoadmapPaused` tối đa 4 tuần, sau đó tự chuyển về `Active` hoặc hỏi lại user.
-
-#### Aggregate Root: `WeeklySchedule`
-- **Nhiệm vụ**: Lịch tập/nghỉ của một tuần cụ thể, tham chiếu `WorkoutRoadmapId` bằng ID.
-- **Value Objects**:
-  - `MuscleSplit`: Nhóm cơ phân bổ cho từng ngày tập.
-  - `DailyPlanIds`: Danh sách ID tham chiếu tới các `DailyWorkoutPlan`.
-- **Repository**: `WeeklyScheduleRepository`
-- **Domain Events**:
-  - `WeeklyScheduleGenerated`: Tạo lịch tuần mới.
-  - `ScheduleDayRescheduled`: Dời ngày tập (Signal B2).
-- **Invariants**:
-  - Tối thiểu 1 ngày nghỉ hoàn toàn, tối đa 6 ngày tập trong tuần (BR-AC-01).
-  - Buổi bỏ tập đánh dấu "Bỏ qua", không tự dồn bù chưa có xác nhận (BR-AC-03).
-
-#### Aggregate Root: `DailyWorkoutPlan`
-- **Nhiệm vụ**: Giáo án chi tiết một buổi tập, sinh JIT để tránh lock `WeeklySchedule`.
-- **Value Objects**:
-  - `WorkoutPrescription`: Bài tập, set, rep, tạ gợi ý, thời gian nghỉ giữa hiệp (`rest_set_sec`), thời gian nghỉ sau bài tập (`rest_exercise_sec`), `target_rpe`, warm-up/cool-down.
-- **Repository**: `DailyWorkoutPlanRepository`
-- **Domain Events**:
-  - `DailyWorkoutPlanGenerated`: Giáo án đã được sinh.
+  - Tối thiểu 1 ngày nghỉ hoàn toàn, tối đa 6 ngày tập trong mỗi tuần (`BR-AC-01`).
+  - Buổi bỏ tập tự động đánh dấu `Skipped` (`BR-AC-03`), không dời đẩy lịch của các ngày tiếp theo.
 
 #### [Domain Service] `AdaptiveCoachEngine`
-- **Nhiệm vụ**: Phát hiện và xử lý 4 tín hiệu hành vi (Signal B1–B4), điều phối 4 giai đoạn lộ trình (`Accumulation` ➔ `Overload` ➔ `Peak` ➔ `Supercompensation/Deload` theo BR-AC-09) và đánh giá CR cuối chu kỳ (BR-AC-04).
-- **Input**: `WorkoutRoadmap`, `WeeklySchedule`, lịch sử `WorkoutSession`.
+- **Nhiệm vụ**: Phát hiện và xử lý 4 tín hiệu hành vi (Signal B1–B4), điều phối 4 giai đoạn lộ trình (`Accumulation` ➔ `Overload` ➔ `Peak` ➔ `Deload` theo BR-AC-09) và đánh giá CR cuối chu kỳ 4 tuần (`BR-AC-04`).
+- **Input**: `WorkoutRoadmap`, lịch sử `WorkoutSession`.
 - **Signal B1** (BR-AC-05): Không hoạt động 7 ngày → Đề xuất 3 phương án (tiếp tục / đặt lại / tạm dừng).
 - **Signal B2** (BR-AC-06): Bỏ tập cùng ngày ≥ 3 lần liên tiếp → Đề xuất dời slot.
 - **Signal B3** (BR-AC-07): ≥ 2 buổi/ngày hoặc RPE ≥ 8.5 liên tục ≥ 5 buổi → Cảnh báo, chèn nghỉ bắt buộc.
 - **Signal B4** (BR-AC-08): 1RM + Form không tăng 3 tuần liên tiếp (CR ≥ 70%) → Đề xuất Deload / đổi bài / tăng set.
 
 #### [Domain Service] `OverloadValidator`
-- **Nhiệm vụ**: Kiểm tra volume `WeeklySchedule` mới không vượt 10% volume thực tế tuần trước (BR-AC-02).
+- **Nhiệm vụ**: Kiểm soát giới hạn biên độ điều chỉnh tải trọng ($\pm 30\%$, `BR-AC-02`).
 
 ---
 

--- a/docs/03_ddd_tactical_design.md
+++ b/docs/03_ddd_tactical_design.md
@@ -40,33 +40,30 @@
 
 ## 2. Context AI Coaching & Planning
 
-#### Aggregate Root: `WorkoutRoadmap`
-- **Nhiệm vụ**: Quản lý toàn bộ Lộ trình 4 tuần (28 ngày tập), 4 tuần `WeeklySchedule` và 28 `DailyWorkoutPlan` chi tiết.
+#### Aggregate Root: `Roadmap`
+- **Nhiệm vụ**: Quản lý toàn bộ Lộ trình 4 tuần (28 ngày), 4 `WeekPlan`, 28 `DayPlan` và các `SessionPlan` theo khung giờ `available_slots`.
 - **Entities & Value Objects**:
-  - `WeeklySchedule` (Entity): Đại diện cho 1 tuần tập (chứa 7 `ScheduleDay` và `MuscleSplit`).
-  - `ScheduleDay` (Value Object): Trạng thái ngày tập (`Training`, `Rest`, `Skipped`), nhóm cơ mục tiêu và ID tham chiếu `DailyWorkoutPlan`.
-  - `DailyWorkoutPlan` (Entity): Giáo án chi tiết một buổi tập (`WorkoutPrescription` gồm bài tập, set, rep, tạ gợi ý, rest time, target RPE, warm-up/cool-down).
+  - `WeekPlan` (Entity): Đại diện cho 1 tuần tập (chứa 7 `DayPlan` và `muscle_split_type`).
+  - `DayPlan` (Entity): Quản lý 1 ngày trên lịch (`scheduled_date`, `is_rest_day`, `available_slots`).
+  - `SessionPlan` (Entity): Kế hoạch buổi tập gắn theo khung giờ rảnh trong ngày (`slot_time`, `status`: `PENDING`, `COMPLETED`, `SKIPPED`, `prescription` JSONB).
   - `RoadmapPhase`: Giai đoạn hiện tại (`Accumulation`, `Overload`, `Peak`, `Deload`) và RPE target.
-  - `CompletionRate`: Tỷ lệ hoàn thành tính vào ngày 28 (cuối chu kỳ 4 tuần).
-- **Repository**: `WorkoutRoadmapRepository`
+- **Repository**: `RoadmapRepository`
 - **Domain Events**:
-  - `RoadmapInitiated`: Khởi tạo lộ trình 4 tuần và 28 giáo án chi tiết.
-  - `RoadmapAdjusted`: Điều chỉnh các giáo án chưa thực thi khi đổi profile/chấn thương.
-  - `RoadmapPaused`: Tạm dừng lộ trình (Signal B1, tối đa 4 tuần).
-  - `RoadmapResumed`: Tiếp tục lộ trình sau khi tạm dừng.
-  - `DailyWorkoutPlanExecuted`: Giáo án của ngày hôm nay đã được thực thi.
+  - `RoadmapInitiated`: Khởi tạo lộ trình 4 tuần (4 `WeekPlan`, 28 `DayPlan` và các `SessionPlan`).
+  - `RoadmapAdjusted`: Điều chỉnh giáo án chưa thực thi (`status = PENDING`) khi có tín hiệu thích ứng hoặc đổi profile.
+  - `SessionPlanExecuted`: Buổi tập trong ngày đã được thực thi thành công.
 - **Invariants**:
-  - Lifecycle: `Active` → `Paused` → `Resumed` → `Completed`.
+  - Lifecycle: `Active` → `Completed` (hoặc `Cancelled`).
   - Tối thiểu 1 ngày nghỉ hoàn toàn, tối đa 6 ngày tập trong mỗi tuần (`BR-AC-01`).
   - Buổi bỏ tập tự động đánh dấu `Skipped` (`BR-AC-03`), không dời đẩy lịch của các ngày tiếp theo.
 
 #### [Domain Service] `AdaptiveCoachEngine`
-- **Nhiệm vụ**: Phát hiện và xử lý 4 tín hiệu hành vi (Signal B1–B4), điều phối 4 giai đoạn lộ trình (`Accumulation` ➔ `Overload` ➔ `Peak` ➔ `Deload` theo BR-AC-09) và đánh giá CR cuối chu kỳ 4 tuần (`BR-AC-04`).
-- **Input**: `WorkoutRoadmap`, lịch sử `WorkoutSession`.
-- **Signal B1** (BR-AC-05): Không hoạt động 7 ngày → Đề xuất 3 phương án (tiếp tục / đặt lại / tạm dừng).
-- **Signal B2** (BR-AC-06): Bỏ tập cùng ngày ≥ 3 lần liên tiếp → Đề xuất dời slot.
-- **Signal B3** (BR-AC-07): ≥ 2 buổi/ngày hoặc RPE ≥ 8.5 liên tục ≥ 5 buổi → Cảnh báo, chèn nghỉ bắt buộc.
-- **Signal B4** (BR-AC-08): 1RM + Form không tăng 3 tuần liên tiếp (CR ≥ 70%) → Đề xuất Deload / đổi bài / tăng set.
+- **Nhiệm vụ**: Phát hiện và xử lý 4 tín hiệu hành vi (Signal B1–B4) và thực thi quy tắc thích ứng định kỳ dựa trên $SCR$ và $\Delta RPE$ (`BR-AC-04`).
+- **Input**: `Roadmap`, lịch sử `WorkoutSession`.
+- **Signal B1** (BR-AC-05): Bỏ tập 3 buổi liên tiếp (hoặc không mở app 7 ngày) → Đề xuất (a) tập tiếp, (b) đặt lại lịch tuần.
+- **Signal B2** (BR-AC-06): Bỏ tập cùng 1 ngày trong tuần ≥ 3 lần liên tiếp → Đề xuất dời slot.
+- **Signal B3** (BR-AC-07): Tập ngoài lịch (ngày nghỉ hoặc buổi thứ 2+ trong ngày) → Check-in hỏi nguyên nhân (quá nhẹ / thừa thời gian / quá sức).
+- **Signal B4** (BR-AC-08): 1RM không tăng 2 tuần liên tiếp (khi $SCR \ge 80\%$) → Đề xuất các phương án phá Plateau (đổi biến thể bài tập / dải rep / thứ tự bài).
 
 #### [Domain Service] `OverloadValidator`
 - **Nhiệm vụ**: Kiểm soát giới hạn biên độ điều chỉnh tải trọng ($\pm 30\%$, `BR-AC-02`).

--- a/docs/NGHIEP_VU_COT_LOI_BABOK.md
+++ b/docs/NGHIEP_VU_COT_LOI_BABOK.md
@@ -1,16 +1,17 @@
 # ĐẶC TẢ YÊU CẦU NGHIỆP VỤ CỐT LÕI (CORE BRD) - FITAI
-### TIÊU CHUẨN: BABOK® GUIDE V3.0 Compliant | Phiên bản: 1.7.0-OPT (Tối ưu Token)
+### TIÊU CHUẨN: BABOK® GUIDE V3.0 Compliant | Phiên bản: 1.18.0
 
 ---
 
 ## KIỂM SOÁT TÀI LIỆU
-- **Mã tài liệu**: FITAI-BRD-CORE-001 | **Ngày hiệu lực**: 03/07/2026
+- **Mã tài liệu**: FITAI-BRD-CORE-001 | **Ngày hiệu lực**: 28/07/2026
 - **Trạng thái**: Approved | **Phân loại**: Internal Confidential
 - **Lịch sử đổi mới chính**:
   * v1.0 (27/06/2026): Hoàn thiện 7 module nghiệp vụ gốc.
   * v1.3 (01/07/2026): Chuyển sang cơ chế sinh lộ trình tổng quan & sinh giáo án chi tiết theo buổi.
   * v1.6 (02/07/2026): Thêm Warm-up/Cool-down, xử lý bỏ tập, Onboarding tối giản (hỏi thiết bị/dị ứng theo ngữ cảnh), Module Admin và Tái cấu trúc quy trình 3.4 thành các Quy tắc nghiệp vụ BR-AC-04 -> BR-AC-08 (CR & Signals B1-B4), tổng quát hóa BR-WL-02.
   * v1.7 (03/07/2026): Bổ sung luồng tập phi AI (timer/nhạc/hướng dẫn) và tư vấn món ăn ngoài.
+  * v1.18 (28/07/2026): Chuẩn hóa Lộ trình cố định 4 tuần, mô hình 4 tầng (Roadmap -> WeekPlan -> DayPlan -> SessionPlan), quy tắc thích ứng SCR & ΔRPE, Signal B1-B4, thích ứng sau chấn thương, và loại bỏ hoàn toàn fitness_level, Pause, Cancel.
 
 ---
 
@@ -37,27 +38,22 @@
 ## 3. BẢN ĐỒ QUY TRÌNH NGHIỆP VỤ
 
 ### 3.1 Quy trình Khởi tạo (Onboarding & Planning)
-1. User nhập thông tin cơ bản, chỉ số cơ thể, mục tiêu (`primary_goal`: Tăng cơ/Giảm mỡ/Sức mạnh), nhóm cơ ưu tiên (`preferred_muscle_groups`) & khung giờ/ngày rảnh (`available_slots`).
+1. User nhập thông tin cơ bản, chỉ số cơ thể, mục tiêu ( Tăng cơ/Giảm mỡ ), nhóm cơ ưu tiên & khung giờ rảnh, dụng cụ có sẵn.
 2. User khai báo chấn thương cũ hoặc bệnh lý mãn tính.
-3. AI Coach tính toán `User Fitness Score` (thể trạng khởi điểm RPE 6–7) và khởi tạo Lộ trình 4 tuần (28 ngày) phân bổ 4 pha luyện tập (Accumulation, Overload, Peak, Deload) cùng các `DailyWorkoutPlan` chi tiết (bài tập, set, rep, tạ gợi ý, thời gian nghỉ) tương ứng các ngày rảnh trong `available_slots` và Gợi ý dinh dưỡng.
+3. khởi tạo Lộ trình 4 tuần (Accumulation, Overload, Peak, Deload) chi tiết (bài tập, set, rep, tạ gợi ý, thời gian nghỉ) tương ứng các thời gian rảnh và Gợi ý dinh dưỡng.
 
 ### 3.2 Quy trình Luyện tập (Workout Execution)
 1. User check-in & cấu hình playlist âm nhạc (phát chạy ngầm xuyên suốt buổi tập).
-2. **Khởi động (Warm-up)**: Nếu giáo án có Warm-up, hệ thống hiển thị bài tập khởi động (hỗ trợ cả luồng AI và Phi AI) kèm tuỳ chọn **Skip Warm-up** để bỏ qua.
+2. **Khởi động (Warm-up)**.
 3. **Thực hiện bài tập chính**: Cả hai nhánh AI và Phi AI đều được thiết kế đồng nhất (cùng có nhạc nền chạy ngầm, timer đếm ngược, tuỳ chọn xem/nghe hướng dẫn on-demand). Sự khác biệt duy nhất là việc kích hoạt module AI Camera:
    - **Đối với bài tập có hỗ trợ AI Camera (Nhánh AI)**: Bật camera trước/sau, căn chỉnh khoảng cách (1.5m - 2m) và ánh sáng. AI Camera tracking khung xương (17 điểm), ước lượng tạ thực tế, đếm rep, tính ROM %, chấm Form Score. Nếu sai tư thế: Audio Ducking (giảm nhạc nền) + Phát giọng nói sửa lỗi thời gian thực (độ trễ <500ms). User xác nhận kết quả set (hệ thống tự động điền rep, tạ, Form Score).
    - **Đối với bài tập phi AI (Nhánh tự ghi nhận)**: Tắt camera. User tự thực hiện theo nhịp của mình và tự nhập kết quả set thủ công khi hoàn thành (Form Score ghi nhận N/A).
-4. **Dãn cơ (Cooldown)**: Trước khi kết thúc buổi tập, nếu giáo án có Cooldown, hệ thống hiển thị bài tập dãn cơ (hỗ trợ cả luồng AI và Phi AI) kèm tuỳ chọn **Skip Cooldown** để bỏ qua.
+4. **Dãn cơ (Cooldown)**.
 5. Nghỉ ngơi → Lặp lại cho đến khi hoàn thành giáo án → Nhận Post-session Report sau khi kết thúc buổi tập.
+6. Trong quá trình tập luyện nếu user có chấn thương thì lập tức dừng buổi tập.
 
-### 3.3 Quy trình Truy xuất & Thực thi Giáo án theo buổi
-1. Trigger: Đến ngày tập hoặc User mở ứng dụng.
-2. Hệ thống đọc trực tiếp `DailyWorkoutPlan` đã khởi tạo của ngày hôm nay từ cơ sở dữ liệu.
-3. User thực hiện Check-in ngắn. Nếu có biến động sức khỏe/chấn thương mới ➔ AI Coach kích hoạt Re-generate giáo án riêng cho hôm nay hoặc điều chỉnh tải trọng.
-4. User nhận giáo án và chuẩn bị thực hiện (chuyển sang Quy trình 3.2).
-
-### 3.4 Quy trình Đánh giá & Điều chỉnh Lộ trình (Adaptive Review Cycle)
-1. **Trigger A (Cuối chu kỳ 4 tuần)**: AI Coach tính Completion Rate (CR) để tự động nâng/hạ hoặc cấu hình lại lộ trình 4 tuần kế tiếp theo quy tắc **BR-AC-04**.
+### 3.3 Quy trình Đánh giá & Điều chỉnh Lộ trình (Adaptive Review Cycle)
+1. **Trigger A (Cuối chu kỳ 4 tuần)**: AI Coach tính Tỷ lệ hoàn thành Set ($SCR = \frac{\text{Số Set thực tế}}{\text{Số Set giao}} \times 100\%$) và Độ lệch mệt mỏi ($\Delta RPE = RPE_{\text{Thực tế}} - RPE_{\text{Target}}$) để tự động điều chỉnh tạ và cấu hình lại lộ trình theo quy tắc **BR-AC-04**.
 2. **Trigger B (Giữa chu kỳ - Event-driven)**: Hệ thống liên tục quét 4 tín hiệu hành vi độc lập (Không hoạt động, Lịch không tương thích, Tập quá tải, Tiến bộ đình trệ) hoặc khi User cập nhật hồ sơ (`ProfileUpdated`) để đề xuất **Re-generate các giáo án chưa tập (`scheduled_date >= today`)** trong 4 tuần theo các quy tắc **BR-AC-05** -> **BR-AC-08**.
 
 ---
@@ -75,13 +71,13 @@
 ### Module 2: AI Coach cá nhân
 | Mã | Nghiệp vụ chi tiết | MoSCoW |
 |---|---|---|
-| **FR-AC-01** | **Khởi tạo kế hoạch**: Sinh Lộ trình 4 tuần (28 ngày tập) phân bổ nhóm cơ & RPE target theo 4 pha (Accumulation, Overload, Peak, Deload) và các giáo án chi tiết dựa trên `available_slots`, `primary_goal`, `preferred_muscle_groups` và `user_fitness_score`. | M |
-| **FR-AC-02** | **Tự động điều chỉnh**: Phân tích hiệu suất tập để tăng/giảm tạ, thay bài tập hoặc chèn Deload Week. | M |
+| **FR-AC-01** | **Khởi tạo kế hoạch**: Sinh Lộ trình 4 tuần (28 ngày tập) phân bổ nhóm cơ & RPE target theo 4 pha (Accumulation, Overload, Peak, Deload) và các giáo án chi tiết dựa trên `available_slots`, `primary_goal`, `preferred_muscle_groups`. | M |
+| **FR-AC-02** | **Tự động điều chỉnh**: Phân tích hiệu suất tập để tăng/giảm tạ | M |
 | **FR-AC-03** | **Bài tập thay thế**: Loại bỏ bài tác động vào vùng chấn thương đột xuất cho đến khi báo phục hồi. | S |
 | **FR-AC-04** | **Đồng hành**: Gửi tin nhắn động viên cá nhân hóa dựa trên dữ liệu thực tế (PR, quay lại sau nghỉ dài). | S |
-| **FR-AC-05** | **Phong cách Coach**: Cho chọn Drill Sergeant (nghiêm khắc), Best Friend (thân thiện), Data Analyst (khoa học). | C |
-| **FR-AC-06** | **Tải giáo án từ cơ sở dữ liệu & Re-generate linh hoạt**: Khi mở ứng dụng, đọc giáo án đã khởi tạo trực tiếp từ cơ sở dữ liệu. Khi có thay đổi hồ sơ hoặc sức khỏe ➔ Re-generate các giáo án chưa thực thi (`scheduled_date >= today`). | M |
-| **FR-AC-07** | **Warm-up/Cool-down**: Tự chèn khởi động (5-10') và giãn cơ (5') theo nhóm cơ sẽ tập của giáo án (hỗ trợ cả AI và Phi AI, cho phép user bỏ qua/Skip). | M |
+| **FR-AC-05** | **Phong cách Coach**: Cho chọn nghiêm khắc, thân thiện, khoa học. | C |
+| **FR-AC-06** | **Re-generate linh hoạt**: Khi có thay đổi hồ sơ hoặc sức khỏe ➔ Re-generate các giáo án chưa thực thi (`scheduled_date >= today`). | M |
+| **FR-AC-07** | **Warm-up/Cool-down**: Tự chèn khởi động (5-10') và giãn cơ (5') theo nhóm cơ sẽ tập của giáo án cho phép user bỏ qua. | M |
 
 ### Module 3: AI Camera Coach (Phân tích tư thế)
 | Mã | Nghiệp vụ chi tiết | MoSCoW |
@@ -129,18 +125,18 @@
 | Mã | Module | Nội dung quy tắc nghiệp vụ |
 |---|---|---|
 | **BR-UM-01** | Hồ sơ | Hồ sơ sức khỏe phải hoàn thiện **$\ge 80\%$** trước khi kích hoạt AI Coach và sinh lộ trình tập đầu tiên. |
-| **BR-AC-01** | Tập luyện | Lịch tập tối đa **6 buổi/tuần**; bắt buộc có ít nhất **1 ngày nghỉ hoàn toàn** trong tuần để phục hồi cơ bắp. |
-| **BR-AC-02** | Tiến độ | **Giới hạn biên độ điều chỉnh tải trọng (Load Adjustment Ceiling)**:<br>Mọi đề xuất điều chỉnh mức tạ/tải trọng của AI Coach (dù tăng tạ khi tiến bộ hay giảm tạ khi mệt mỏi) đều bị giới hạn tối đa trong khoảng **$\pm 30\%$** so với mức tạ cao nhất trong lịch sử hoặc mức tạ gợi ý gần nhất của bài tập đó. |
+| **BR-AC-01** | Tập luyện | Lịch tập tối đa **6 buổi/tuần** |
+| **BR-AC-02** | Tiến độ | **Giới hạn**:<br>Mọi điều chỉnh mức tạ/tải trọng đều bị giới hạn tối đa trong khoảng **$\pm 30\%$** so với mức tạ cao nhất trong lịch sử hoặc mức tạ gợi ý gần nhất của bài tập đó. |
 | **BR-CC-01** | AI Camera | Rep hợp lệ để đếm số khi biên độ chuyển động (ROM) khớp đạt ít nhất **$\ge 70\%$** so với biên độ tiêu chuẩn. |
 | **BR-CC-02** | Chống gian lận | Tỷ lệ frame nhận diện khớp hợp lệ < 50% trong buổi tập dưới camera → Đánh dấu "Không đạt chuẩn xác thực" (Chỉ áp dụng khi sử dụng AI Camera, trừ bài nằm sàn/phòng tối được chuyển sang ghi nhận thủ công). |
 | **BR-NU-01** | Dinh dưỡng | AI Nutrition tuyệt đối không gợi ý thực đơn tổng năng lượng dưới **1,200 kcal/ngày** cho bất kỳ đối tượng nào. |
 | **BR-NU-02** | Dinh dưỡng | Nguồn protein chính đã ăn trong Meal History sẽ bị khóa không gợi ý lại trong vòng **7 ngày tiếp theo**. |
-| **BR-AC-03** | Tập luyện | Giáo án các buổi bỏ tập mặc định tự động đánh dấu là **"Skipped" (Bỏ qua)** và tiến hành sinh ngay giáo án tập cho ngày hôm nay theo đúng lịch. |
-| **BR-AC-04** | Lộ trình | **Quy tắc điều chỉnh CR cuối chu kỳ (Trigger A)**:<br>- **CR < 40%**: Hỏi lý do bỏ tập, chờ phản hồi mới đề xuất giảm số buổi/tuần và rút ngắn thời lượng giáo án.<br>- **40% <= CR < 70%**: Giữ nguyên số buổi, giảm tải lượng 10-15%, chèn xen kẽ buổi Express 30 phút. Tự động sinh lộ trình mới.<br>- **70% <= CR < 90%**: Giữ nguyên cấu trúc, tăng Progressive Overload <= 10% theo BR-AC-02. Tự sinh lộ trình.<br>- **CR >= 90%**: Đề xuất tăng cường độ hoặc thêm 1 buổi/tuần (không vượt BR-AC-01), gắn badge "Xuất sắc". |
-| **BR-AC-05** | Lộ trình | **Signal B1 (Không hoạt động 7 ngày liên tiếp)**: AI Coach gửi tin nhắn check-in theo phong cách đã chọn, đề xuất 3 phương án: (a) tập tiếp từ buổi bỏ gần nhất, (b) đặt lại lịch tuần này, (c) tạm dừng lộ trình (Pause tối đa 4 tuần). Không tự chỉnh lịch nếu user chưa phản hồi. |
-| **BR-AC-06** | Lịch tập | **Signal B2 (Lịch không tương thích)**: User bỏ tập cùng 1 ngày trong tuần $\ge 3$ lần liên tiếp → AI đề xuất dời slot ngày đó sang ngày khác. Nếu đồng ý thì cập nhật lịch tuần, nếu từ chối thì giữ nguyên và không hỏi lại. |
-| **BR-AC-07** | Tập luyện | **Signal B3 (Tập quá tải - Overtraining)**: Kích hoạt khi user tập $\ge 2$ buổi/ngày hoặc RPE trung bình $\ge 8.5$ liên tục $\ge 5$ buổi → Cảnh báo quá tải, bắt buộc chèn 1 ngày nghỉ trong lịch kế tiếp, gợi ý Active Recovery. |
-| **BR-AC-08** | Lộ trình | **Signal B4 (Tiến bộ đình trệ - Plateau)**: Sức mạnh (1RM) và Form trung bình không tăng trong 3 tuần liên tiếp (chỉ tính tuần có CR $\ge 70\%$) → AI Coach gợi ý chọn: (a) Deload Week (giảm 40% tải lượng 1 tuần), (b) Đổi biến thể bài tập tương đương, (c) Tăng set giữ tạ. |
+| **BR-AC-03** | Tập luyện | **Xử lý Bỏ tập**: Ngày tập trôi qua mà không thực hiện sẽ tự động chuyển sang trạng thái **`SKIPPED`** (tính 0 set hoàn thành vào $SCR$). |
+| **BR-AC-04** | Lộ trình | **Quy tắc Thích ứng & Điều chỉnh Định kỳ (Trigger A)**:<br>Chạy cuối mỗi tuần/chu kỳ dựa trên $SCR = \frac{\text{Số Set thực tế}}{\text{Số Set giao}} \times 100\%$ và $\Delta RPE = RPE_{\text{Thực tế}} - RPE_{\text{Target}}$:<br>1. **Tăng tải lũy tiến**: Khi $SCR \ge 80\%$ và $-1 \le \Delta RPE \le +1$ $\rightarrow$ Tự động tăng mức tạ gợi ý $+2.5\% \rightarrow +5\%$ cho tuần kế tiếp.<br>2. **Quản lý mệt mỏi & Deload**: Khi $RPE_{\text{Thực tế}} \ge 9.0$ liên tục 3 buổi hoặc $\Delta RPE \ge +2.0$ $\rightarrow$ Tự động kích hoạt tuần Deload (giảm 30% volume & 10% tạ).<br>3. **Thích ứng Lịch bận kéo dài**: Khi $SCR < 50\%$ trong 2 tuần liên tiếp $\rightarrow$ AI Coach đề xuất giảm 1 buổi/tuần hoặc chuyển sang giáo án Express 30 phút. |
+| **BR-AC-05** | Lộ trình | **Signal B1 (Bỏ tập cấp tính / Mất tích)**: User bỏ tập 3 buổi liên tiếp (hoặc không mở app 7 ngày) $\rightarrow$ AI Coach gửi tin nhắn check-in theo phong cách đã chọn, đề xuất: (a) tập tiếp từ buổi bỏ gần nhất, (b) đặt lại lịch tuần này. Không tự chỉnh lịch nếu user chưa phản hồi. |
+| **BR-AC-06** | Lịch tập | **Signal B2 (Kẹt lịch cố định / Pattern Mismatch)**: User bỏ tập cùng 1 ngày trong tuần $\ge 3$ lần liên tiếp $\rightarrow$ AI đề xuất dời slot ngày đó sang ngày khác. Nếu đồng ý thì cập nhật lịch tuần, nếu từ chối thì giữ nguyên và không hỏi lại. |
+| **BR-AC-07** | Tập luyện | **Signal B3 (Tập ngoài lịch / Unscheduled Workout)**:<br>Kích hoạt khi user thực hiện buổi tập ngoài lịch (tập vào ngày nghỉ hoặc tập buổi thứ 2+ trong cùng ngày). AI Coach gửi tin nhắn Check-in phân loại nguyên nhân:<br>• **Do bài tập quá nhẹ**: Tự động tăng mức tạ gợi ý $+10\% \rightarrow +15\%$ cho các buổi sau.<br>• **Do dư thừa thời gian**: Ghi nhận buổi tập, giữ nguyên lịch trình (hoặc đề xuất tăng buổi tập cố định nếu muốn đổi lịch lâu dài).<br>• **Do tập quá sức / Nguy hiểm**: Cảnh báo nguy cơ chấn thương và chèn 1 ngày nghỉ phục hồi. |
+| **BR-AC-08** | Lộ trình | **Signal B4 (Cơ bắp bị chai lỳ / Plateau)**:<br>Kích hoạt khi Sức mạnh ước tính (1RM) của bài tập chính không tăng trong 2 tuần liên tiếp (chỉ tính các tuần có $SCR \ge 80\%$). AI Coach gửi tin nhắn đề xuất các phương án phá Plateau:<br>• **Đổi biến thể bài tập tương đương** (VD: Barbell Bench Press $\rightarrow$ Dumbbell Press).<br>• **Điều chỉnh dải Rep/Set** (VD: Chuyển từ 8–10 reps sang 4–6 reps heavy).<br>• **Thay đổi thứ tự bài tập** trong buổi tập. |
 | **BR-AC-09** | Tập luyện | **Thích ứng sau phục hồi (Post-Injury Adaptation)**: Khi một khớp chấn thương được xác nhận phục hồi (`recovered`), hệ thống áp dụng cơ chế bảo vệ trong **3 buổi tập đầu tiên** liên quan đến nhóm cơ của khớp đó: (1) Giới hạn tải lượng gợi ý tối đa không vượt quá **50%** mức tạ cao nhất lịch sử (PR) trước chấn thương. (2) Ưu tiên gợi ý các bài tập dùng Bodyweight hoặc Machine/Cable (đường chuyển động cố định) thay vì bài Free Weight tự do. (3) Chỉ cho phép quay lại Progressive Overload bình thường khi đạt RPE $\le 7$ và Form Score $\ge 80\%$ liên tục trong 3 buổi tập bảo vệ này. |
 | **BR-WL-01** | Buổi tập | **Giới hạn thời gian**: Cảnh báo kết thúc sau 90 phút (người mới) hoặc 180 phút (người cũ). Đạt 240 phút không tương tác → Tự động đóng buổi tập, lưu nhãn `Anomalous Session`, loại dữ liệu khỏi tính Overload, buổi sau bắt buộc Recovery. |
 | **BR-WL-02** | Buổi tập | **Phát hiện tải lượng luyện tập (Training Load) bất thường**: Tải lượng buổi tập > 250% trung bình 5 buổi gần nhất có cùng nhóm cơ/mục tiêu → Yêu cầu xác nhận trước khi lưu; bắt buộc chèn $\ge 1$ ngày nghỉ hoàn toàn cho nhóm cơ đó. |
@@ -151,7 +147,7 @@
 
 ## 6. YÊU CẦU DỮ LIỆU NGHIỆP VỤ (DATA)
 - **Đầu vào (Inputs)**:
-  * Profile: Chỉ số cơ thể, mục tiêu, chấn thương/bệnh lý, `experience_level`, khung giờ cố định. (`equipment_list` & `food_restrictions` thu thập dần qua chatbot).
+  * Profile: Chỉ số cơ thể, mục tiêu, chấn thương/bệnh lý, khung giờ cố định, danh sách dụng cụ khả dụng (`available_equipment`). (`food_restrictions` thu thập dần qua chatbot).
   * Video: Luồng video $\ge 720\text{p}$, $30\text{fps}$.
   * RPE: Đánh giá gắng sức (1-10) sau set/buổi.
   * Nhật ký ăn uống (Meal Logs).

--- a/docs/NGHIEP_VU_COT_LOI_BABOK.md
+++ b/docs/NGHIEP_VU_COT_LOI_BABOK.md
@@ -37,9 +37,9 @@
 ## 3. BẢN ĐỒ QUY TRÌNH NGHIỆP VỤ
 
 ### 3.1 Quy trình Khởi tạo (Onboarding & Planning)
-1. User nhập thông tin cơ bản, chỉ số cơ thể, mục tiêu (Tăng cơ/Giảm mỡ) & khung giờ tập cố định.
+1. User nhập thông tin cơ bản, chỉ số cơ thể, mục tiêu (`primary_goal`: Tăng cơ/Giảm mỡ/Sức mạnh), nhóm cơ ưu tiên (`preferred_muscle_groups`) & khung giờ/ngày rảnh (`available_slots`).
 2. User khai báo chấn thương cũ hoặc bệnh lý mãn tính.
-3. AI Coach tính toán `User Fitness Score` & khởi tạo Lộ trình tổng quan 4 tuần, Lịch tập tuần và Gợi ý dinh dưỡng.
+3. AI Coach tính toán `User Fitness Score` (thể trạng khởi điểm RPE 6–7) và khởi tạo Lộ trình 4 tuần (28 ngày) phân bổ 4 pha luyện tập (Accumulation, Overload, Peak, Deload) cùng các `DailyWorkoutPlan` chi tiết (bài tập, set, rep, tạ gợi ý, thời gian nghỉ) tương ứng các ngày rảnh trong `available_slots` và Gợi ý dinh dưỡng.
 
 ### 3.2 Quy trình Luyện tập (Workout Execution)
 1. User check-in & cấu hình playlist âm nhạc (phát chạy ngầm xuyên suốt buổi tập).
@@ -50,15 +50,15 @@
 4. **Dãn cơ (Cooldown)**: Trước khi kết thúc buổi tập, nếu giáo án có Cooldown, hệ thống hiển thị bài tập dãn cơ (hỗ trợ cả luồng AI và Phi AI) kèm tuỳ chọn **Skip Cooldown** để bỏ qua.
 5. Nghỉ ngơi → Lặp lại cho đến khi hoàn thành giáo án → Nhận Post-session Report sau khi kết thúc buổi tập.
 
-### 3.3 Quy trình Sinh giáo án theo buổi (Just-In-Time Workout Generation)
-1. Trigger: Đến ngày tập / User mở app.
-2. AI Coach hỏi/nhận trạng thái sức khỏe (chấn thương mới, độ phục hồi) & phân tích dữ liệu RPE/Form buổi trước.
-3. AI Coach tự động sinh giáo án chi tiết hôm nay (bài tập, set, rep, tạ gợi ý).
+### 3.3 Quy trình Truy xuất & Thực thi Giáo án theo buổi
+1. Trigger: Đến ngày tập hoặc User mở ứng dụng.
+2. Hệ thống đọc trực tiếp `DailyWorkoutPlan` đã khởi tạo của ngày hôm nay từ cơ sở dữ liệu.
+3. User thực hiện Check-in ngắn. Nếu có biến động sức khỏe/chấn thương mới ➔ AI Coach kích hoạt Re-generate giáo án riêng cho hôm nay hoặc điều chỉnh tải trọng.
 4. User nhận giáo án và chuẩn bị thực hiện (chuyển sang Quy trình 3.2).
 
 ### 3.4 Quy trình Đánh giá & Điều chỉnh Lộ trình (Adaptive Review Cycle)
 1. **Trigger A (Cuối chu kỳ 4 tuần)**: AI Coach tính Completion Rate (CR) để tự động nâng/hạ hoặc cấu hình lại lộ trình 4 tuần kế tiếp theo quy tắc **BR-AC-04**.
-2. **Trigger B (Giữa chu kỳ - Event-driven)**: Hệ thống liên tục quét 4 tín hiệu hành vi độc lập (Không hoạt động, Lịch không tương thích, Tập quá tải, Tiến bộ đình trệ) để đề xuất điều chỉnh nhanh giáo án theo các quy tắc **BR-AC-05** -> **BR-AC-08**.
+2. **Trigger B (Giữa chu kỳ - Event-driven)**: Hệ thống liên tục quét 4 tín hiệu hành vi độc lập (Không hoạt động, Lịch không tương thích, Tập quá tải, Tiến bộ đình trệ) hoặc khi User cập nhật hồ sơ (`ProfileUpdated`) để đề xuất **Re-generate các giáo án chưa tập (`scheduled_date >= today`)** trong 4 tuần theo các quy tắc **BR-AC-05** -> **BR-AC-08**.
 
 ---
 
@@ -75,12 +75,12 @@
 ### Module 2: AI Coach cá nhân
 | Mã | Nghiệp vụ chi tiết | MoSCoW |
 |---|---|---|
-| **FR-AC-01** | **Khởi tạo kế hoạch**: Sinh Lộ trình 4 tuần (mốc định hướng) & Lịch tập tuần (phân bổ cơ). Không sinh chi tiết bài ở bước này. | M |
+| **FR-AC-01** | **Khởi tạo kế hoạch**: Sinh Lộ trình 4 tuần (28 ngày tập) phân bổ nhóm cơ & RPE target theo 4 pha (Accumulation, Overload, Peak, Deload) và các giáo án chi tiết dựa trên `available_slots`, `primary_goal`, `preferred_muscle_groups` và `user_fitness_score`. | M |
 | **FR-AC-02** | **Tự động điều chỉnh**: Phân tích hiệu suất tập để tăng/giảm tạ, thay bài tập hoặc chèn Deload Week. | M |
 | **FR-AC-03** | **Bài tập thay thế**: Loại bỏ bài tác động vào vùng chấn thương đột xuất cho đến khi báo phục hồi. | S |
 | **FR-AC-04** | **Đồng hành**: Gửi tin nhắn động viên cá nhân hóa dựa trên dữ liệu thực tế (PR, quay lại sau nghỉ dài). | S |
 | **FR-AC-05** | **Phong cách Coach**: Cho chọn Drill Sergeant (nghiêm khắc), Best Friend (thân thiện), Data Analyst (khoa học). | C |
-| **FR-AC-06** | **Sinh giáo án theo buổi**: Sinh bài tập, set, rep, tạ gợi ý trước buổi tập. AI Coach hỏi 1-2 câu ngắn về thiết bị & dị ứng thực phẩm theo ngữ cảnh nếu chưa có thông tin. | M |
+| **FR-AC-06** | **Tải giáo án từ cơ sở dữ liệu & Re-generate linh hoạt**: Khi mở ứng dụng, đọc giáo án đã khởi tạo trực tiếp từ cơ sở dữ liệu. Khi có thay đổi hồ sơ hoặc sức khỏe ➔ Re-generate các giáo án chưa thực thi (`scheduled_date >= today`). | M |
 | **FR-AC-07** | **Warm-up/Cool-down**: Tự chèn khởi động (5-10') và giãn cơ (5') theo nhóm cơ sẽ tập của giáo án (hỗ trợ cả AI và Phi AI, cho phép user bỏ qua/Skip). | M |
 
 ### Module 3: AI Camera Coach (Phân tích tư thế)

--- a/docs/usecase/01_onboarding.md
+++ b/docs/usecase/01_onboarding.md
@@ -96,6 +96,6 @@
 **Main Flow**
 1. User cập nhật các trường thông tin trong Profile (`primary_goal`, `available_equipment`, `preferred_muscle_groups`, `available_slots`).
 2. System cập nhật thông tin và phát `ProfileUpdated`.
-3. `Coaching Context` nhận `ProfileUpdated` và tự động kích hoạt Re-evaluation cho `WeeklySchedule` bắt đầu từ ngày tập tiếp theo.
+3. `Coaching Context` nhận `ProfileUpdated` và tự động kích hoạt Re-generation (FR-AC-06) cho các `SessionPlan` bắt đầu từ ngày tập tiếp theo.
 
 **Domain Events**: `ProfileUpdated`

--- a/docs/usecase/02_coaching_planning.md
+++ b/docs/usecase/02_coaching_planning.md
@@ -7,7 +7,7 @@
 
 ---
 
-### UC-02.1 InitiateWorkoutRoadmap
+### UC-02.1 InitiateRoadmap
 
 | | |
 |---|---|
@@ -15,74 +15,75 @@
 | **Precondition** | Event `UserProfileCompleted` được nhận. `ActiveCoachEnabled = true`. |
 
 **Main Flow**
-1. System đọc `BiologicalMetrics`, `primary_goal`, `preferred_muscle_groups`, `available_equipment` và `available_slots` từ `User`.
-2. System tính `UserFitnessScore` (thể trạng khởi điểm người mới - Baseline RPE 6–7).
-3. System tạo `WorkoutRoadmap` 4 tuần (28 ngày) với `CompletionRate = 0`.
-4. System phân bổ 4 tuần theo 4 pha tiến trình chuẩn (`BR-AC-09`): Tuần 1 (Accumulation RPE 6–7), Tuần 2 (Overload RPE 7–8), Tuần 3 (Peak RPE 8–9), Tuần 4 (Deload RPE 5–6 giảm 40–50% volume).
-5. System phân bổ các ngày tập vào `available_slots`, tuân thủ tối đa 6 buổi/tuần và tối thiểu 1 ngày nghỉ hoàn toàn (`BR-AC-01`).
-6. System tạo **28 `DailyWorkoutPlan` chi tiết** (`WorkoutPrescription` gồm bài tập, set, rep, tạ gợi ý, rest time, target RPE) tương ứng các ngày tập trong 4 tuần.
-7. System gọi `OverloadValidator` kiểm soát giới hạn điều chỉnh tải trọng ($\pm 30\%$, `BR-AC-02`).
-8. System lưu `WorkoutRoadmap` (chứa 4 tuần, 28 ngày và 28 giáo án chi tiết) và phát event `RoadmapInitiated`.
+1. System đọc `biological_metrics`, `primary_goal`, `preferred_muscle_groups`, `available_equipment` và `available_slots` từ `User`.
+2. System khởi tạo Baseline RPE 6–7 cho lộ trình làm quen ban đầu.
+3. System tạo `Roadmap` 4 tuần (28 ngày) với `status = ACTIVE`.
+4. System tạo 4 `WeekPlan` tương ứng 4 tuần, phân bổ theo 4 pha tiến trình chuẩn: Tuần 1 (Accumulation RPE 6–7), Tuần 2 (Overload RPE 7–8), Tuần 3 (Peak RPE 8–9), Tuần 4 (Deload RPE 5–6 giảm 30% volume & 10% tạ).
+5. System phân bổ 28 `DayPlan` tương ứng 28 ngày trên lịch (lưu `scheduled_date`, `is_rest_day`, `available_slots`).
+6. Với các ngày tập (`is_rest_day = false`), System khởi tạo `SessionPlan` gắn theo từng khung giờ rảnh (`slot_time`), chứa `prescription` bài tập (warm-up, main, cool-down, set, rep, weight, target RPE) với `status = PENDING`.
+7. System gọi `OverloadValidator` kiểm soát giới hạn điều chỉnh tải trọng ($\pm 30\%$, tối đa $+5\text{kg}$ bài free-weight nặng, `BR-AC-02`).
+8. System lưu `Roadmap` (gồm 4 `WeekPlan`, 28 `DayPlan` và các `SessionPlan`) và phát event `RoadmapInitiated`.
 
 **Alternative Flow**
-- A1: User có `Injury` active → System loại bỏ bài tập tác động vùng chấn thương khi sinh giáo án.
+- A1: User có `Injury` active → System loại bỏ bài tập tác động vùng chấn thương khi sinh giáo án `prescription`.
 - A2: `preferred_muscle_groups` rỗng → System tự động áp dụng `MuscleSplit` cân bằng chuẩn (Push/Pull/Legs hoặc Upper/Lower split).
 
 **Error / Edge Cases**
-- E1: `BiologicalMetrics` không đủ dữ liệu → Hủy quy trình, yêu cầu hoàn thiện hồ sơ.
+- E1: `biological_metrics` không đủ dữ liệu → Hủy quy trình, yêu cầu hoàn thiện hồ sơ.
 - E2: `OverloadValidator` từ chối bài tập (vượt trần 30%) → Hạ mức tạ về trần tối đa hợp lệ và tiếp tục.
 
-**Postcondition**: `WorkoutRoadmap` 4 tuần và 28 `DailyWorkoutPlan` được khởi tạo sẵn sàng trong cơ sở dữ liệu.  
-> *`CoachingService.InitiateRoadmap()` gọi `WorkoutRoadmapRepository.Save()`.*
+**Postcondition**: `Roadmap` 4 tuần và các `SessionPlan` (chứa `prescription` NOT NULL) được khởi tạo sẵn sàng trong cơ sở dữ liệu.  
+> *`CoachingService.InitiateRoadmap()` gọi `RoadmapRepository.Save()`.*
 
 **Domain Events**: `RoadmapInitiated`
 
 ---
 
-### UC-02.2 ExecuteDailyWorkoutPlan
+### UC-02.2 ExecuteSessionPlan
 
 | | |
 |---|---|
 | **Actor** | System (AI Coach) · User |
-| **Precondition** | `WorkoutRoadmap` đang ở trạng thái `Active`. Đến ngày tập theo lịch. |
+| **Precondition** | `Roadmap` đang ở trạng thái `ACTIVE`. Đến khung giờ tập theo lịch (`scheduled_date = today`, `slot_time`). |
 
 **Main Flow**
-1. User mở ứng dụng trong ngày tập. System đọc trực tiếp `DailyWorkoutPlan` đã khởi tạo của ngày hôm nay từ cơ sở dữ liệu.
-2. System hiển thị câu hỏi Check-in ngắn về tình trạng sức khỏe hôm nay (chấn thương mới, độ mệt mỏi/giờ ngủ).
-3. System kiểm tra trạng thái buổi tập trước đó. Nếu buổi trước bị bỏ tập ➔ Tự động đánh dấu buổi cũ là `Skipped` (`BR-AC-03`), giữ nguyên giáo án ngày hôm nay.
-4. User nhận giáo án và bắt đầu buổi tập (chuyển sang UC-03 Workout Execution).
+1. User mở ứng dụng trong khung giờ tập. System đọc trực tiếp `SessionPlan` của buổi tập hôm nay từ cơ sở dữ liệu.
+2. System kiểm tra trạng thái các buổi tập trước đó. Nếu buổi trước chưa thực hiện ➔ Tự động đánh dấu buổi cũ là `SKIPPED` (`BR-AC-03`), các set bỏ lỡ tính $0$ vào $SCR$, giữ nguyên giáo án buổi hôm nay.
+3. System hiển thị câu hỏi Check-in ngắn về tình trạng sức khỏe hôm nay (chấn thương mới, mệt mỏi/giờ ngủ).
+4. User xác nhận giáo án `prescription` buổi tập hôm nay và bắt đầu tập (chuyển sang UC-03 Workout Execution).
+5. Sau khi kết thúc buổi tập, System cập nhật `status = COMPLETED` cho `SessionPlan` buổi hôm nay.
 
 **Alternative Flow**
-- A1: Check-in phát hiện chấn thương mới hoặc mệt mỏi cấp tính ➔ System kích hoạt Re-generate giáo án riêng cho ngày hôm nay (giảm tải hoặc đổi bài phục hồi nhẹ).
-- A2: Ngày hôm nay là ngày nghỉ theo lịch ➔ System thông báo "Hôm nay nghỉ phục hồi".
+- A1: Check-in phát hiện chấn thương mới hoặc mệt mỏi cấp tính ($\Delta RPE \ge +2.0$) ➔ System kích hoạt Re-generate `prescription` riêng cho `SessionPlan` hôm nay (giảm tải hoặc đổi bài phục hồi nhẹ).
+- A2: Ngày hôm nay là ngày nghỉ theo lịch (`is_rest_day = true`) ➔ System thông báo "Hôm nay nghỉ phục hồi". Khi trôi qua ngày nghỉ, status tự động chuyển `COMPLETED`.
 
 **Error / Edge Cases**
-- E1: `DailyWorkoutPlan` không tồn tại do dữ liệu lỗi ➔ System tự động sinh JIT giáo án cho ngày hôm nay theo `ScheduleDay`.
+- E1: `SessionPlan` không tồn tại do lỗi dữ liệu ➔ System tự động khởi tạo JIT `SessionPlan` bổ sung cho khung giờ hôm nay.
 
-**Postcondition**: Giáo án của ngày hôm nay sẵn sàng cho User thực thi.  
-> *`CoachingService.GetDailyPlan()` đọc trực tiếp từ `WorkoutRoadmapRepository`.*
+**Postcondition**: Buổi tập hôm nay được thực thi thành công và `SessionPlan.status` cập nhật thành `COMPLETED`.  
+> *`CoachingService.GetSessionPlan()` đọc trực tiếp từ `RoadmapRepository`.*
 
-**Domain Events**: `DailyWorkoutPlanExecuted`
+**Domain Events**: `SessionPlanExecuted`
 
 ---
 
-### UC-02.3 ReevaluateScheduleOnProfileUpdated
+### UC-02.3 RegenerateScheduleOnProfileUpdated
 
 | | |
 |---|---|
 | **Actor** | System (AI Coach) |
-| **Precondition** | Event `ProfileUpdated` hoặc tín hiệu điều chỉnh (`Signal B1–B4`) được nhận. `WorkoutRoadmap` đang ở trạng thái `Active`. |
+| **Precondition** | Event `ProfileUpdated` hoặc tín hiệu điều chỉnh (`Signal B1–B4`, `Trigger A BR-AC-04`) được nhận. `Roadmap` đang ở trạng thái `ACTIVE`. |
 
 **Main Flow**
 1. System đọc thông tin snapshot mới từ `User` (`available_equipment`, `available_slots`, `preferred_muscle_groups`, `primary_goal`).
-2. System xác định danh sách các ngày chưa thực thi (`scheduled_date >= today` và `status != COMPLETED`).
-3. System kích hoạt Re-generation cho các `DailyWorkoutPlan` chưa thực thi:
+2. System xác định danh sách các buổi tập chưa thực thi (`scheduled_date >= today` và `status = PENDING`).
+3. System kích hoạt Re-generation cho `prescription` của các `SessionPlan` chưa thực thi:
    - Cập nhật bài tập tương thích với `available_equipment` mới.
    - Điều chỉnh phân bổ ngày tập theo `available_slots` mới.
    - Điều chỉnh `MuscleSplit` theo `preferred_muscle_groups` và `primary_goal`.
-4. System lưu thông tin cập nhật vào `WorkoutRoadmap` và phát event `RoadmapAdjusted`.
+4. System lưu thông tin cập nhật vào `Roadmap` và phát event `RoadmapAdjusted`.
 
-**Postcondition**: Toàn bộ giáo án các ngày chưa thực thi trong 4 tuần được cập nhật.  
-> *`CoachingService.ReevaluateSchedule()` gọi `WorkoutRoadmapRepository.Save()` và phát `RoadmapAdjusted`.*
+**Postcondition**: Toàn bộ giáo án các buổi tập chưa thực thi trong 4 tuần được cập nhật.  
+> *`CoachingService.RegenerateSchedule()` gọi `RoadmapRepository.Save()` và phát `RoadmapAdjusted`.*
 
 **Domain Events**: `RoadmapAdjusted`

--- a/docs/usecase/02_coaching_planning.md
+++ b/docs/usecase/02_coaching_planning.md
@@ -12,105 +12,77 @@
 | | |
 |---|---|
 | **Actor** | System (AI Coach) |
-| **Precondition** | `UserProfileCompleted` event được nhận. `ActiveCoachEnabled = true`. |
+| **Precondition** | Event `UserProfileCompleted` được nhận. `ActiveCoachEnabled = true`. |
 
 **Main Flow**
 1. System đọc `BiologicalMetrics`, `primary_goal`, `preferred_muscle_groups`, `available_equipment` và `available_slots` từ `User`.
-2. System tính `FitnessScore` và xác định giai đoạn khởi điểm.
-3. System tạo `WorkoutRoadmap` (4 tuần) với `RoadmapPhase` và `CompletionRate = 0`.
-4. System tạo `WeeklySchedule` đầu tiên (giai đoạn Accumulation - Tích lũy, RPE 6–7) với `MuscleSplit` phân bổ theo `primary_goal`, ưu tiên `preferred_muscle_groups` và gán vào các ngày rảnh trong `available_slots`, tuân thủ `BR-AC-01` và `BR-AC-09`.
-5. System gọi `OverloadValidator` (Go Upper Safety Envelope) để xác nhận giới hạn biên độ điều chỉnh tải trọng hợp lệ ($\pm 30\%$, BR-AC-02).
-6. System phát `RoadmapInitiated`.
+2. System tính `UserFitnessScore` (thể trạng khởi điểm người mới - Baseline RPE 6–7).
+3. System tạo `WorkoutRoadmap` 4 tuần (28 ngày) với `CompletionRate = 0`.
+4. System phân bổ 4 tuần theo 4 pha tiến trình chuẩn (`BR-AC-09`): Tuần 1 (Accumulation RPE 6–7), Tuần 2 (Overload RPE 7–8), Tuần 3 (Peak RPE 8–9), Tuần 4 (Deload RPE 5–6 giảm 40–50% volume).
+5. System phân bổ các ngày tập vào `available_slots`, tuân thủ tối đa 6 buổi/tuần và tối thiểu 1 ngày nghỉ hoàn toàn (`BR-AC-01`).
+6. System tạo **28 `DailyWorkoutPlan` chi tiết** (`WorkoutPrescription` gồm bài tập, set, rep, tạ gợi ý, rest time, target RPE) tương ứng các ngày tập trong 4 tuần.
+7. System gọi `OverloadValidator` kiểm soát giới hạn điều chỉnh tải trọng ($\pm 30\%$, `BR-AC-02`).
+8. System lưu `WorkoutRoadmap` (chứa 4 tuần, 28 ngày và 28 giáo án chi tiết) và phát event `RoadmapInitiated`.
 
 **Alternative Flow**
-- A1: User có `Injury` active → System loại bỏ bài tập tác động vùng chấn thương khi sinh lịch tuần.
-- A2: `preferred_muscle_groups` rỗng → System tự động áp dụng `MuscleSplit` phân bổ cân bằng chuẩn (Standard Push/Pull/Legs hoặc Upper/Lower split).
+- A1: User có `Injury` active → System loại bỏ bài tập tác động vùng chấn thương khi sinh giáo án.
+- A2: `preferred_muscle_groups` rỗng → System tự động áp dụng `MuscleSplit` cân bằng chuẩn (Push/Pull/Legs hoặc Upper/Lower split).
 
 **Error / Edge Cases**
-- E1: `BiologicalMetrics` không đủ dữ liệu → không sinh được lộ trình, yêu cầu hoàn thiện hồ sơ.
-- E2: `OverloadValidator` từ chối bài tập (vượt trần 30%) → tự điều chỉnh tạ xuống trần hợp lệ và tiếp tục.
+- E1: `BiologicalMetrics` không đủ dữ liệu → Hủy quy trình, yêu cầu hoàn thiện hồ sơ.
+- E2: `OverloadValidator` từ chối bài tập (vượt trần 30%) → Hạ mức tạ về trần tối đa hợp lệ và tiếp tục.
 
-**Postcondition**: `WorkoutRoadmap` và `WeeklySchedule` tuần 1 được tạo. Chưa sinh `DailyWorkoutPlan`.  
-> *`CoachingService.InitiateRoadmap()` gọi `WorkoutRoadmapRepository.Save()` và `WeeklyScheduleRepository.Save()`.*
+**Postcondition**: `WorkoutRoadmap` 4 tuần và 28 `DailyWorkoutPlan` được khởi tạo sẵn sàng trong cơ sở dữ liệu.  
+> *`CoachingService.InitiateRoadmap()` gọi `WorkoutRoadmapRepository.Save()`.*
 
-**Domain Events**: `RoadmapInitiated` · `WeeklyScheduleGenerated`
+**Domain Events**: `RoadmapInitiated`
 
 ---
 
-### UC-02.2 GenerateDailyWorkoutPlan (JIT)
+### UC-02.2 ExecuteDailyWorkoutPlan
 
 | | |
 |---|---|
-| **Actor** | System (AI Coach) |
-| **Precondition** | Đến ngày tập theo `WeeklySchedule`. `DailyWorkoutPlan` chưa tồn tại cho ngày hôm nay. Trạng thái buổi tập trước đã được xử lý (hoặc tự động chuyển `Skipped`). |
+| **Actor** | System (AI Coach) · User |
+| **Precondition** | `WorkoutRoadmap` đang ở trạng thái `Active`. Đến ngày tập theo lịch. |
 
 **Main Flow**
-1. User mở ứng dụng trong ngày tập, System hiển thị câu hỏi tương tác ngắn (Check-in pop-up) về tình trạng sức khỏe hôm nay (chấn thương mới, độ phục hồi/giờ ngủ).
-2. System kiểm tra trạng thái buổi tập trước đó theo lịch. Nếu buổi trước bị bỏ tập:
-   - System tự động đánh dấu buổi tập cũ là `Skipped` (`BR-AC-03`), tiếp tục sinh giáo án cho ngày hôm nay theo đúng lịch.
-3. System sinh `WorkoutPrescription` (bài tập, set, rep, tạ gợi ý, `rest_set_sec`, `rest_exercise_sec`, `target_rpe` theo Phase của tuần, warm-up/cool-down) dựa trên `MuscleSplit` của ngày hôm nay, `PersonalRecord` (1RM) hiện tại và chỉ chọn các bài tập có dụng cụ thuộc `available_equipment`.
-4. System kiểm tra `Injury` active — loại bỏ bài tập tác động vùng chấn thương và thay thế bằng bài tương đương.
-5. System tạo `DailyWorkoutPlan`, phát `DailyWorkoutPlanGenerated`.
+1. User mở ứng dụng trong ngày tập. System đọc trực tiếp `DailyWorkoutPlan` đã khởi tạo của ngày hôm nay từ cơ sở dữ liệu.
+2. System hiển thị câu hỏi Check-in ngắn về tình trạng sức khỏe hôm nay (chấn thương mới, độ mệt mỏi/giờ ngủ).
+3. System kiểm tra trạng thái buổi tập trước đó. Nếu buổi trước bị bỏ tập ➔ Tự động đánh dấu buổi cũ là `Skipped` (`BR-AC-03`), giữ nguyên giáo án ngày hôm nay.
+4. User nhận giáo án và bắt đầu buổi tập (chuyển sang UC-03 Workout Execution).
 
 **Alternative Flow**
-- A1: User mở app và hỏi trạng thái hôm nay qua chatbot — System hỏi 1–2 câu về thiết bị, dị ứng nếu chưa có trong `ChatbotContext`.
-- A2: Ngày hôm nay là ngày nghỉ theo lịch → không sinh giáo án, thông báo "Hôm nay nghỉ phục hồi".
-- A3: Buổi tập gần nhất bị tự động đóng vì không tương tác (Anomalous Session - đánh dấu từ UC-03.4) → System truyền cờ `anomalous_session_detected = true` vào Prompt để Gemini LLM tự chủ sinh giáo án phục hồi nhẹ (Active Recovery BR-WL-01).
+- A1: Check-in phát hiện chấn thương mới hoặc mệt mỏi cấp tính ➔ System kích hoạt Re-generate giáo án riêng cho ngày hôm nay (giảm tải hoặc đổi bài phục hồi nhẹ).
+- A2: Ngày hôm nay là ngày nghỉ theo lịch ➔ System thông báo "Hôm nay nghỉ phục hồi".
 
 **Error / Edge Cases**
-- E1: Không tìm thấy `WeeklySchedule` cho ngày hôm nay → báo lỗi, đề xuất tạo lịch mới.
-- E2: Toàn bộ bài tập bị loại bỏ do chấn thương → sinh giáo án phục hồi nhẹ (active recovery), không tập nặng.
-- E3: `PersonalRecord` chưa có (user mới) → dùng tạ gợi ý mặc định theo `BiologicalMetrics`.
+- E1: `DailyWorkoutPlan` không tồn tại do dữ liệu lỗi ➔ System tự động sinh JIT giáo án cho ngày hôm nay theo `ScheduleDay`.
 
-**Postcondition**: `DailyWorkoutPlan` với `WorkoutPrescription` đầy đủ sẵn sàng để user thực thi.  
-> *`CoachingService.GenerateDailyPlan()` gọi `DailyWorkoutPlanRepository.Save()` và `WorkoutPerformanceRepository.GetLatest1RM()`.*
+**Postcondition**: Giáo án của ngày hôm nay sẵn sàng cho User thực thi.  
+> *`CoachingService.GetDailyPlan()` đọc trực tiếp từ `WorkoutRoadmapRepository`.*
 
-**Domain Events**: `DailyWorkoutPlanGenerated`
+**Domain Events**: `DailyWorkoutPlanExecuted`
 
 ---
 
-### UC-02.3 GenerateNextWeeklySchedule
+### UC-02.3 ReevaluateScheduleOnProfileUpdated
 
 | | |
 |---|---|
 | **Actor** | System (AI Coach) |
-| **Precondition** | Lịch tuần hiện tại chuẩn bị kết thúc (hoặc kết thúc). `WorkoutRoadmap` đang ở trạng thái `Active`. |
-
-**Main Flow**
-1. System đọc lịch sử tập luyện thực tế của tuần vừa rồi.
-2. System sinh `WeeklySchedule` tiếp theo (tuần 2 - Overload RPE 7–8, tuần 3 - Peak RPE 8–9, hoặc tuần 4 - Supercompensation/Deload RPE 5–6 giảm 40–50% volume với cờ `is_deload_week = true`), tuân thủ `BR-AC-01` và `BR-AC-09`.
-3. System gọi `OverloadValidator` kiểm soát giới hạn biên độ điều chỉnh tải trọng ($\pm 30\%$, BR-AC-02).
-4. System lưu `WeeklySchedule` mới và phát `WeeklyScheduleGenerated`.
-
-**Alternative Flow**
-- A1: `OverloadValidator` từ chối bài tập (vượt trần 30%) → tự động hạ về trần tối đa hợp lệ.
-
-**Error / Edge Cases**
-- E1: Dữ liệu bị lỗi hoặc tuần trước bị bỏ qua hoàn toàn → Dùng thiết lập mặc định theo Lộ trình.
-
-**Postcondition**: `WeeklySchedule` tuần tiếp theo được tạo sẵn sàng để sinh giáo án hàng ngày.
-> *`CoachingService.GenerateWeeklySchedule()` gọi `WeeklyScheduleRepository.Save()` và phát `WeeklyScheduleGenerated`.*
-
-**Domain Events**: `WeeklyScheduleGenerated`
-
----
-
-### UC-02.4 ReevaluateScheduleOnProfileUpdated
-
-| | |
-|---|---|
-| **Actor** | System (AI Coach) |
-| **Precondition** | Event `ProfileUpdated` được nhận. `WorkoutRoadmap` đang ở trạng thái `Active`. |
+| **Precondition** | Event `ProfileUpdated` hoặc tín hiệu điều chỉnh (`Signal B1–B4`) được nhận. `WorkoutRoadmap` đang ở trạng thái `Active`. |
 
 **Main Flow**
 1. System đọc thông tin snapshot mới từ `User` (`available_equipment`, `available_slots`, `preferred_muscle_groups`, `primary_goal`).
-2. System kích hoạt Re-evaluation cho `WeeklySchedule` bắt đầu từ ngày tập tiếp theo:
-   - Cập nhật danh mục bài tập tương thích với `available_equipment` mới.
-   - Điều chỉnh ngày tập trong tuần theo `available_slots` mới.
-   - Phân bổ lại `MuscleSplit` theo `preferred_muscle_groups` và `primary_goal`.
-3. System cập nhật `WeeklySchedule` và phát `WeeklyScheduleGenerated`.
+2. System xác định danh sách các ngày chưa thực thi (`scheduled_date >= today` và `status != COMPLETED`).
+3. System kích hoạt Re-generation cho các `DailyWorkoutPlan` chưa thực thi:
+   - Cập nhật bài tập tương thích với `available_equipment` mới.
+   - Điều chỉnh phân bổ ngày tập theo `available_slots` mới.
+   - Điều chỉnh `MuscleSplit` theo `preferred_muscle_groups` và `primary_goal`.
+4. System lưu thông tin cập nhật vào `WorkoutRoadmap` và phát event `RoadmapAdjusted`.
 
-**Postcondition**: `WeeklySchedule` được điều chỉnh từ ngày tập tiếp theo.  
-> *`CoachingService.ReevaluateSchedule()` cập nhật `WeeklyScheduleRepository.Save()` và publish `WeeklyScheduleGenerated`.*
+**Postcondition**: Toàn bộ giáo án các ngày chưa thực thi trong 4 tuần được cập nhật.  
+> *`CoachingService.ReevaluateSchedule()` gọi `WorkoutRoadmapRepository.Save()` và phát `RoadmapAdjusted`.*
 
-**Domain Events**: `WeeklyScheduleGenerated`
+**Domain Events**: `RoadmapAdjusted`

--- a/docs/usecase/03_workout_execution.md
+++ b/docs/usecase/03_workout_execution.md
@@ -12,7 +12,7 @@
 | | |
 |---|---|
 | **Actor** | User |
-| **Precondition** | `DailyWorkoutPlan` đã tồn tại. Không có `WorkoutSession` nào đang `InProgress` cho User. |
+| **Precondition** | `SessionPlan` đã tồn tại. Không có `WorkoutSession` nào đang `InProgress` cho User. |
 
 **Main Flow**
 1. User check-in, chọn playlist âm nhạc (phát chạy ngầm xuyên suốt session).
@@ -24,7 +24,7 @@
 
 **Error / Edge Cases**
 - E1: Đã có session `InProgress` → từ chối, hiển thị tuỳ chọn tiếp tục hoặc đóng session cũ.
-- E2: Không tìm thấy `DailyWorkoutPlan` hôm nay → kích hoạt UC-02.2 trước.
+- E2: Không tìm thấy `SessionPlan` hôm nay → kích hoạt UC-02.2 trước.
 
 **Postcondition**: `WorkoutSession` `InProgress`.  
 
@@ -104,14 +104,14 @@
    - Nếu giáo án có bài dãn cơ (`Cooldown`), hệ thống hiển thị giao diện dãn cơ (chạy qua UC-03.2 hoặc UC-03.3) kèm nút **Skip Cooldown**.
    - Nếu không có Cooldown hoặc User nhấn Skip, tiếp tục luồng hoàn thành.
 3. System gọi `TrainingLoadGuard`: so sánh tổng volume buổi này với trung bình 5 buổi gần nhất cùng nhóm cơ.
-   - Nếu vượt 250% → yêu cầu user xác nhận trước khi lưu, chèn ≥ 1 ngày nghỉ vào `WeeklySchedule`.
+   - Nếu vượt 250% → yêu cầu user xác nhận trước khi lưu, chèn ≥ 1 ngày nghỉ vào `DayPlan`.
 4. System tính `SessionSummary` (tổng set, volume, FormScore trung bình).
 5. System cập nhật `WorkoutSession` sang `Completed`, phát `WorkoutSessionCompleted`.
 6. System hiển thị Post-session Report.
 
 **Alternative Flow**
 - A1: Buổi tập vượt 240 phút không tương tác → System tự đóng, ghi nhãn `AnomalousSession`, loại khỏi tính Overload.
-- A2: Buổi tập vượt 90 phút (người mới) hoặc 180 phút (người cũ) → cảnh báo, user có thể tiếp tục hoặc kết thúc.
+- A2: Buổi tập vượt 90 phút → cảnh báo thời lượng tập kéo dài, user có thể tiếp tục hoặc kết thúc.
 - A3: User cập nhật cân nặng hiện tại của mình lúc kết thúc buổi tập → System ghi nhận chỉ số cơ thể mới, phát event `BodyMetricUpdated`.
 
 **Error / Edge Cases**

--- a/docs/usecase/04_adaptive_review_cycle.md
+++ b/docs/usecase/04_adaptive_review_cycle.md
@@ -7,41 +7,39 @@
 
 ---
 
-### UC-04.1 EvaluateEndOfCycleCompletionRate
+### UC-04.1 EvaluateWeeklyAdaptiveCycle
 
 | | |
 |---|---|
 | **Actor** | System (AI Coach) |
-| **Precondition** | Lộ trình 4 tuần vừa kết thúc. |
+| **Precondition** | Hoàn thành 1 tuần tập (hoặc cuối chu kỳ 4 tuần). |
 
 **Main Flow**
-1. System tính `CompletionRate` (CR) = số buổi hoàn thành / tổng số buổi đã lên lịch (loại trừ `AnomalousSession`).
-2. System áp dụng quy tắc BR-AC-04:
-   - CR < 40%: Hỏi lý do, chờ phản hồi, đề xuất giảm số buổi/tuần và rút ngắn thời lượng. Nếu user đồng ý → cấu hình lại; nếu từ chối → chuyển sang **A1**.
-   - 40% ≤ CR < 70%: Giảm tải lượng 10–15%, chèn xen kẽ buổi Express 30 phút. Tự sinh lộ trình mới.
-   - 70% ≤ CR < 90%: Giữ cấu trúc, tăng Progressive Overload ≤ 10%. Tự sinh lộ trình mới.
-   - CR ≥ 90%: Đề xuất tăng cường độ hoặc thêm 1 buổi/tuần (không vượt BR-AC-01), gắn badge "Xuất sắc". Nếu user đồng ý → thêm buổi; nếu từ chối → chuyển sang **A1**.
-3. System tạo `WorkoutRoadmap` mới, phát `RoadmapInitiated`.
+1. System tính Tỷ lệ hoàn thành Set ($SCR = \frac{\text{Số Set thực tế}}{\text{Số Set giao}} \times 100\%$) và Độ lệch mệt mỏi ($\Delta RPE = RPE_{\text{Thực tế}} - RPE_{\text{Target}}$).
+2. System áp dụng quy tắc thích ứng định kỳ `BR-AC-04`:
+   - **Tăng tải lũy tiến** ($SCR \ge 80\%$ và $-1 \le \Delta RPE \le +1$): Tự động tăng mức tạ gợi ý $+2.5\% \rightarrow +5\%$ cho tuần kế tiếp.
+   - **Quản lý mệt mỏi & Deload** ($RPE_{\text{Thực tế}} \ge 9.0$ liên tục 3 buổi hoặc $\Delta RPE \ge +2.0$): Tự động kích hoạt tuần Deload (giảm 30% volume & 10% tạ).
+   - **Thích �23. System cập nhật `prescription` bài tập của các `SessionPlan` tuần kế tiếp, phát `RoadmapAdjusted`.
 
 **Alternative Flow**
-- A1: User từ chối đề xuất thay đổi số buổi tập (khi CR < 40% hoặc CR ≥ 90%) → System giữ nguyên cấu trúc số buổi/tuần cũ của lộ trình, nhưng tự động điều chỉnh Progressive Overload (tăng/giảm mức tạ hoặc volume tạ gợi ý) tương ứng để đảm bảo tính an toàn và thích ứng.
+- A1: User từ chối giảm số buổi tập khi $SCR < 50\%$ ➔ System giữ nguyên cấu trúc số buổi cũ, nhưng tự động chuyển sang giáo án Express 30 phút để hỗ trợ hoàn thành.
 
 **Error / Edge Cases**
-- E1: CR < 40% và user không phản hồi sau 48h → tự áp dụng phương án giảm tải mặc định.
+- E1: $SCR < 50\%$ và user không phản hồi sau 48h ➔ Tự áp dụng phương án chuyển sang giáo án Express 30 phút.
 
-**Postcondition**: Lộ trình mới được khởi tạo.  
-> *`AdaptiveCoachEngine.EvaluateEndOfCycle()` đọc `WorkoutRoadmapRepository` và `WorkoutSessionRepository`.*
+**Postcondition**: Giáo án tuần kế tiếp được cập nhật thích ứng theo $SCR$ và $\Delta RPE$.  
+> *`AdaptiveCoachEngine.EvaluateWeeklyCycle()` đọc `RoadmapRepository` và `WorkoutSessionRepository`.*
 
-**Domain Events**: `RoadmapAdjusted` · `RoadmapInitiated`
+**Domain Events**: `RoadmapAdjusted`
 
 ---
 
-### UC-04.2 DetectSignalB1 — Không hoạt động
+### UC-04.2 DetectSignalB1 — Bỏ tập cấp tính / Mất tích
 
 | | |
 |---|---|
 | **Actor** | System (AI Coach) |
-| **Precondition** | User không có `WorkoutSession` nào trong 7 ngày liên tiếp. |
+| **Precondition** | User bỏ tập 3 buổi liên tiếp (hoặc không có `WorkoutSession` trong 7 ngày). |
 
 **Main Flow**
 1. `AdaptiveCoachEngine` phát hiện Signal B1.
@@ -49,22 +47,18 @@
 3. User phản hồi, chọn phương án:
    - (a) Tiếp tục từ buổi bỏ gần nhất.
    - (b) Đặt lại lịch tuần này.
-   - (c) Tạm dừng lộ trình (Pause).
 4. System thực thi phương án đã chọn.
-
-**Alternative Flow**
-- A1: Chọn Pause → `WorkoutRoadmap` chuyển sang `Paused`. Tối đa 4 tuần. Sau 4 tuần tự chuyển lại `Active` và hỏi lại user.
 
 **Error / Edge Cases**
 - E1: User không phản hồi trong 24h → không tự thay đổi lịch, gửi nhắc lại sau 24h.
 
 **Postcondition**: Lịch tập được cập nhật theo lựa chọn của user (hoặc giữ nguyên nếu không phản hồi).
 
-**Domain Events**: `RoadmapPaused` | `RoadmapAdjusted`
+**Domain Events**: `RoadmapAdjusted`
 
 ---
 
-### UC-04.3 DetectSignalB2 — Lịch không tương thích
+### UC-04.3 DetectSignalB2 — Kẹt lịch cố định
 
 | | |
 |---|---|
@@ -74,7 +68,7 @@
 **Main Flow**
 1. `AdaptiveCoachEngine` phát hiện Signal B2.
 2. System đề xuất dời slot ngày đó sang ngày khác còn trống trong tuần.
-3. If user đồng ý → Re-generate các giáo án chưa thực thi trong `WorkoutRoadmap`, phát `RoadmapAdjusted`.
+3. Nếu user đồng ý → Cập nhật phân bổ ngày tập trong `DayPlan`, phát `RoadmapAdjusted`.
 4. Nếu user từ chối → giữ nguyên, không hỏi lại về vấn đề này.
 
 **Error / Edge Cases**
@@ -84,41 +78,84 @@
 
 ---
 
-### UC-04.4 DetectSignalB3 — Overtraining
+### UC-04.4 DetectSignalB3 — Tập ngoài lịch (Unscheduled Workout)
 
 | | |
 |---|---|
 | **Actor** | System (AI Coach) |
-| **Precondition** | User tập ≥ 2 buổi/ngày hoặc Session RPE (điểm đánh giá nỗ lực cả buổi tập do người dùng khai báo) trung bình ≥ 8.5 liên tục ≥ 5 buổi. |
+| **Precondition** | User tập vào ngày nghỉ (`is_rest_day = true`) hoặc tập buổi thứ 2+ trong cùng 1 ngày. |
 
 **Main Flow**
 1. `AdaptiveCoachEngine` phát hiện Signal B3.
-2. System cảnh báo nguy cơ quá tải, đề xuất Active Recovery.
-3. System bắt buộc chèn 1 ngày nghỉ vào `WorkoutRoadmap` cho ngày kế tiếp và Re-generate giáo án các ngày chưa thực thi.
+2. System gửi tin nhắn Check-in hỏi lý do (Tập quá nhẹ / Thừa thời gian / Tập quá sức).
+3. System xử lý thích ứng theo lý do user chọn:
+   - Do bài tập quá nhẹ ➔ Tăng tạ gợi ý $+10\% \rightarrow +15\%$ cho các buổi sau.
+   - Do thừa thời gian ➔ Ghi nhận buổi tập, giữ nguyên lịch trình (hoặc gợi ý tăng buổi tập/tuần nếu chọn đổi lịch).
+   - Do tập quá sức / Nguy hiểm ➔ Cảnh báo chấn thương và chèn 1 ngày nghỉ phục hồi (`is_rest_day = true`).
 
 **Error / Edge Cases**
-- E1: User từ chối ngày nghỉ → System vẫn chèn (bắt buộc, không cho bypass).
+- E1: User không phản hồi tin nhắn Check-in ➔ Giữ nguyên buổi tập đã ghi nhận và giữ lịch trình hiện tại.
 
 **Domain Events**: `RoadmapAdjusted`
 
 ---
 
-### UC-04.5 DetectSignalB4 — Plateau
+### UC-04.5 DetectSignalB4 — Cơ bắp bị chai lỳ (Plateau)
 
 | | |
 |---|---|
 | **Actor** | System (AI Coach) |
-| **Precondition** | 1RM và FormScore trung bình không tăng trong 3 tuần liên tiếp có CR ≥ 70%. |
+| **Precondition** | Sức mạnh ước tính (1RM) của bài tập chính không tăng trong 2 tuần liên tiếp (chỉ tính các tuần có $SCR \ge 80\%$). |
 
 **Main Flow**
-1. `AdaptiveCoachEngine` phát hiện Signal B4.
-2. System đề xuất 3 phương án:
-   - (a) Deload Week: giảm 40% tải lượng 1 tuần.
-   - (b) Đổi biến thể bài tập tương đương.
-   - (c) Tăng số set, giữ nguyên tạ.
-3. User chọn phương án. System cập nhật `DailyWorkoutPlan` kế tiếp.
+1. `AdaptiveCoachEngine` phát hiện Signal B4 khi kết thúc buổi tập cuối Tuần 2.
+2. System gửi Push Notification / In-App Alert thông báo cho User.
+3. Khi User tương tác qua gRPC Stream, System đề xuất 3 phương án phá Plateau:
+   - (a) Đổi biến thể bài tập tương đương.
+   - (b) Điều chỉnh dải Rep/Set (VD: chuyển từ 8–10 reps sang 4–6 reps heavy).
+   - (c) Thay đổi thứ tự bài tập trong buổi tập.
+4. User chọn phương án và bấm Confirm ➔ System cập nhật `prescription` trong `SessionPlan` của các tuần tới.
 
 **Error / Edge Cases**
-- E1: User không chọn trong 48h → tự áp dụng Deload Week (an toàn nhất).
+- E1: User không tương tác ➔ Tự động áp dụng đổi biến thể bài tập tương đương cho tuần tới.
+
+**Postcondition**: Bài tập tuần tới được làm mới để phá vỡ giai đoạn đình trệ.
+
+**Domain Events**: `RoadmapAdjusted`
+
+---
+
+### UC-04.6 AdaptPostInjuryRecovery — Thích ứng sau phục hồi chấn thương
+
+| | |
+|---|---|
+| **Actor** | System (AI Coach) |
+| **Precondition** | Một chấn thương được xác nhận phục hồi (`recovered`). |
+
+**Main Flow**
+1. System áp dụng cơ chế bảo vệ trong **3 buổi tập đầu tiên** liên quan đến nhóm cơ của khớp vừa phục hồi:
+   - Giới hạn mức tạ gợi ý tối đa không vượt quá **50%** mức tạ PR trước chấn thương.
+   - Ưu tiên gợi ý bài Bodyweight hoặc Machine/Cable (đường chuyển động cố định).
+2. Với mỗi buổi tập bảo vệ hoàn thành:
+   - Nếu đạt $RPE \le 7$ (với bài dùng AI Camera bổ sung thêm $Form\ Score \ge 80\%$) ➔ Ghi nhận 1 buổi bảo vệ thành công.
+3. Sau khi hoàn thành đủ 3 buổi bảo vệ đạt chuẩn ➔ System mở lại cơ chế Progressive Overload bình thường.
+
+**Error / Edge Cases**
+- E1: Sau 3 buổi mà $RPE > 7$ hoặc $Form\ Score < 80\%$ ➔ Kéo dài giai đoạn bảo vệ cho đến khi đạt đủ điều kiện an toàn.
+
+**Postcondition**: Người tập quay lại chu kỳ tăng tải bình thường sau khi phục hồi an toàn.
+
+**Domain Events**: `RoadmapAdjusted`�t hiện Signal B4 khi kết thúc buổi tập cuối Tuần 2.
+2. System gửi Push Notification / In-App Alert thông báo cho User.
+3. Khi User tương tác qua gRPC Stream, System đề xuất 3 phương án phá Plateau:
+   - (a) Đổi biến thể bài tập tương đương.
+   - (b) Điều chỉnh dải Rep/Set (VD: chuyển từ 8–10 reps sang 4–6 reps heavy).
+   - (c) Thay đổi thứ tự bài tập trong buổi tập.
+4. User chọn phương án và bấm Confirm ➔ System cập nhật `prescription` trong `ScheduleDay` của các tuần tới.
+
+**Error / Edge Cases**
+- E1: User không tương tác ➔ Tự động áp dụng đổi biến thể bài tập tương đương cho tuần tới.
+
+**Postcondition**: Bài tập tuần tới được làm mới để phá vỡ giai đoạn đình trệ.
 
 **Domain Events**: `RoadmapAdjusted`

--- a/docs/usecase/04_adaptive_review_cycle.md
+++ b/docs/usecase/04_adaptive_review_cycle.md
@@ -60,7 +60,7 @@
 
 **Postcondition**: Lịch tập được cập nhật theo lựa chọn của user (hoặc giữ nguyên nếu không phản hồi).
 
-**Domain Events**: `RoadmapPaused` | `WeeklyScheduleGenerated`
+**Domain Events**: `RoadmapPaused` | `RoadmapAdjusted`
 
 ---
 
@@ -74,13 +74,13 @@
 **Main Flow**
 1. `AdaptiveCoachEngine` phát hiện Signal B2.
 2. System đề xuất dời slot ngày đó sang ngày khác còn trống trong tuần.
-3. If user đồng ý → cập nhật `WeeklySchedule`, phát `ScheduleDayRescheduled`.
+3. If user đồng ý → Re-generate các giáo án chưa thực thi trong `WorkoutRoadmap`, phát `RoadmapAdjusted`.
 4. Nếu user từ chối → giữ nguyên, không hỏi lại về vấn đề này.
 
 **Error / Edge Cases**
 - E1: Không còn ngày trống trong tuần (đã tối đa 6 buổi) → chỉ thông báo, không đề xuất đổi.
 
-**Domain Events**: `ScheduleDayRescheduled`
+**Domain Events**: `RoadmapAdjusted`
 
 ---
 
@@ -94,12 +94,12 @@
 **Main Flow**
 1. `AdaptiveCoachEngine` phát hiện Signal B3.
 2. System cảnh báo nguy cơ quá tải, đề xuất Active Recovery.
-3. System bắt buộc chèn 1 ngày nghỉ vào `WeeklySchedule` kế tiếp.
+3. System bắt buộc chèn 1 ngày nghỉ vào `WorkoutRoadmap` cho ngày kế tiếp và Re-generate giáo án các ngày chưa thực thi.
 
 **Error / Edge Cases**
 - E1: User từ chối ngày nghỉ → System vẫn chèn (bắt buộc, không cho bypass).
 
-**Domain Events**: `WeeklyScheduleGenerated`
+**Domain Events**: `RoadmapAdjusted`
 
 ---
 

--- a/docs/usecase/README.md
+++ b/docs/usecase/README.md
@@ -5,7 +5,7 @@ Thư mục này chứa đặc tả Use Case chi tiết cho từng phân hệ (Bo
 | File đặc tả | Phân hệ (Context) | Các Use Case cụ thể |
 | :--- | :--- | :--- |
 | [`01_onboarding.md`](01_onboarding.md) | Onboarding | - UC-01.1 RegisterUser<br>- UC-01.2 CompleteHealthProfile<br>- UC-01.3 ReportInjury |
-| [`02_coaching_planning.md`](02_coaching_planning.md) | Coaching & Planning | - UC-02.1 InitiateWorkoutRoadmap<br>- UC-02.2 ExecuteDailyWorkoutPlan<br>- UC-02.3 ReevaluateScheduleOnProfileUpdated |
+| [`02_coaching_planning.md`](02_coaching_planning.md) | Coaching & Planning | - UC-02.1 InitiateRoadmap<br>- UC-02.2 ExecuteSessionPlan<br>- UC-02.3 RegenerateScheduleOnProfileUpdated |
 | [`03_workout_execution.md`](03_workout_execution.md) | Workout Execution | - UC-03.1 StartWorkoutSession<br>- UC-03.2 LogSet — AI Camera<br>- UC-03.3 LogSet — Phi AI<br>- UC-03.4 CompleteWorkoutSession<br>- UC-03.5 RecordPersonalRecord |
-| [`04_adaptive_review_cycle.md`](04_adaptive_review_cycle.md) | Adaptive Review Cycle | - UC-04.1 EvaluateEndOfCycleCompletionRate<br>- UC-04.2 DetectSignalB1 — Không hoạt động<br>- UC-04.3 DetectSignalB2 — Lịch không tương thích<br>- UC-04.4 DetectSignalB3 — Overtraining<br>- UC-04.5 DetectSignalB4 — Plateau |
+| [`04_adaptive_review_cycle.md`](04_adaptive_review_cycle.md) | Adaptive Review Cycle | - UC-04.1 EvaluateWeeklyAdaptiveCycle<br>- UC-04.2 DetectSignalB1 — Bỏ tập cấp tính / Mất tích<br>- UC-04.3 DetectSignalB2 — Kẹt lịch cố định<br>- UC-04.4 DetectSignalB3 — Tập ngoài lịch<br>- UC-04.5 DetectSignalB4 — Cơ bắp bị chai lỳ (Plateau) |
 | [`05_nutrition.md`](05_nutrition.md) | Nutrition | - UC-05.1 GenerateDailyNutritionPlan<br>- UC-05.2 LogMeal |

--- a/docs/usecase/README.md
+++ b/docs/usecase/README.md
@@ -5,7 +5,7 @@ Thư mục này chứa đặc tả Use Case chi tiết cho từng phân hệ (Bo
 | File đặc tả | Phân hệ (Context) | Các Use Case cụ thể |
 | :--- | :--- | :--- |
 | [`01_onboarding.md`](01_onboarding.md) | Onboarding | - UC-01.1 RegisterUser<br>- UC-01.2 CompleteHealthProfile<br>- UC-01.3 ReportInjury |
-| [`02_coaching_planning.md`](02_coaching_planning.md) | Coaching & Planning | - UC-02.1 InitiateWorkoutRoadmap<br>- UC-02.2 GenerateDailyWorkoutPlan (JIT)<br>- UC-02.3 GenerateNextWeeklySchedule |
+| [`02_coaching_planning.md`](02_coaching_planning.md) | Coaching & Planning | - UC-02.1 InitiateWorkoutRoadmap<br>- UC-02.2 ExecuteDailyWorkoutPlan<br>- UC-02.3 ReevaluateScheduleOnProfileUpdated |
 | [`03_workout_execution.md`](03_workout_execution.md) | Workout Execution | - UC-03.1 StartWorkoutSession<br>- UC-03.2 LogSet — AI Camera<br>- UC-03.3 LogSet — Phi AI<br>- UC-03.4 CompleteWorkoutSession<br>- UC-03.5 RecordPersonalRecord |
 | [`04_adaptive_review_cycle.md`](04_adaptive_review_cycle.md) | Adaptive Review Cycle | - UC-04.1 EvaluateEndOfCycleCompletionRate<br>- UC-04.2 DetectSignalB1 — Không hoạt động<br>- UC-04.3 DetectSignalB2 — Lịch không tương thích<br>- UC-04.4 DetectSignalB3 — Overtraining<br>- UC-04.5 DetectSignalB4 — Plateau |
 | [`05_nutrition.md`](05_nutrition.md) | Nutrition | - UC-05.1 GenerateDailyNutritionPlan<br>- UC-05.2 LogMeal |

--- a/proto/contracts/core/coaching/v1/event/coaching_events.proto
+++ b/proto/contracts/core/coaching/v1/event/coaching_events.proto
@@ -15,23 +15,12 @@ message RoadmapInitiated {
   google.protobuf.Timestamp initiated_at = 5;
 }
 
-message WeeklyScheduleGenerated {
-  string weekly_schedule_id = 1;
+message DailyWorkoutPlanExecuted {
+  string daily_workout_plan_id = 1;
   string roadmap_id = 2;
   string user_id = 3;
-  int32 week_number = 4;
-  google.type.Date start_date = 5;
-  google.type.Date end_date = 6;
-  google.protobuf.Timestamp generated_at = 7;
-}
-
-message DailyWorkoutPlanGenerated {
-  string daily_workout_plan_id = 1;
-  string weekly_schedule_id = 2;
-  string roadmap_id = 3;
-  string user_id = 4;
-  google.type.Date scheduled_date = 5;
-  google.protobuf.Timestamp generated_at = 6;
+  google.type.Date scheduled_date = 4;
+  google.protobuf.Timestamp executed_at = 5;
 }
 
 message RoadmapAdjusted {

--- a/proto/contracts/core/coaching/v1/event/coaching_events.proto
+++ b/proto/contracts/core/coaching/v1/event/coaching_events.proto
@@ -5,49 +5,28 @@ package contracts.core.coaching.v1.event;
 option go_package = "github.com/viethung213/gym-companion/internal/gen/go/contracts/core/coaching/v1/event;coachingv1event";
 
 import "google/protobuf/timestamp.proto";
-import "google/type/date.proto";
+import "proto/contracts/core/coaching/v1/message/coaching_messages.proto";
 
-message RoadmapInitiated {
+message RoadmapInitiatedEventPayload {
   string roadmap_id = 1;
   string user_id = 2;
-  google.type.Date start_date = 3;
-  google.type.Date end_date = 4;
-  google.protobuf.Timestamp initiated_at = 5;
+  google.protobuf.Timestamp initiated_at = 3;
+  message.Roadmap roadmap = 4;
 }
 
-message DailyWorkoutPlanExecuted {
-  string daily_workout_plan_id = 1;
-  string roadmap_id = 2;
-  string user_id = 3;
-  google.type.Date scheduled_date = 4;
-  google.protobuf.Timestamp executed_at = 5;
-}
-
-message RoadmapAdjusted {
+message RoadmapAdjustedEventPayload {
   string roadmap_id = 1;
   string user_id = 2;
   string reason = 3;
   google.protobuf.Timestamp adjusted_at = 4;
+  message.Roadmap roadmap = 5;
 }
 
-message RoadmapCompleted {
-  string roadmap_id = 1;
-  string user_id = 2;
-  google.protobuf.Timestamp completed_at = 3;
-}
-
-message DailyWorkoutPlanRegenerated {
-  string daily_workout_plan_id = 1;
-  string weekly_schedule_id = 2;
-  string roadmap_id = 3;
-  string user_id = 4;
-  google.type.Date scheduled_date = 5;
-  string reason = 6; // Ví dụ: "injury_reported", "equipment_missing"
-  google.protobuf.Timestamp regenerated_at = 7;
-}
-
-message PreWorkoutCheckInSubmitted {
-  string user_id = 1;
-  string check_in_id = 2;
-  google.protobuf.Timestamp submitted_at = 3;
+message SessionPlanExecutedEventPayload {
+  string session_plan_id = 1;
+  string roadmap_id = 2;
+  string user_id = 3;
+  google.protobuf.Timestamp executed_at = 4;
+  float session_scr = 5;
+  float session_delta_rpe = 6;
 }

--- a/proto/contracts/core/coaching/v1/message/coaching_messages.proto
+++ b/proto/contracts/core/coaching/v1/message/coaching_messages.proto
@@ -40,7 +40,6 @@ message InitiateRoadmapPayload {
 
 message InitiateRoadmapResponse {
   WorkoutRoadmap roadmap = 1;
-  WeeklySchedule first_weekly_schedule = 2;
 }
 
 message ListWorkoutRoadmapsRequest {
@@ -70,7 +69,6 @@ message GetActiveRoadmapRequest {
 
 message GetActiveRoadmapResponse {
   WorkoutRoadmap roadmap = 1;
-  WeeklySchedule current_weekly_schedule = 2;
 }
 
 message GetPreWorkoutCheckInRequest {
@@ -108,6 +106,8 @@ message WorkoutRoadmap {
   RoadmapStatus status = 3;
   google.type.Date start_date = 4;
   google.type.Date end_date = 5;
+  repeated WeeklySchedule weekly_schedules = 6;
+  repeated DailyWorkoutPlan daily_workout_plans = 7;
 }
 
 message WeeklySchedule {

--- a/proto/contracts/core/coaching/v1/message/coaching_messages.proto
+++ b/proto/contracts/core/coaching/v1/message/coaching_messages.proto
@@ -13,20 +13,11 @@ enum RoadmapStatus {
   ROADMAP_STATUS_COMPLETED = 2;
 }
 
-enum WorkoutDayStatus {
-  WORKOUT_DAY_STATUS_UNSPECIFIED = 0;
-  WORKOUT_DAY_STATUS_TRAINING = 1;     // Ngày có lịch tập
-  WORKOUT_DAY_STATUS_REST = 2;         // Ngày nghỉ phục hồi
-  WORKOUT_DAY_STATUS_SKIPPED = 3;      // Lịch là tập nhưng bỏ lỡ (không tập)
-  WORKOUT_DAY_STATUS_RESCHEDULED = 4;  // Chủ động dời lịch sang ngày khác
-}
-
-enum DailyPlanStatus {
-  DAILY_PLAN_STATUS_UNSPECIFIED = 0;
-  DAILY_PLAN_STATUS_DRAFT = 1;
-  DAILY_PLAN_STATUS_ACTIVE = 2;
-  DAILY_PLAN_STATUS_COMPLETED = 3;
-  DAILY_PLAN_STATUS_SKIPPED = 4;
+enum SessionPlanStatus {
+  SESSION_PLAN_STATUS_UNSPECIFIED = 0;
+  SESSION_PLAN_STATUS_PENDING = 1;   // Chưa tập / chờ tập
+  SESSION_PLAN_STATUS_COMPLETED = 2; // Đã hoàn thành buổi tập
+  SESSION_PLAN_STATUS_SKIPPED = 3;   // Đã bỏ qua / không tập
 }
 
 message InitiateRoadmapRequest {
@@ -39,28 +30,28 @@ message InitiateRoadmapPayload {
 }
 
 message InitiateRoadmapResponse {
-  WorkoutRoadmap roadmap = 1;
+  Roadmap roadmap = 1;
 }
 
-message ListWorkoutRoadmapsRequest {
+message ListRoadmapsRequest {
   string user_id = 1;
   RoadmapStatus status = 2;
   int32 page_size = 3;
   string page_token = 4;
 }
 
-message ListWorkoutRoadmapsResponse {
-  repeated WorkoutRoadmap roadmaps = 1;
+message ListRoadmapsResponse {
+  repeated Roadmap roadmaps = 1;
   string next_page_token = 2;
 }
 
-message GetWorkoutRoadmapRequest {
+message GetRoadmapRequest {
   string user_id = 1;
   string roadmap_id = 2;
 }
 
-message GetWorkoutRoadmapResponse {
-  WorkoutRoadmap roadmap = 1;
+message GetRoadmapResponse {
+  Roadmap roadmap = 1;
 }
 
 message GetActiveRoadmapRequest {
@@ -68,78 +59,72 @@ message GetActiveRoadmapRequest {
 }
 
 message GetActiveRoadmapResponse {
-  WorkoutRoadmap roadmap = 1;
+  Roadmap roadmap = 1;
 }
 
-message GetPreWorkoutCheckInRequest {
+message GetSessionPlanRequest {
   string user_id = 1;
+  string session_plan_id = 2;
 }
 
-message GetPreWorkoutCheckInResponse {
-  string check_in_id = 1;
-  repeated CheckInQuestion questions = 2;
+message GetSessionPlanResponse {
+  SessionPlan session_plan = 1;
 }
 
-message SubmitPreWorkoutCheckInRequest {
+message RegenerateScheduleRequest {
   string user_id = 1;
-  string check_in_id = 2;
-  repeated CheckInAnswer answers = 3;
+  string roadmap_id = 2;
+  string reason = 3;
 }
 
-message SubmitPreWorkoutCheckInResponse {
-  bool requires_regeneration = 1;
-  string coach_feedback = 2;
+message RegenerateScheduleResponse {
+  Roadmap roadmap = 1;
 }
 
-message GetDailyWorkoutPlanRequest {
-  string user_id = 1;
-  google.type.Date scheduled_date = 2;
-}
-
-message GetDailyWorkoutPlanResponse {
-  DailyWorkoutPlan daily_workout_plan = 1;
-}
-
-message WorkoutRoadmap {
+message Roadmap {
   string roadmap_id = 1;
   string user_id = 2;
   RoadmapStatus status = 3;
   google.type.Date start_date = 4;
   google.type.Date end_date = 5;
-  repeated WeeklySchedule weekly_schedules = 6;
-  repeated DailyWorkoutPlan daily_workout_plans = 7;
+  repeated WeekPlan week_plans = 6;
 }
 
-message WeeklySchedule {
-  string weekly_schedule_id = 1;
+message WeekPlan {
+  string week_plan_id = 1;
   string roadmap_id = 2;
   string user_id = 3;
   int32 week_number = 4;
   google.type.Date start_date = 5;
   google.type.Date end_date = 6;
   string muscle_split_type = 7;
-  repeated ScheduleDay schedule_days = 8;
+  repeated DayPlan day_plans = 8;
 }
 
-message ScheduleDay {
-  google.type.Date scheduled_date = 1;
-  string day_of_week = 2;
-  WorkoutDayStatus status = 3;
-  repeated string target_muscle_groups = 4;
-  string daily_workout_plan_id = 5;
-}
-
-message DailyWorkoutPlan {
-  string daily_workout_plan_id = 1;
-  string user_id = 2;
+message DayPlan {
+  string day_plan_id = 1;
+  string week_plan_id = 2;
   string roadmap_id = 3;
-  string weekly_schedule_id = 4;
+  string user_id = 4;
   google.type.Date scheduled_date = 5;
-  DailyPlanStatus status = 6;
-  WorkoutPrescription workout_prescription = 7;
-  string reasoning_explanation = 8;
-  string adjustment_explanation = 9;
-  google.protobuf.Timestamp generated_at = 10;
+  bool is_rest_day = 6;
+  repeated string available_slots = 7;
+  repeated SessionPlan session_plans = 8;
+}
+
+message SessionPlan {
+  string session_plan_id = 1;
+  string day_plan_id = 2;
+  string week_plan_id = 3;
+  string roadmap_id = 4;
+  string user_id = 5;
+  google.type.Date scheduled_date = 6;
+  string slot_time = 7;
+  SessionPlanStatus status = 8;
+  repeated string target_muscle_groups = 9;
+  WorkoutPrescription prescription = 10;
+  string reasoning_explanation = 11;
+  google.protobuf.Timestamp generated_at = 12;
 }
 
 message WorkoutPrescription {

--- a/proto/contracts/core/coaching/v1/service/coaching_service.proto
+++ b/proto/contracts/core/coaching/v1/service/coaching_service.proto
@@ -34,7 +34,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
 };
 
 service CoachingService {
-  // Create the initial four-week roadmap and first weekly schedule.
+  // Create the complete four-week roadmap with pre-generated daily workout plans.
   rpc InitiateRoadmap (contracts.core.coaching.v1.message.InitiateRoadmapRequest) returns (contracts.core.coaching.v1.message.InitiateRoadmapResponse) {
     option (google.api.http) = {
       post: "/api/v1/users/{user_id}/workout-roadmaps"

--- a/proto/contracts/core/coaching/v1/service/coaching_service.proto
+++ b/proto/contracts/core/coaching/v1/service/coaching_service.proto
@@ -11,8 +11,8 @@ import "contracts/core/coaching/v1/message/coaching_messages.proto";
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   info: {
     title: "AI Workout Coaching API"
-    version: "1.0"
-    description: "API for workout roadmap planning, weekly scheduling, daily workout plans, and adaptive coaching review."
+    version: "1.18"
+    description: "API for 4-week workout roadmap planning, weekly scheduling, daily plan execution, and adaptive coaching review."
   }
   security_definitions: {
     security: {
@@ -34,57 +34,47 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
 };
 
 service CoachingService {
-  // Create the complete four-week roadmap with pre-generated daily workout plans.
+  // Create the complete 4-week roadmap with initial session plans.
   rpc InitiateRoadmap (contracts.core.coaching.v1.message.InitiateRoadmapRequest) returns (contracts.core.coaching.v1.message.InitiateRoadmapResponse) {
     option (google.api.http) = {
-      post: "/api/v1/users/{user_id}/workout-roadmaps"
+      post: "/api/v1/users/{user_id}/roadmaps"
       body: "payload"
     };
   }
 
   // List roadmaps for a user, optionally filtered by status.
-  rpc ListWorkoutRoadmaps (contracts.core.coaching.v1.message.ListWorkoutRoadmapsRequest) returns (contracts.core.coaching.v1.message.ListWorkoutRoadmapsResponse) {
+  rpc ListRoadmaps (contracts.core.coaching.v1.message.ListRoadmapsRequest) returns (contracts.core.coaching.v1.message.ListRoadmapsResponse) {
     option (google.api.http) = {
-      get: "/api/v1/users/{user_id}/workout-roadmaps"
+      get: "/api/v1/users/{user_id}/roadmaps"
     };
   }
 
   // Get one roadmap by id.
-  rpc GetWorkoutRoadmap (contracts.core.coaching.v1.message.GetWorkoutRoadmapRequest) returns (contracts.core.coaching.v1.message.GetWorkoutRoadmapResponse) {
+  rpc GetRoadmap (contracts.core.coaching.v1.message.GetRoadmapRequest) returns (contracts.core.coaching.v1.message.GetRoadmapResponse) {
     option (google.api.http) = {
-      get: "/api/v1/users/{user_id}/workout-roadmaps/{roadmap_id}"
+      get: "/api/v1/users/{user_id}/roadmaps/{roadmap_id}"
     };
   }
 
   // Get the single active roadmap for a user.
   rpc GetActiveRoadmap (contracts.core.coaching.v1.message.GetActiveRoadmapRequest) returns (contracts.core.coaching.v1.message.GetActiveRoadmapResponse) {
     option (google.api.http) = {
-      get: "/api/v1/users/{user_id}/workout-roadmaps/active"
+      get: "/api/v1/users/{user_id}/roadmaps/active"
     };
   }
 
-  // Get pre-workout check-in questions dynamically generated for today's session.
-  rpc GetPreWorkoutCheckIn (contracts.core.coaching.v1.message.GetPreWorkoutCheckInRequest) returns (contracts.core.coaching.v1.message.GetPreWorkoutCheckInResponse) {
+  // Get a specific session plan by id.
+  rpc GetSessionPlan (contracts.core.coaching.v1.message.GetSessionPlanRequest) returns (contracts.core.coaching.v1.message.GetSessionPlanResponse) {
     option (google.api.http) = {
-      get: "/api/v1/users/{user_id}/pre-workout-checkin"
+      get: "/api/v1/users/{user_id}/session-plans/{session_plan_id}"
     };
   }
 
-  // Submit answers for the pre-workout check-in.
-  rpc SubmitPreWorkoutCheckIn (contracts.core.coaching.v1.message.SubmitPreWorkoutCheckInRequest) returns (contracts.core.coaching.v1.message.SubmitPreWorkoutCheckInResponse) {
+  // Re-generate future unexecuted session plans when profile/adaptation rules trigger (FR-AC-06).
+  rpc RegenerateSchedule (contracts.core.coaching.v1.message.RegenerateScheduleRequest) returns (contracts.core.coaching.v1.message.RegenerateScheduleResponse) {
     option (google.api.http) = {
-      post: "/api/v1/users/{user_id}/pre-workout-checkin:submit"
+      post: "/api/v1/users/{user_id}/roadmaps/{roadmap_id}:regenerate"
       body: "*"
-    };
-  }
-
-  // Get today's detailed workout plan.
-  // TODO: In the future, this RPC will be refactored into a Server Streaming RPC to support Warm-up Rendering
-  // and progressive JIT streaming (as defined in ADR-01):
-  // rpc GetDailyWorkoutPlan (GetDailyWorkoutPlanRequest) returns (stream GetDailyWorkoutPlanResponse);
-  rpc GetDailyWorkoutPlan (contracts.core.coaching.v1.message.GetDailyWorkoutPlanRequest) returns (contracts.core.coaching.v1.message.GetDailyWorkoutPlanResponse) {
-    option (google.api.http) = {
-      get: "/api/v1/users/{user_id}/daily-workout-plans/today"
     };
   }
 }


### PR DESCRIPTION
### 1. Problem to Solve
- Khởi tạo Lộ trình 4 tuần ở kiến trúc cũ bị xé nhỏ theo từng tuần (chỉ sinh WeeklySchedule cho Tuần 1, sau đó phải sinh tuần 2, 3, 4 cuốn chiếu).
- Phức tạp hóa DDD khi phải duy trì 2 Aggregate Roots độc lập (WorkoutRoadmap và WeeklySchedule) và 2 Repositories riêng biệt.

### 2. Proposed Solution
- **Sinh 100% trọn gói Lộ trình 4 tuần (28 ngày tập)**: Khi khởi tạo WorkoutRoadmap (UC-02.1), AI Coach sinh ngay 4 tuần theo 4 pha tiến trình chuẩn (BR-AC-09) và 28 giáo án chi tiết (DailyWorkoutPlan).
- **Gộp Aggregate Root**: Biến WorkoutRoadmap thành Aggregate Root duy nhất sở hữu WeeklySchedule (Entities) và ScheduleDay (Value Objects), quản lý DailyWorkoutPlan.
- **Loại bỏ Abstractions Thừa**: Xóa WeeklyScheduleRepository và bãi bỏ Use Case sinh tuần cuốn chiếu cũ.
- **Truy xuất trực tiếp từ DB**: Khi mở app tập, đọc trực tiếp DailyWorkoutPlan hôm nay từ cơ sở dữ liệu. Khi có biến động profile/sức khỏe ➔ Re-generate các giáo án chưa thực thi (scheduled_date >= today).

### 3. Changes & Impact
- \docs/NGHIEP_VU_COT_LOI_BABOK.md\: Cập nhật Quy trình 3.1, 3.3, FR-AC-01 và FR-AC-06.
- \docs/usecase/02_coaching_planning.md\: Cập nhật UC-02.1, UC-02.2, bãi bỏ UC-02.3 cũ, thêm UC-02.3 ReevaluateWorkoutRoadmap.
- \docs/usecase/04_adaptive_review_cycle.md\ & \docs/usecase/README.md\: Cập nhật domain events và danh mục usecases.
- \docs/02_bounded_context.md\ & \docs/03_ddd_tactical_design.md\: Cập nhật ranh giới Bounded Context và DDD Aggregate Root cho WorkoutRoadmap.
- \proto/contracts/core/coaching/v1/\: Cập nhật RPC, messages và events trong proto files.

### 4. Testing & Verification
- **Doc Integrity Check**: Đã kiểm tra sự đồng bộ 100% giữa BABOK BRD, Use Cases, DDD Tactical Design và Protobuf Contracts.
- **Language Audit**: Loại bỏ hoàn toàn từ phô trương/hội thoại, tuân thủ 7 nguyên tắc đặc tả nghiệp vụ.