### PR TITLE
✨ feat(coaching): implement 4-tier bounded context with agentic architecture

### DIFF
--- a/docs/02_bounded_context.md
+++ b/docs/02_bounded_context.md
@@ -50,7 +50,7 @@
 - **Context liên quan**:
   - Đọc `BiologicalMetrics`, `Injury`, `PrimaryGoal`, `AvailableEquipment`, `PreferredMuscleGroups`, `AvailableSlots` từ `User Profile`.
   - Đọc thông tin bài tập được quản lý bởi `Workout Execution & Motion`.
-  - Lắng nghe `WorkoutSessionCompleted` từ `Workout Execution`.
+  - Lắng nghe `WorkoutSessionCompleted` (nghiệm thu COMPLETED) và `WorkoutSessionAborted` (chuyển SKIPPED khi timeout/hủy) từ `Workout Execution`.
   - Gọi Shared Infrastructure để gửi Push Notification.
 
 ---

--- a/internal/coaching/application/command/apply_adaptive_cycle.go
+++ b/internal/coaching/application/command/apply_adaptive_cycle.go
@@ -1,0 +1,120 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/contextbuilder"
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	domainevent "github.com/viethung213/gym-companion/internal/coaching/domain/event"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/service"
+	"github.com/viethung213/gym-companion/internal/coaching/infrastructure/guardrail"
+)
+
+// ApplyAdaptiveCycleCommand triggers UC-04.1 (BR-AC-04) evaluation.
+type ApplyAdaptiveCycleCommand struct {
+	UserID  string
+	Metrics []service.WeeklyMetrics
+}
+
+// ApplyAdaptiveCycleResult echoes the decision applied.
+type ApplyAdaptiveCycleResult struct {
+	Decision service.AdaptationDecision
+	Roadmap  *roadmap.Roadmap
+}
+
+// ApplyAdaptiveCycleHandler orchestrates BR-AC-04 Trigger A.
+type ApplyAdaptiveCycleHandler struct {
+	tx      port.TransactionManager
+	repo    port.RoadmapRepository
+	agent   port.CoachAgent
+	builder *contextbuilder.Builder
+	guard   *guardrail.Engine
+	outbox  port.OutboxWriter
+	clock   port.Clock
+	engine  *service.AdaptiveCoachEngine
+}
+
+// NewApplyAdaptiveCycleHandler wires the handler.
+func NewApplyAdaptiveCycleHandler(
+	tx port.TransactionManager,
+	repo port.RoadmapRepository,
+	agent port.CoachAgent,
+	builder *contextbuilder.Builder,
+	guard *guardrail.Engine,
+	outbox port.OutboxWriter,
+	clock port.Clock,
+	engine *service.AdaptiveCoachEngine,
+) *ApplyAdaptiveCycleHandler {
+	if engine == nil {
+		engine = service.NewAdaptiveCoachEngine()
+	}
+	return &ApplyAdaptiveCycleHandler{
+		tx: tx, repo: repo, agent: agent, builder: builder,
+		guard: guard, outbox: outbox, clock: clock, engine: engine,
+	}
+}
+
+// Handle evaluates BR-AC-04 and applies the result via CoachAgent.Adapt.
+func (h *ApplyAdaptiveCycleHandler) Handle(ctx context.Context, cmd ApplyAdaptiveCycleCommand) (*ApplyAdaptiveCycleResult, error) {
+	if cmd.UserID == "" {
+		return nil, errors.New("user_id required")
+	}
+	decision := h.engine.EvaluateTriggerA(cmd.Metrics)
+	if decision.Kind == service.AdaptationNoOp {
+		return &ApplyAdaptiveCycleResult{Decision: decision}, nil
+	}
+
+	rm, err := h.repo.FindActiveByUser(ctx, cmd.UserID)
+	if err != nil {
+		return nil, err
+	}
+	now := h.clock.Now()
+	cc, err := h.builder.Build(ctx, port.FlowAdaptiveCycle, cmd.UserID, rm, now)
+	if err != nil {
+		return nil, err
+	}
+
+	drafts, err := h.agent.Adapt(ctx, cc, decision.Reason, nil)
+	if err != nil {
+		return nil, fmt.Errorf("agent adapt: %w", err)
+	}
+
+	// Apply drafts in-place onto pending sessions (D3 invariant).
+	for _, d := range drafts {
+		s, ok := rm.FindSession(d.SessionPlanID)
+		if !ok {
+			continue
+		}
+		if s.Status() != roadmap.SessionPlanStatusPending {
+			continue
+		}
+		if err := s.RewritePrescription(d.Prescription, d.TargetMuscleGroups, d.Reasoning, now); err != nil {
+			return nil, err
+		}
+	}
+
+	if result := h.guard.Check(rm); result.Status != guardrail.StatusApproved {
+		return nil, fmt.Errorf("guardrail rejected adaptive cycle: %+v", result.Violations)
+	}
+
+	err = h.tx.WithTransaction(ctx, func(txCtx context.Context) error {
+		rm.Touch(now)
+		if err := h.repo.Save(txCtx, rm); err != nil {
+			return err
+		}
+		evt := &domainevent.RoadmapAdjusted{
+			RoadmapID:  rm.ID(),
+			UserID:     rm.UserID(),
+			Reason:     "adaptive_cycle:" + decision.Reason,
+			AdjustedAt: now,
+		}
+		return h.outbox.Enqueue(txCtx, rm.UserID(), evt)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &ApplyAdaptiveCycleResult{Decision: decision, Roadmap: rm}, nil
+}

--- a/internal/coaching/application/command/initiate_roadmap.go
+++ b/internal/coaching/application/command/initiate_roadmap.go
@@ -1,0 +1,108 @@
+// Package command holds application command handlers for the Coaching context.
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/contextbuilder"
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	domainevent "github.com/viethung213/gym-companion/internal/coaching/domain/event"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+	"github.com/viethung213/gym-companion/internal/coaching/infrastructure/guardrail"
+)
+
+// InitiateRoadmapCommand is the input to UC-02.1.
+type InitiateRoadmapCommand struct {
+	UserID string
+}
+
+// InitiateRoadmapResult wraps the persisted roadmap snapshot.
+type InitiateRoadmapResult struct {
+	Roadmap *roadmap.Roadmap
+}
+
+// InitiateRoadmapHandler orchestrates: ContextBuilder → CoachAgent → Guard →
+// Save (Roadmap + Outbox event) in a single transaction.
+type InitiateRoadmapHandler struct {
+	tx        port.TransactionManager
+	repo      port.RoadmapRepository
+	agent     port.CoachAgent
+	builder   *contextbuilder.Builder
+	guard     *guardrail.Engine
+	outbox    port.OutboxWriter
+	clock     port.Clock
+}
+
+// NewInitiateRoadmapHandler wires the handler.
+func NewInitiateRoadmapHandler(
+	tx port.TransactionManager,
+	repo port.RoadmapRepository,
+	agent port.CoachAgent,
+	builder *contextbuilder.Builder,
+	guard *guardrail.Engine,
+	outbox port.OutboxWriter,
+	clock port.Clock,
+) *InitiateRoadmapHandler {
+	return &InitiateRoadmapHandler{
+		tx: tx, repo: repo, agent: agent, builder: builder,
+		guard: guard, outbox: outbox, clock: clock,
+	}
+}
+
+// Handle executes UC-02.1.
+func (h *InitiateRoadmapHandler) Handle(ctx context.Context, cmd InitiateRoadmapCommand) (*InitiateRoadmapResult, error) {
+	if cmd.UserID == "" {
+		return nil, errors.New("user_id is required")
+	}
+
+	// Reject if an ACTIVE roadmap already exists (BR-AC constraint enforced also
+	// at DB level via ux_roadmaps_user_active).
+	existing, err := h.repo.FindActiveByUser(ctx, cmd.UserID)
+	if err != nil && !errors.Is(err, roadmap.ErrRoadmapNotFound) {
+		return nil, fmt.Errorf("check active roadmap: %w", err)
+	}
+	if existing != nil {
+		return nil, roadmap.ErrActiveRoadmapExists
+	}
+
+	now := h.clock.Now()
+	cc, err := h.builder.Build(ctx, port.FlowInitiate4Week, cmd.UserID, nil, now)
+	if err != nil {
+		return nil, fmt.Errorf("build context: %w", err)
+	}
+
+	draft, err := h.agent.GenerateRoadmap(ctx, cc, nil)
+	if err != nil {
+		return nil, fmt.Errorf("agent generate: %w", err)
+	}
+	if err := draft.ValidateFullStructure(); err != nil {
+		return nil, fmt.Errorf("draft structure: %w", err)
+	}
+
+	if result := h.guard.Check(draft); result.Status != guardrail.StatusApproved {
+		return nil, fmt.Errorf("guardrail rejected: %+v", result.Violations)
+	}
+
+	var out *InitiateRoadmapResult
+	err = h.tx.WithTransaction(ctx, func(txCtx context.Context) error {
+		if err := h.repo.Save(txCtx, draft); err != nil {
+			return err
+		}
+		evt := &domainevent.RoadmapInitiated{
+			RoadmapID:   draft.ID(),
+			UserID:      draft.UserID(),
+			InitiatedAt: now,
+		}
+		if err := h.outbox.Enqueue(txCtx, draft.UserID(), evt); err != nil {
+			return err
+		}
+		out = &InitiateRoadmapResult{Roadmap: draft}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/coaching/application/command/initiate_roadmap_test.go
+++ b/internal/coaching/application/command/initiate_roadmap_test.go
@@ -1,0 +1,163 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/contextbuilder"
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	domainevent "github.com/viethung213/gym-companion/internal/coaching/domain/event"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/service"
+	"github.com/viethung213/gym-companion/internal/coaching/infrastructure/ai"
+	"github.com/viethung213/gym-companion/internal/coaching/infrastructure/guardrail"
+)
+
+// ---- mocks ----
+
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) Now() time.Time { return c.t }
+
+type incrIDs struct{ n int }
+
+func (i *incrIDs) NewID() string {
+	i.n++
+	return "id-" + strconv.Itoa(i.n)
+}
+
+type fakeTx struct{}
+
+func (fakeTx) WithTransaction(ctx context.Context, fn func(context.Context) error) error {
+	return fn(ctx)
+}
+
+type memRepo struct {
+	byID       map[string]*roadmap.Roadmap
+	activeByID map[string]string // userID -> roadmap.ID
+}
+
+func newMemRepo() *memRepo {
+	return &memRepo{byID: map[string]*roadmap.Roadmap{}, activeByID: map[string]string{}}
+}
+
+func (m *memRepo) Save(_ context.Context, r *roadmap.Roadmap) error {
+	m.byID[r.ID()] = r
+	if r.Status() == roadmap.RoadmapStatusActive {
+		m.activeByID[r.UserID()] = r.ID()
+	}
+	return nil
+}
+func (m *memRepo) FindByID(_ context.Context, id string) (*roadmap.Roadmap, error) {
+	if r, ok := m.byID[id]; ok {
+		return r, nil
+	}
+	return nil, roadmap.ErrRoadmapNotFound
+}
+func (m *memRepo) FindActiveByUser(_ context.Context, userID string) (*roadmap.Roadmap, error) {
+	if id, ok := m.activeByID[userID]; ok {
+		return m.byID[id], nil
+	}
+	return nil, roadmap.ErrRoadmapNotFound
+}
+func (m *memRepo) ListByUser(context.Context, string, roadmap.RoadmapStatus, int, int) ([]*roadmap.Roadmap, error) {
+	return nil, nil
+}
+func (m *memRepo) FindSessionByID(_ context.Context, sid string) (*roadmap.Roadmap, error) {
+	for _, r := range m.byID {
+		if _, ok := r.FindSession(sid); ok {
+			return r, nil
+		}
+	}
+	return nil, roadmap.ErrSessionNotFound
+}
+
+type captureOutbox struct {
+	events []domainevent.Event
+}
+
+func (c *captureOutbox) Enqueue(_ context.Context, _ string, evs ...domainevent.Event) error {
+	c.events = append(c.events, evs...)
+	return nil
+}
+
+type stubProfile struct{ p port.Profile }
+
+func (s *stubProfile) GetProfile(_ context.Context, _ string) (port.Profile, error) { return s.p, nil }
+
+type stubWorkouts struct{}
+
+func (stubWorkouts) GetRecentSessions(context.Context, string, time.Time) ([]port.WorkoutSession, error) {
+	return nil, nil
+}
+func (stubWorkouts) GetSetLogs(context.Context, string, string, int) ([]port.SetLog, error) {
+	return nil, nil
+}
+
+func buildHandler(t *testing.T) (*InitiateRoadmapHandler, *memRepo, *captureOutbox) {
+	t.Helper()
+	clock := &fakeClock{t: time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)}
+	ids := &incrIDs{}
+	agent := ai.NewMockCoachAgent(ids, clock)
+	builder := contextbuilder.NewBuilder(
+		&stubProfile{p: port.Profile{
+			UserID:                "user-1",
+			PrimaryGoal:           "MUSCLE_GAIN",
+			PreferredMuscleGroups: []string{"chest", "back"},
+		}},
+		stubWorkouts{},
+		contextbuilder.NewStaticPromptRegistry(),
+	)
+	guard := guardrail.NewEngine(service.NewOverloadValidator(), nil, nil)
+	repo := newMemRepo()
+	outbox := &captureOutbox{}
+	h := NewInitiateRoadmapHandler(fakeTx{}, repo, agent, builder, guard, outbox, clock)
+	return h, repo, outbox
+}
+
+func TestInitiateRoadmap_HappyPath(t *testing.T) {
+	h, repo, outbox := buildHandler(t)
+	res, err := h.Handle(context.Background(), InitiateRoadmapCommand{UserID: "user-1"})
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if res == nil || res.Roadmap == nil {
+		t.Fatalf("nil result")
+	}
+	if res.Roadmap.Status() != roadmap.RoadmapStatusActive {
+		t.Errorf("status=%s", res.Roadmap.Status())
+	}
+	// Roadmap must be persisted.
+	if _, err := repo.FindActiveByUser(context.Background(), "user-1"); err != nil {
+		t.Errorf("expected active roadmap in repo: %v", err)
+	}
+	// Outbox must have RoadmapInitiated.
+	if len(outbox.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(outbox.events))
+	}
+	if _, ok := outbox.events[0].(*domainevent.RoadmapInitiated); !ok {
+		t.Errorf("expected RoadmapInitiated, got %T", outbox.events[0])
+	}
+}
+
+func TestInitiateRoadmap_RejectsDuplicateActive(t *testing.T) {
+	h, _, _ := buildHandler(t)
+	if _, err := h.Handle(context.Background(), InitiateRoadmapCommand{UserID: "user-1"}); err != nil {
+		t.Fatalf("first init: %v", err)
+	}
+	_, err := h.Handle(context.Background(), InitiateRoadmapCommand{UserID: "user-1"})
+	if !errors.Is(err, roadmap.ErrActiveRoadmapExists) {
+		t.Errorf("expected ErrActiveRoadmapExists, got %v", err)
+	}
+}
+
+func TestInitiateRoadmap_MissingUserID(t *testing.T) {
+	h, _, _ := buildHandler(t)
+	_, err := h.Handle(context.Background(), InitiateRoadmapCommand{UserID: ""})
+	if err == nil {
+		t.Errorf("expected error for missing user_id")
+	}
+}

--- a/internal/coaching/application/command/regenerate_schedule.go
+++ b/internal/coaching/application/command/regenerate_schedule.go
@@ -1,0 +1,120 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/contextbuilder"
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	domainevent "github.com/viethung213/gym-companion/internal/coaching/domain/event"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+	"github.com/viethung213/gym-companion/internal/coaching/infrastructure/guardrail"
+)
+
+// RegenerateScheduleCommand is the input to UC-02.3.
+type RegenerateScheduleCommand struct {
+	UserID string
+	Reason string // "profile_updated", "injury_reported", "injury_recovered", ...
+}
+
+// RegenerateScheduleResult echoes the updated roadmap.
+type RegenerateScheduleResult struct {
+	Roadmap *roadmap.Roadmap
+}
+
+// RegenerateScheduleHandler orchestrates UC-02.3 (FR-AC-06).
+type RegenerateScheduleHandler struct {
+	tx      port.TransactionManager
+	repo    port.RoadmapRepository
+	agent   port.CoachAgent
+	builder *contextbuilder.Builder
+	guard   *guardrail.Engine
+	outbox  port.OutboxWriter
+	clock   port.Clock
+}
+
+// NewRegenerateScheduleHandler wires the handler.
+func NewRegenerateScheduleHandler(
+	tx port.TransactionManager,
+	repo port.RoadmapRepository,
+	agent port.CoachAgent,
+	builder *contextbuilder.Builder,
+	guard *guardrail.Engine,
+	outbox port.OutboxWriter,
+	clock port.Clock,
+) *RegenerateScheduleHandler {
+	return &RegenerateScheduleHandler{tx: tx, repo: repo, agent: agent, builder: builder, guard: guard, outbox: outbox, clock: clock}
+}
+
+// Handle executes UC-02.3: rewrite only PENDING sessions from today onward (D3).
+func (h *RegenerateScheduleHandler) Handle(ctx context.Context, cmd RegenerateScheduleCommand) (*RegenerateScheduleResult, error) {
+	if cmd.UserID == "" {
+		return nil, errors.New("user_id required")
+	}
+
+	now := h.clock.Now()
+
+	// Load current active roadmap.
+	rm, err := h.repo.FindActiveByUser(ctx, cmd.UserID)
+	if err != nil {
+		return nil, err
+	}
+
+	pending := rm.PendingSessionsFrom(now)
+	if len(pending) == 0 {
+		// Nothing to regenerate.
+		return &RegenerateScheduleResult{Roadmap: rm}, nil
+	}
+
+	cc, err := h.builder.Build(ctx, port.FlowRegenerate, cmd.UserID, rm, now)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]string, 0, len(pending))
+	for _, s := range pending {
+		ids = append(ids, s.ID())
+	}
+
+	drafts, err := h.agent.RegeneratePending(ctx, cc, ids, nil)
+	if err != nil {
+		return nil, fmt.Errorf("agent regenerate: %w", err)
+	}
+
+	// Apply drafts in-place onto the aggregate.
+	for _, draft := range drafts {
+		s, ok := rm.FindSession(draft.SessionPlanID)
+		if !ok {
+			continue // Session may have been completed between load and generate — skip.
+		}
+		if s.Status() != roadmap.SessionPlanStatusPending {
+			continue // Someone else finalized it — respect D3.
+		}
+		if err := s.RewritePrescription(draft.Prescription, draft.TargetMuscleGroups, draft.Reasoning, now); err != nil {
+			return nil, fmt.Errorf("rewrite session %s: %w", draft.SessionPlanID, err)
+		}
+	}
+
+	if result := h.guard.Check(rm); result.Status != guardrail.StatusApproved {
+		return nil, fmt.Errorf("guardrail rejected regen: %+v", result.Violations)
+	}
+
+	err = h.tx.WithTransaction(ctx, func(txCtx context.Context) error {
+		rm.Touch(now)
+		if err := h.repo.Save(txCtx, rm); err != nil {
+			return err
+		}
+		evt := &domainevent.RoadmapAdjusted{
+			RoadmapID:  rm.ID(),
+			UserID:     rm.UserID(),
+			Reason:     cmd.Reason,
+			AdjustedAt: now,
+		}
+		return h.outbox.Enqueue(txCtx, rm.UserID(), evt)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &RegenerateScheduleResult{Roadmap: rm}, nil
+}

--- a/internal/coaching/application/command/session_completion.go
+++ b/internal/coaching/application/command/session_completion.go
@@ -1,0 +1,167 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	domainevent "github.com/viethung213/gym-companion/internal/coaching/domain/event"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/service"
+)
+
+// CompleteSessionCommand is the input from WorkoutSessionCompleted event.
+type CompleteSessionCommand struct {
+	SessionPlanID       string
+	TotalActualSets     int
+	TotalPrescribedSets int
+	AverageActualRPE    float64
+	CompletedAt         string // RFC3339 timestamp for logging
+}
+
+// CompleteSessionResult echoes state.
+type CompleteSessionResult struct {
+	RoadmapID       string
+	SessionPlanID   string
+	SCR             float32
+	DeltaRPE        float32
+}
+
+// CompleteSessionHandler transitions a SessionPlan to COMPLETED and computes
+// SCR / ΔRPE per BR-AC-04 (D7: scalar formula).
+type CompleteSessionHandler struct {
+	tx     port.TransactionManager
+	repo   port.RoadmapRepository
+	scr    *service.SCRCalculator
+	outbox port.OutboxWriter
+	clock  port.Clock
+}
+
+// NewCompleteSessionHandler wires the handler.
+func NewCompleteSessionHandler(tx port.TransactionManager, repo port.RoadmapRepository, scr *service.SCRCalculator, outbox port.OutboxWriter, clock port.Clock) *CompleteSessionHandler {
+	if scr == nil {
+		scr = service.NewSCRCalculator()
+	}
+	return &CompleteSessionHandler{tx: tx, repo: repo, scr: scr, outbox: outbox, clock: clock}
+}
+
+// Handle applies the transition. Idempotent when the session is already COMPLETED.
+func (h *CompleteSessionHandler) Handle(ctx context.Context, cmd CompleteSessionCommand) (*CompleteSessionResult, error) {
+	if cmd.SessionPlanID == "" {
+		return nil, errors.New("session_plan_id required")
+	}
+
+	var out *CompleteSessionResult
+	err := h.tx.WithTransaction(ctx, func(txCtx context.Context) error {
+		rm, err := h.repo.FindSessionByID(txCtx, cmd.SessionPlanID)
+		if err != nil {
+			return fmt.Errorf("find session's roadmap: %w", err)
+		}
+		session, ok := rm.FindSession(cmd.SessionPlanID)
+		if !ok {
+			return roadmap.ErrSessionNotFound
+		}
+
+		// Compute SCR / ΔRPE.
+		scrPct := float32(h.scr.SCR(cmd.TotalActualSets, cmd.TotalPrescribedSets))
+		// Target RPE lives in the WeekPlan; find it.
+		targetRPE := findTargetRPEForSession(rm, cmd.SessionPlanID)
+		delta := float32(h.scr.DeltaRPE(cmd.AverageActualRPE, float64(targetRPE)))
+
+		now := h.clock.Now()
+		if err := session.MarkCompleted(scrPct, delta, now); err != nil {
+			return fmt.Errorf("mark completed: %w", err)
+		}
+		rm.Touch(now)
+
+		if err := h.repo.Save(txCtx, rm); err != nil {
+			return err
+		}
+		evt := &domainevent.SessionPlanExecuted{
+			SessionPlanID:   session.ID(),
+			RoadmapID:       rm.ID(),
+			UserID:          rm.UserID(),
+			ExecutedAt:      now,
+			SessionSCR:      scrPct,
+			SessionDeltaRPE: delta,
+		}
+		if err := h.outbox.Enqueue(txCtx, rm.UserID(), evt); err != nil {
+			return err
+		}
+		out = &CompleteSessionResult{
+			RoadmapID:     rm.ID(),
+			SessionPlanID: session.ID(),
+			SCR:           scrPct,
+			DeltaRPE:      delta,
+		}
+		return nil
+	})
+	return out, err
+}
+
+// AbortSessionCommand corresponds to WorkoutSessionAborted event.
+type AbortSessionCommand struct {
+	SessionPlanID string
+	Reason        string
+}
+
+// AbortSessionHandler marks the session as SKIPPED (per D3/A7 clarification:
+// no separate ABORTED state; aborted sessions map to SKIPPED).
+type AbortSessionHandler struct {
+	tx     port.TransactionManager
+	repo   port.RoadmapRepository
+	outbox port.OutboxWriter
+	clock  port.Clock
+}
+
+// NewAbortSessionHandler wires the handler.
+func NewAbortSessionHandler(tx port.TransactionManager, repo port.RoadmapRepository, outbox port.OutboxWriter, clock port.Clock) *AbortSessionHandler {
+	return &AbortSessionHandler{tx: tx, repo: repo, outbox: outbox, clock: clock}
+}
+
+// Handle applies the SKIPPED transition. Idempotent when already SKIPPED.
+func (h *AbortSessionHandler) Handle(ctx context.Context, cmd AbortSessionCommand) error {
+	if cmd.SessionPlanID == "" {
+		return errors.New("session_plan_id required")
+	}
+	return h.tx.WithTransaction(ctx, func(txCtx context.Context) error {
+		rm, err := h.repo.FindSessionByID(txCtx, cmd.SessionPlanID)
+		if err != nil {
+			return err
+		}
+		session, ok := rm.FindSession(cmd.SessionPlanID)
+		if !ok {
+			return roadmap.ErrSessionNotFound
+		}
+		if err := session.MarkSkipped(); err != nil {
+			return err
+		}
+		rm.Touch(h.clock.Now())
+		if err := h.repo.Save(txCtx, rm); err != nil {
+			return err
+		}
+		evt := &domainevent.RoadmapAdjusted{
+			RoadmapID:  rm.ID(),
+			UserID:     rm.UserID(),
+			Reason:     "workout_session_aborted:" + cmd.Reason,
+			AdjustedAt: h.clock.Now(),
+		}
+		return h.outbox.Enqueue(txCtx, rm.UserID(), evt)
+	})
+}
+
+// findTargetRPEForSession finds the target RPE from the WeekPlan containing
+// the given session. Returns 0 if not found.
+func findTargetRPEForSession(rm *roadmap.Roadmap, sessionPlanID string) float32 {
+	for _, w := range rm.Weeks() {
+		for _, d := range w.Days() {
+			for _, s := range d.Sessions() {
+				if s.ID() == sessionPlanID {
+					return w.Info().TargetRPE
+				}
+			}
+		}
+	}
+	return 0
+}

--- a/internal/coaching/application/command/session_completion_test.go
+++ b/internal/coaching/application/command/session_completion_test.go
@@ -1,0 +1,108 @@
+package command
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	domainevent "github.com/viethung213/gym-companion/internal/coaching/domain/event"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/service"
+)
+
+func seedRoadmap(t *testing.T, repo *memRepo) *roadmap.Roadmap {
+	t.Helper()
+	base := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
+	wp, _ := roadmap.NewWeekPlan(roadmap.WeekPlanInfo{
+		WeekPlanID: "wp-1", RoadmapID: "rm-1", UserID: "user-1",
+		WeekNumber: 1, Phase: roadmap.PhaseAccumulation, TargetRPE: 7.0,
+		StartDate: base, EndDate: base.AddDate(0, 0, 6),
+	})
+	dp, _ := roadmap.NewDayPlan(roadmap.DayPlanInfo{
+		DayPlanID: "dp-1", WeekPlanID: "wp-1", RoadmapID: "rm-1", UserID: "user-1",
+		ScheduledDate: base,
+	})
+	sp, _ := roadmap.NewSessionPlan(roadmap.SessionPlanInfo{
+		SessionPlanID: "sp-1", DayPlanID: "dp-1", WeekPlanID: "wp-1", RoadmapID: "rm-1",
+		UserID: "user-1", ScheduledDate: base,
+	}, time.Now())
+	_ = dp.AddSession(sp)
+	_ = wp.AddDay(dp)
+
+	weeks := []*roadmap.WeekPlan{wp}
+	// Fill remaining weeks minimally to satisfy structural checks (optional here).
+	for i := 2; i <= 4; i++ {
+		w, _ := roadmap.NewWeekPlan(roadmap.WeekPlanInfo{
+			WeekPlanID: "wp-" + string(rune('0'+i)), RoadmapID: "rm-1", UserID: "user-1",
+			WeekNumber: int32(i),
+			Phase:      []roadmap.Phase{roadmap.PhaseOverload, roadmap.PhasePeak, roadmap.PhaseDeload}[i-2],
+			TargetRPE:  7.0,
+			StartDate:  base.AddDate(0, 0, (i-1)*7),
+			EndDate:    base.AddDate(0, 0, (i-1)*7+6),
+		})
+		weeks = append(weeks, w)
+	}
+	r, _ := roadmap.NewRoadmap(roadmap.RoadmapInfo{
+		RoadmapID: "rm-1", UserID: "user-1",
+		StartDate: base, EndDate: base.AddDate(0, 0, 28),
+	}, weeks, time.Now())
+	_ = repo.Save(context.Background(), r)
+	return r
+}
+
+func TestCompleteSession_MarksCompletedAndEmitsEvent(t *testing.T) {
+	repo := newMemRepo()
+	seedRoadmap(t, repo)
+	outbox := &captureOutbox{}
+	clock := &fakeClock{t: time.Date(2026, 8, 3, 8, 0, 0, 0, time.UTC)}
+	h := NewCompleteSessionHandler(fakeTx{}, repo, service.NewSCRCalculator(), outbox, clock)
+
+	res, err := h.Handle(context.Background(), CompleteSessionCommand{
+		SessionPlanID:       "sp-1",
+		TotalActualSets:     12,
+		TotalPrescribedSets: 15,
+		AverageActualRPE:    7.5,
+	})
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if res.SCR != 80.0 {
+		t.Errorf("SCR=%v, want 80.0", res.SCR)
+	}
+	if res.DeltaRPE != 0.5 { // 7.5 - 7.0
+		t.Errorf("DeltaRPE=%v, want 0.5", res.DeltaRPE)
+	}
+	rm := repo.byID["rm-1"]
+	sp, _ := rm.FindSession("sp-1")
+	if sp.Status() != roadmap.SessionPlanStatusCompleted {
+		t.Errorf("session status=%s", sp.Status())
+	}
+	if len(outbox.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(outbox.events))
+	}
+	if _, ok := outbox.events[0].(*domainevent.SessionPlanExecuted); !ok {
+		t.Errorf("expected SessionPlanExecuted, got %T", outbox.events[0])
+	}
+}
+
+func TestAbortSession_MarksSkipped(t *testing.T) {
+	repo := newMemRepo()
+	seedRoadmap(t, repo)
+	outbox := &captureOutbox{}
+	h := NewAbortSessionHandler(fakeTx{}, repo, outbox, &fakeClock{t: time.Now()})
+
+	err := h.Handle(context.Background(), AbortSessionCommand{SessionPlanID: "sp-1", Reason: "user_cancelled"})
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	rm := repo.byID["rm-1"]
+	sp, _ := rm.FindSession("sp-1")
+	if sp.Status() != roadmap.SessionPlanStatusSkipped {
+		t.Errorf("session status=%s, want SKIPPED", sp.Status())
+	}
+	if len(outbox.events) != 1 {
+		t.Errorf("expected 1 RoadmapAdjusted, got %d", len(outbox.events))
+	}
+	_ = port.OutboxRecord{} // keep port import
+}

--- a/internal/coaching/application/contextbuilder/builder.go
+++ b/internal/coaching/application/contextbuilder/builder.go
@@ -1,0 +1,101 @@
+// Package contextbuilder assembles the CoachContext payload that CoachAgent
+// consumes. It gathers snapshots from UserProfileReader + WorkoutSessionReader
+// + the current Roadmap and applies the flow-specific instructions template.
+package contextbuilder
+
+import (
+	"context"
+	"time"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+)
+
+// Builder is a plain struct — inject its dependencies via NewBuilder.
+type Builder struct {
+	profile   port.UserProfileReader
+	workouts  port.WorkoutSessionReader
+	lookback  time.Duration
+	prompts   PromptRegistry
+}
+
+// NewBuilder wires a ContextBuilder.
+func NewBuilder(profile port.UserProfileReader, workouts port.WorkoutSessionReader, prompts PromptRegistry) *Builder {
+	return &Builder{
+		profile:  profile,
+		workouts: workouts,
+		lookback: 28 * 24 * time.Hour, // 4 weeks of history is enough for BR-AC-04..08
+		prompts:  prompts,
+	}
+}
+
+// Build produces a CoachContext for the given flow. currentRoadmap may be nil
+// (e.g. UC-02.1 InitiateRoadmap where no prior roadmap exists).
+func (b *Builder) Build(ctx context.Context, flow port.FlowType, userID string, currentRoadmap *roadmap.Roadmap, now time.Time) (port.CoachContext, error) {
+	profile, err := b.profile.GetProfile(ctx, userID)
+	if err != nil {
+		return port.CoachContext{}, err
+	}
+
+	sessions, err := b.workouts.GetRecentSessions(ctx, userID, now.Add(-b.lookback))
+	if err != nil {
+		return port.CoachContext{}, err
+	}
+
+	cc := port.CoachContext{
+		Flow:           flow,
+		UserID:         userID,
+		Profile:        profile,
+		RecentSessions: sessions,
+		InjuryStatus:   profile.ActiveInjuries,
+	}
+
+	if currentRoadmap != nil {
+		cc.CurrentRoadmap = buildSnapshot(currentRoadmap, now)
+	}
+
+	instr, schema, err := b.prompts.Render(flow, cc)
+	if err != nil {
+		return port.CoachContext{}, err
+	}
+	cc.Instructions = instr
+	cc.OutputSchemaHint = schema
+	return cc, nil
+}
+
+func buildSnapshot(r *roadmap.Roadmap, now time.Time) *port.RoadmapSnapshot {
+	snap := &port.RoadmapSnapshot{
+		RoadmapID:      r.ID(),
+		Phase:          currentPhase(r, now),
+		CurrentWeekNum: currentWeekNum(r, now),
+	}
+	for _, s := range r.PendingSessionsFrom(now) {
+		info := s.Info()
+		snap.PendingSessions = append(snap.PendingSessions, port.SessionSnapshot{
+			SessionPlanID: info.SessionPlanID,
+			ScheduledDate: info.ScheduledDate.Format("2006-01-02"),
+			MuscleGroups:  info.TargetMuscleGroups,
+		})
+	}
+	return snap
+}
+
+func currentPhase(r *roadmap.Roadmap, now time.Time) roadmap.Phase {
+	for _, w := range r.Weeks() {
+		info := w.Info()
+		if !now.Before(info.StartDate) && !now.After(info.EndDate) {
+			return info.Phase
+		}
+	}
+	return ""
+}
+
+func currentWeekNum(r *roadmap.Roadmap, now time.Time) int32 {
+	for _, w := range r.Weeks() {
+		info := w.Info()
+		if !now.Before(info.StartDate) && !now.After(info.EndDate) {
+			return info.WeekNumber
+		}
+	}
+	return 0
+}

--- a/internal/coaching/application/contextbuilder/prompts.go
+++ b/internal/coaching/application/contextbuilder/prompts.go
@@ -1,0 +1,119 @@
+package contextbuilder
+
+import (
+	"fmt"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+)
+
+// PromptRegistry renders the instruction template and returns the desired
+// JSON output schema hint for a given flow.
+type PromptRegistry interface {
+	Render(flow port.FlowType, cc port.CoachContext) (instructions string, schemaHint string, err error)
+}
+
+// StaticPromptRegistry is a simple, in-memory implementation good enough for
+// phase-1. Real LLM adapters can replace this with template files.
+type StaticPromptRegistry struct{}
+
+// NewStaticPromptRegistry returns the default in-memory registry.
+func NewStaticPromptRegistry() *StaticPromptRegistry { return &StaticPromptRegistry{} }
+
+// Render implements PromptRegistry.
+func (r *StaticPromptRegistry) Render(flow port.FlowType, cc port.CoachContext) (string, string, error) {
+	switch flow {
+	case port.FlowInitiate4Week:
+		return initiatePrompt(cc), schema4WeekRoadmap, nil
+	case port.FlowRegenerate:
+		return regeneratePrompt(cc), schemaSessionList, nil
+	case port.FlowAdaptiveCycle:
+		return adaptiveCyclePrompt(cc), schemaSessionList, nil
+	case port.FlowSignalHandler:
+		return signalPrompt(cc), schemaSessionList, nil
+	case port.FlowPostInjury:
+		return postInjuryPrompt(cc), schemaSessionList, nil
+	case port.FlowDashboard:
+		return "", "", nil // Dashboard doesn't invoke agent
+	case port.FlowSuggestAdHocSession:
+		return suggestAdHocPrompt(cc), schemaSuggestedSession, nil
+	default:
+		return "", "", fmt.Errorf("unknown flow: %s", flow)
+	}
+}
+
+func initiatePrompt(cc port.CoachContext) string {
+	return fmt.Sprintf(`Task: Generate a 4-week training roadmap for user %s.
+Profile:
+  Primary goal: %s
+  Available equipment: %v
+  Preferred muscle groups: %v
+  Available slots: %v
+  Active injuries: %d
+Constraints:
+  - Max 6 training sessions per week (BR-AC-01).
+  - Week 1: ACCUMULATION (target RPE 6-7).
+  - Week 2: OVERLOAD (target RPE 7-8).
+  - Week 3: PEAK (target RPE 8-9).
+  - Week 4: DELOAD (target RPE 5-6, volume -30%%, intensity -10%%).
+  - Include warmup (5-10 min) and cooldown (5 min) per session.
+  - Weight suggestions must be within ±30%% of history/PR.
+Output the roadmap as JSON conforming to the schema.`,
+		cc.UserID,
+		cc.Profile.PrimaryGoal,
+		cc.Profile.AvailableEquipment,
+		cc.Profile.PreferredMuscleGroups,
+		cc.Profile.AvailableSlots,
+		len(cc.InjuryStatus),
+	)
+}
+
+func regeneratePrompt(cc port.CoachContext) string {
+	return fmt.Sprintf(`Task: Regenerate PENDING sessions for user %s in response to profile/injury changes.
+Only touch sessions listed in current_roadmap.pending_sessions. Preserve COMPLETED sessions untouched.
+Respect the same guardrails as roadmap initiation.`,
+		cc.UserID)
+}
+
+func adaptiveCyclePrompt(cc port.CoachContext) string {
+	return fmt.Sprintf(`Task: Apply an adaptive-cycle adjustment (BR-AC-04) for user %s based on last week's metrics.
+The orchestrator has already decided which rule applies. Your job is to translate that decision into
+concrete SessionPlan prescriptions for the next week's PENDING sessions.`,
+		cc.UserID)
+}
+
+func signalPrompt(cc port.CoachContext) string {
+	return fmt.Sprintf(`Task: Respond to a behavioral signal (B1-B4) for user %s.
+Adjust upcoming PENDING sessions per the signal reason. Explain reasoning in the reasoning field of each session.`,
+		cc.UserID)
+}
+
+func postInjuryPrompt(cc port.CoachContext) string {
+	return fmt.Sprintf(`Task: Post-injury protective adjustment (BR-AC-09) for user %s.
+For the next 3 sessions targeting the recovered muscle group:
+  - Cap weight at 50%% of pre-injury PR.
+  - Prefer machine/cable/bodyweight exercises over free weights.
+  - Target RPE ≤ 7 for AI-verified form ≥ 80%%.`,
+		cc.UserID)
+}
+
+func suggestAdHocPrompt(cc port.CoachContext) string {
+	return fmt.Sprintf(`Task: Suggest a single ad-hoc workout for user %s.
+This is a read-only suggestion — nothing will be persisted. Respect:
+  - Injuries: %d active
+  - Available equipment: %v
+  - User preferences: %v
+Output a WorkoutPrescription (warmups + main + cooldowns) and 1-line reasoning.`,
+		cc.UserID,
+		len(cc.InjuryStatus),
+		cc.Profile.AvailableEquipment,
+		cc.Profile.PreferredMuscleGroups,
+	)
+}
+
+// JSON schema hints (opaque strings — the LLM adapter is responsible for
+// parsing / enforcing them). Phase-1 mock ignores them.
+const (
+	schema4WeekRoadmap     = `{"type":"object","properties":{"weeks":{"type":"array","minItems":4,"maxItems":4}}}`
+	schemaSessionList      = `{"type":"array","items":{"type":"object","required":["session_plan_id","prescription"]}}`
+	schemaSuggestedSession = `{"type":"object","required":["prescription"],"properties":{"prescription":{"type":"object"},"reasoning":{"type":"string"}}}`
+)

--- a/internal/coaching/application/port/coach_agent.go
+++ b/internal/coaching/application/port/coach_agent.go
@@ -1,0 +1,113 @@
+package port
+
+import (
+	"context"
+
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+)
+
+// FlowType identifies which coaching workflow invoked the agent.
+type FlowType string
+
+const (
+	FlowInitiate4Week      FlowType = "INITIATE_4_WEEK"
+	FlowRegenerate         FlowType = "REGENERATE_PENDING"
+	FlowAdaptiveCycle      FlowType = "ADAPTIVE_CYCLE"
+	FlowSignalHandler      FlowType = "SIGNAL_HANDLER"
+	FlowPostInjury         FlowType = "POST_INJURY_RECOVERY"
+	FlowDashboard          FlowType = "DASHBOARD_SUMMARY"
+	// FlowSuggestAdHocSession is a read-only flow: user asks the agent to
+	// suggest a single ad-hoc workout (outside the roadmap). Nothing is
+	// persisted; the frontend decides what to do with the suggestion.
+	FlowSuggestAdHocSession FlowType = "SUGGEST_AD_HOC_SESSION"
+)
+
+// CoachContext is the payload passed to CoachAgent — a snapshot of everything
+// the agent needs to produce a prescription (Profile + history + PR + injuries
+// + current roadmap state). Populated by application/contextbuilder.
+type CoachContext struct {
+	Flow             FlowType
+	UserID           string
+	Profile          Profile
+	RecentSessions   []WorkoutSession
+	InjuryStatus     []InjuryStatus
+	CurrentRoadmap   *RoadmapSnapshot
+	Instructions     string // flow-specific instruction template rendered
+	OutputSchemaHint string // JSON schema hint (opaque to Go, used by the LLM adapter)
+}
+
+// RoadmapSnapshot is a lightweight read-only view of the current roadmap.
+type RoadmapSnapshot struct {
+	RoadmapID       string
+	Phase           roadmap.Phase
+	CurrentWeekNum  int32
+	PendingSessions []SessionSnapshot
+}
+
+// SessionSnapshot is a read-only view of one SessionPlan.
+type SessionSnapshot struct {
+	SessionPlanID  string
+	ScheduledDate  string // YYYY-MM-DD
+	Phase          roadmap.Phase
+	MuscleGroups   []string
+}
+
+// Feedback carries reject reasons from Evaluator or Guard when a previous
+// draft was rejected. Generator uses this on retry.
+type Feedback struct {
+	Iteration int
+	Issues    []Issue
+}
+
+// Issue is one Evaluator/Guard finding.
+type Issue struct {
+	Code        string
+	Description string
+	Path        string
+	Severity    string // "BLOCKER" or "WARNING"
+}
+
+// AdHocHint is what the user (via chat or a simple form) tells the coach when
+// asking for a one-off session suggestion.
+type AdHocHint struct {
+	FreeText          string   // "help me pick chest exercises for 30 minutes"
+	MuscleGroups      []string // optional narrowing filter
+	AvailableEquipment []string // may differ from profile (e.g. at hotel gym)
+	DurationMinutes   int      // 0 = no preference
+	IntensityHint     string   // "light" | "normal" | "hard" — optional
+}
+
+// SuggestedSession is the read-only output of FlowSuggestAdHocSession. It
+// carries a full WorkoutPrescription plus reasoning so the frontend can render
+// it and let the user decide (start workout / discard / bookmark).
+//
+// This value object is intentionally NOT a roadmap.SessionPlan — it never
+// enters the aggregate and is not persisted. If the user later commits to
+// use it, the frontend hands the exercises off to Workout Execution.
+type SuggestedSession struct {
+	MuscleGroups []string
+	Prescription roadmap.WorkoutPrescription
+	Reasoning    string
+	// EstimatedRPE is a soft hint the agent used when picking weights.
+	EstimatedRPE float32
+}
+
+// CoachAgent is the LLM (or deterministic mock) that generates prescriptions.
+// It is deliberately stateless w.r.t. downstream steps (Evaluator/Guard) — the
+// orchestrator passes Feedback on retry.
+type CoachAgent interface {
+	// GenerateRoadmap synthesizes a full 4-week draft for a new user.
+	GenerateRoadmap(ctx context.Context, cc CoachContext, fb *Feedback) (*roadmap.Roadmap, error)
+
+	// RegeneratePending rewrites the given PENDING sessions in-place.
+	// The returned slice mirrors the ordering of input session IDs.
+	RegeneratePending(ctx context.Context, cc CoachContext, sessionIDs []string, fb *Feedback) ([]roadmap.SessionPlanInfo, error)
+
+	// Adapt applies a specific AdaptationDecision (Trigger A / Signal B / injury) to
+	// the pending portion of the roadmap.
+	Adapt(ctx context.Context, cc CoachContext, decisionReason string, fb *Feedback) ([]roadmap.SessionPlanInfo, error)
+
+	// SuggestAdHocSession returns a single-session suggestion. Read-only:
+	// nothing is persisted, no domain event is emitted. FlowSuggestAdHocSession.
+	SuggestAdHocSession(ctx context.Context, cc CoachContext, hint AdHocHint) (SuggestedSession, error)
+}

--- a/internal/coaching/application/port/ports.go
+++ b/internal/coaching/application/port/ports.go
@@ -1,0 +1,74 @@
+// Package port defines all outbound interfaces the Coaching application layer
+// depends on. Concrete adapters live under infrastructure/.
+package port
+
+import (
+	"context"
+	"time"
+
+	"github.com/viethung213/gym-companion/internal/coaching/domain/event"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+)
+
+// Clock abstracts time.Now() for deterministic tests.
+type Clock interface {
+	Now() time.Time
+}
+
+// IDGenerator abstracts UUID/ULID generation.
+type IDGenerator interface {
+	NewID() string
+}
+
+// TransactionManager runs fn inside a database transaction. The context is
+// wrapped so that repositories can pick up the tx handle from it.
+type TransactionManager interface {
+	WithTransaction(ctx context.Context, fn func(txCtx context.Context) error) error
+}
+
+// TxManager is an alias kept for parity with other bounded contexts.
+type TxManager = TransactionManager
+
+// RoadmapRepository persists the Roadmap aggregate tree.
+type RoadmapRepository interface {
+	Save(ctx context.Context, r *roadmap.Roadmap) error
+	FindByID(ctx context.Context, roadmapID string) (*roadmap.Roadmap, error)
+	FindActiveByUser(ctx context.Context, userID string) (*roadmap.Roadmap, error)
+	ListByUser(ctx context.Context, userID string, status roadmap.RoadmapStatus, limit, offset int) ([]*roadmap.Roadmap, error)
+	FindSessionByID(ctx context.Context, sessionPlanID string) (*roadmap.Roadmap, error)
+}
+
+// OutboxRecord mirrors coaching.outbox row structure.
+type OutboxRecord struct {
+	ID           string
+	EventID      string
+	EventType    string
+	Payload      []byte
+	PartitionKey string
+	CreatedAt    time.Time
+	Published    bool
+	PublishedAt  *time.Time
+}
+
+// OutboxRepository manages rows in coaching.outbox and coaching.outbox_log.
+type OutboxRepository interface {
+	Save(ctx context.Context, record *OutboxRecord) error
+	FetchUnpublished(ctx context.Context, limit int) ([]*OutboxRecord, error)
+	MarkPublished(ctx context.Context, ids []string) error
+	ExecuteInLock(ctx context.Context, lockID int64, fn func(txCtx context.Context) error) error
+	// LogProcessed records that an inbound event has been consumed (D9 idempotency).
+	// Returns (true, nil) if this is a new event that was recorded, (false, nil) if
+	// the event_id was already present (duplicate delivery), or an error.
+	LogProcessed(ctx context.Context, eventID, eventType, partitionKey string, payload []byte) (fresh bool, err error)
+}
+
+// OutboxWriter is a convenience port for enqueueing domain events into the outbox
+// as CloudEvents envelopes, always inside the caller's transaction.
+type OutboxWriter interface {
+	Enqueue(ctx context.Context, partitionKey string, events ...event.Event) error
+}
+
+// BrokerPublisher publishes outbox events to Kafka.
+type BrokerPublisher interface {
+	PublishBatch(ctx context.Context, records []*OutboxRecord) error
+}

--- a/internal/coaching/application/port/readers.go
+++ b/internal/coaching/application/port/readers.go
@@ -1,0 +1,112 @@
+package port
+
+import (
+	"context"
+	"time"
+)
+
+// Slot represents a user's available training window.
+type Slot struct {
+	DayOfWeek time.Weekday
+	StartTime string // "HH:MM"
+	EndTime   string // "HH:MM"
+}
+
+// InjuryStatus is a compact summary of one active injury.
+type InjuryStatus struct {
+	MuscleGroup  string
+	ReportedAt   time.Time
+	RecoveredAt  *time.Time
+	Notes        string
+}
+
+// Profile is what Coaching needs from the Profile bounded context.
+type Profile struct {
+	UserID                string
+	WeightKg              float64
+	HeightCm              float64
+	Age                   int
+	PrimaryGoal           string
+	AvailableEquipment    []string
+	PreferredMuscleGroups []string
+	AvailableSlots        []Slot
+	ActiveInjuries        []InjuryStatus
+	UpdatedAt             time.Time
+}
+
+// UserProfileReader is the port for querying the Profile bounded context.
+type UserProfileReader interface {
+	GetProfile(ctx context.Context, userID string) (Profile, error)
+}
+
+// WorkoutSession is the subset of workout execution data Coaching needs.
+type WorkoutSession struct {
+	SessionID        string
+	UserID           string
+	PlanID           string
+	CompletedAt      time.Time
+	TotalSets        int
+	TotalPrescribed  int
+	AverageRPE       float64
+	AverageFormScore float64
+	Aborted          bool
+	AbortReason      string
+}
+
+// SetLog is a minimal set-level record used by 1RM estimation.
+type SetLog struct {
+	ExerciseID string
+	Weight     float64
+	Reps       int
+	RPE        float64
+	CompletedAt time.Time
+}
+
+// WorkoutSessionReader is the port for querying execution history.
+type WorkoutSessionReader interface {
+	GetRecentSessions(ctx context.Context, userID string, since time.Time) ([]WorkoutSession, error)
+	GetSetLogs(ctx context.Context, userID string, exerciseID string, limit int) ([]SetLog, error)
+}
+
+// ExerciseFilter is the search filter used by Agent Tools.
+type ExerciseFilter struct {
+	MuscleGroup      string
+	Equipment        []string
+	DifficultyLevel  string
+	ExcludeMuscle    string
+	Limit            int
+}
+
+// Exercise is the minimal exercise info Coaching consumes.
+type Exercise struct {
+	ExerciseID    string
+	Name          string
+	MuscleGroup   string
+	Equipment     string
+	Difficulty    string
+	IsBodyweight  bool
+	IsMachineOrCable bool
+}
+
+// ExerciseCatalogReader is the port for querying the Exercise catalog.
+type ExerciseCatalogReader interface {
+	SearchByFilter(ctx context.Context, f ExerciseFilter) ([]Exercise, error)
+	GetByID(ctx context.Context, exerciseID string) (Exercise, error)
+}
+
+// Notifier delivers personality-styled messages to the user. Phase-1 uses a
+// stub logger implementation.
+type Notifier interface {
+	Send(ctx context.Context, userID string, message string, promptID string) error
+}
+
+// UserResponse is what UserResponseWaiter returns when the user replies.
+type UserResponse struct {
+	Choice string // opaque option code chosen by the user
+}
+
+// UserResponseWaiter blocks (with timeout) waiting for the user to reply to a
+// prompt sent by Notifier. Phase-1 uses an in-memory dev stub.
+type UserResponseWaiter interface {
+	Wait(ctx context.Context, promptID string, timeout time.Duration) (UserResponse, error)
+}

--- a/internal/coaching/application/query/queries.go
+++ b/internal/coaching/application/query/queries.go
@@ -1,0 +1,93 @@
+// Package query holds read-only handlers.
+package query
+
+import (
+	"context"
+	"errors"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+)
+
+// GetActiveRoadmapQuery is the input to the corresponding query.
+type GetActiveRoadmapQuery struct{ UserID string }
+
+// GetRoadmapQuery is the input to GetRoadmap.
+type GetRoadmapQuery struct {
+	UserID    string
+	RoadmapID string
+}
+
+// ListRoadmapsQuery filters user roadmaps.
+type ListRoadmapsQuery struct {
+	UserID string
+	Status roadmap.RoadmapStatus // optional
+	Limit  int
+	Offset int
+}
+
+// GetSessionPlanQuery is the input to GetSessionPlan.
+type GetSessionPlanQuery struct {
+	UserID        string
+	SessionPlanID string
+}
+
+// Handlers exposes all read-side operations.
+type Handlers struct {
+	repo port.RoadmapRepository
+}
+
+// NewHandlers wires the query bundle.
+func NewHandlers(repo port.RoadmapRepository) *Handlers {
+	return &Handlers{repo: repo}
+}
+
+// GetActiveRoadmap returns the active roadmap for a user.
+func (h *Handlers) GetActiveRoadmap(ctx context.Context, q GetActiveRoadmapQuery) (*roadmap.Roadmap, error) {
+	if q.UserID == "" {
+		return nil, errors.New("user_id required")
+	}
+	return h.repo.FindActiveByUser(ctx, q.UserID)
+}
+
+// GetRoadmap fetches a specific roadmap by id, verifying ownership.
+func (h *Handlers) GetRoadmap(ctx context.Context, q GetRoadmapQuery) (*roadmap.Roadmap, error) {
+	if q.UserID == "" || q.RoadmapID == "" {
+		return nil, errors.New("user_id and roadmap_id required")
+	}
+	rm, err := h.repo.FindByID(ctx, q.RoadmapID)
+	if err != nil {
+		return nil, err
+	}
+	if rm.UserID() != q.UserID {
+		return nil, roadmap.ErrRoadmapNotFound
+	}
+	return rm, nil
+}
+
+// ListRoadmaps returns paginated roadmaps.
+func (h *Handlers) ListRoadmaps(ctx context.Context, q ListRoadmapsQuery) ([]*roadmap.Roadmap, error) {
+	if q.UserID == "" {
+		return nil, errors.New("user_id required")
+	}
+	return h.repo.ListByUser(ctx, q.UserID, q.Status, q.Limit, q.Offset)
+}
+
+// GetSessionPlan returns the session by id (with ownership check via parent roadmap).
+func (h *Handlers) GetSessionPlan(ctx context.Context, q GetSessionPlanQuery) (*roadmap.SessionPlan, error) {
+	if q.UserID == "" || q.SessionPlanID == "" {
+		return nil, errors.New("user_id and session_plan_id required")
+	}
+	rm, err := h.repo.FindSessionByID(ctx, q.SessionPlanID)
+	if err != nil {
+		return nil, err
+	}
+	if rm.UserID() != q.UserID {
+		return nil, roadmap.ErrRoadmapNotFound
+	}
+	s, ok := rm.FindSession(q.SessionPlanID)
+	if !ok {
+		return nil, roadmap.ErrSessionNotFound
+	}
+	return s, nil
+}

--- a/internal/coaching/application/query/suggest_ad_hoc_session.go
+++ b/internal/coaching/application/query/suggest_ad_hoc_session.go
@@ -1,0 +1,70 @@
+package query
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/contextbuilder"
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+)
+
+// SuggestAdHocSessionQuery is the read-only input for Flow 5.
+type SuggestAdHocSessionQuery struct {
+	UserID string
+	Hint   port.AdHocHint
+}
+
+// SuggestAdHocSessionHandler runs the ad-hoc session recommendation flow.
+// Read-only: no roadmap mutation, no outbox event, no transaction.
+// The frontend decides what to do with the returned suggestion.
+type SuggestAdHocSessionHandler struct {
+	repo    port.RoadmapRepository
+	agent   port.CoachAgent
+	builder *contextbuilder.Builder
+	clock   port.Clock
+}
+
+// NewSuggestAdHocSessionHandler wires the handler.
+func NewSuggestAdHocSessionHandler(
+	repo port.RoadmapRepository,
+	agent port.CoachAgent,
+	builder *contextbuilder.Builder,
+	clock port.Clock,
+) *SuggestAdHocSessionHandler {
+	return &SuggestAdHocSessionHandler{repo: repo, agent: agent, builder: builder, clock: clock}
+}
+
+// Handle returns a SuggestedSession for the user. If the user has no active
+// roadmap, the suggestion still works — it just uses Accumulation defaults.
+func (h *SuggestAdHocSessionHandler) Handle(ctx context.Context, q SuggestAdHocSessionQuery) (port.SuggestedSession, error) {
+	if q.UserID == "" {
+		return port.SuggestedSession{}, errors.New("user_id required")
+	}
+	now := h.clock.Now()
+
+	// Load active roadmap if any (drives phase / injury awareness).
+	var active *roadmap.Roadmap
+	rm, err := h.repo.FindActiveByUser(ctx, q.UserID)
+	if err == nil {
+		active = rm
+	} else if !errors.Is(err, roadmap.ErrRoadmapNotFound) {
+		return port.SuggestedSession{}, err
+	}
+
+	cc, err := h.builder.Build(ctx, port.FlowSuggestAdHocSession, q.UserID, active, now)
+	if err != nil {
+		return port.SuggestedSession{}, err
+	}
+
+	// If the hint overrides equipment, patch the CoachContext copy.
+	if len(q.Hint.AvailableEquipment) > 0 {
+		cc.Profile.AvailableEquipment = q.Hint.AvailableEquipment
+	}
+
+	return h.agent.SuggestAdHocSession(ctx, cc, q.Hint)
+}
+
+// Compile-time no-op to hint the reader that this handler is read-only.
+var _ = time.Now

--- a/internal/coaching/application/query/suggest_ad_hoc_session_test.go
+++ b/internal/coaching/application/query/suggest_ad_hoc_session_test.go
@@ -1,0 +1,150 @@
+package query
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/contextbuilder"
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+	"github.com/viethung213/gym-companion/internal/coaching/infrastructure/ai"
+)
+
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) Now() time.Time { return c.t }
+
+type incrIDs struct{ n int }
+
+func (i *incrIDs) NewID() string {
+	i.n++
+	return "id-" + strconv.Itoa(i.n)
+}
+
+// memRepo — minimal implementation of port.RoadmapRepository for tests.
+type memRepo struct{ active *roadmap.Roadmap }
+
+func (m *memRepo) Save(context.Context, *roadmap.Roadmap) error { return nil }
+func (m *memRepo) FindByID(context.Context, string) (*roadmap.Roadmap, error) {
+	return nil, roadmap.ErrRoadmapNotFound
+}
+func (m *memRepo) FindActiveByUser(context.Context, string) (*roadmap.Roadmap, error) {
+	if m.active != nil {
+		return m.active, nil
+	}
+	return nil, roadmap.ErrRoadmapNotFound
+}
+func (m *memRepo) ListByUser(context.Context, string, roadmap.RoadmapStatus, int, int) ([]*roadmap.Roadmap, error) {
+	return nil, nil
+}
+func (m *memRepo) FindSessionByID(context.Context, string) (*roadmap.Roadmap, error) {
+	return nil, roadmap.ErrSessionNotFound
+}
+
+type stubProfile struct{ p port.Profile }
+
+func (s *stubProfile) GetProfile(context.Context, string) (port.Profile, error) { return s.p, nil }
+
+type stubWorkouts struct{}
+
+func (stubWorkouts) GetRecentSessions(context.Context, string, time.Time) ([]port.WorkoutSession, error) {
+	return nil, nil
+}
+func (stubWorkouts) GetSetLogs(context.Context, string, string, int) ([]port.SetLog, error) {
+	return nil, nil
+}
+
+func buildSuggestHandler(t *testing.T) *SuggestAdHocSessionHandler {
+	t.Helper()
+	clock := &fakeClock{t: time.Date(2026, 7, 28, 8, 0, 0, 0, time.UTC)}
+	agent := ai.NewMockCoachAgent(&incrIDs{}, clock)
+	builder := contextbuilder.NewBuilder(
+		&stubProfile{p: port.Profile{
+			UserID:                "u-1",
+			PrimaryGoal:           "MUSCLE_GAIN",
+			PreferredMuscleGroups: []string{"back"},
+			AvailableEquipment:    []string{"BARBELL"},
+		}},
+		stubWorkouts{},
+		contextbuilder.NewStaticPromptRegistry(),
+	)
+	return NewSuggestAdHocSessionHandler(&memRepo{}, agent, builder, clock)
+}
+
+func TestSuggestAdHocSession_HappyPath_NoActiveRoadmap(t *testing.T) {
+	h := buildSuggestHandler(t)
+	got, err := h.Handle(context.Background(), SuggestAdHocSessionQuery{
+		UserID: "u-1",
+		Hint:   port.AdHocHint{FreeText: "quick back session"},
+	})
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(got.Prescription.MainExercises) == 0 {
+		t.Errorf("expected main exercises, got empty")
+	}
+	if len(got.MuscleGroups) == 0 {
+		t.Errorf("expected muscle groups")
+	}
+	if got.EstimatedRPE == 0 {
+		t.Errorf("expected non-zero EstimatedRPE")
+	}
+}
+
+func TestSuggestAdHocSession_HintOverridesMuscleGroups(t *testing.T) {
+	h := buildSuggestHandler(t)
+	got, err := h.Handle(context.Background(), SuggestAdHocSessionQuery{
+		UserID: "u-1",
+		Hint:   port.AdHocHint{MuscleGroups: []string{"legs"}},
+	})
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(got.MuscleGroups) != 1 || got.MuscleGroups[0] != "legs" {
+		t.Errorf("expected legs override, got %v", got.MuscleGroups)
+	}
+}
+
+func TestSuggestAdHocSession_DurationCap_ShrinksSets(t *testing.T) {
+	h := buildSuggestHandler(t)
+	// 15 minutes - 10' overhead = 5' → floor(5/3) = 1 set max
+	got, err := h.Handle(context.Background(), SuggestAdHocSessionQuery{
+		UserID: "u-1",
+		Hint:   port.AdHocHint{DurationMinutes: 15},
+	})
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	totalSets := 0
+	for _, ex := range got.Prescription.MainExercises {
+		totalSets += int(ex.TargetSets)
+	}
+	if totalSets > 1 {
+		t.Errorf("expected total sets <= 1 for 15min budget, got %d", totalSets)
+	}
+}
+
+func TestSuggestAdHocSession_IntensityHintAffectsRPE(t *testing.T) {
+	h := buildSuggestHandler(t)
+	light, _ := h.Handle(context.Background(), SuggestAdHocSessionQuery{
+		UserID: "u-1", Hint: port.AdHocHint{IntensityHint: "light"},
+	})
+	hard, _ := h.Handle(context.Background(), SuggestAdHocSessionQuery{
+		UserID: "u-1", Hint: port.AdHocHint{IntensityHint: "hard"},
+	})
+	if light.EstimatedRPE >= hard.EstimatedRPE {
+		t.Errorf("light RPE (%v) should be < hard RPE (%v)", light.EstimatedRPE, hard.EstimatedRPE)
+	}
+}
+
+func TestSuggestAdHocSession_MissingUserID(t *testing.T) {
+	h := buildSuggestHandler(t)
+	_, err := h.Handle(context.Background(), SuggestAdHocSessionQuery{})
+	if err == nil {
+		t.Errorf("expected error for missing user_id")
+	}
+	_ = errors.Is
+}

--- a/internal/coaching/docs/design.md
+++ b/internal/coaching/docs/design.md
@@ -35,14 +35,13 @@ flowchart LR
 
 ---
 
-### ⚪ Core Flow 2.1 — Mở App ngoài giờ tập (`Dashboard / Non-Workout Hours Flow`)
-- **Kích hoạt khi**: Học viên mở App vào các thời điểm ngoài khung giờ tập (`slot_time`).
-- **Hành vi hệ thống**: **KHÔNG gọi AI Agent** để tiết kiệm tài nguyên.
-- **Màn hình Dashboard hiển thị (đọc trực tiếp từ DB)**:
-  1. **Lộ trình hiện tại**: Hiển thị Tiến độ Lộ trình 4 tuần (Ví dụ: `Tuần 2 / 4 - Pha Overload`).
-  2. **Buổi tập sắp tới**: Hiển thị tóm tắt `SessionPlan` tiếp theo (`status = PENDING`) kèm đồng hồ đếm ngược / nhắc nhở khung giờ tập (`slot_time`).
-  3. **Tiến độ Tuần**: Tỷ lệ hoàn thành buổi tập trong tuần (Ví dụ: `3/4 buổi completed`).
-  4. **Các nút thao tác chủ động**: *"Xem chi tiết Lịch 4 tuần"*, *"Yêu cầu đổi lịch tập"* (`RegenerateSchedule`), *"Khai báo chấn thương mới"*.
+### ⚪ Core Flow 2.1 — Mở App ngoài giờ tập
+1. Khi hết plan, ngày rest, hoặc ngoài roadmap.
+2. Chọn list bài tập: **tự chọn** (FE gọi Exercise catalog) hoặc **yêu cầu Coach AI gợi ý** (FE gọi Coaching `SuggestAdHocSession` — read-only, không lưu DB).
+3. User được chỉnh sửa list (swap/add/remove/đổi sets/weight) trước khi bắt đầu.
+4. Bấm "Bắt đầu tập" → FE gọi Workout Execution.
+5. Xong buổi → Workout Execution phát event **`AdHocWorkoutCompleted`** (event mới, tách với `WorkoutSessionCompleted`).
+6. Coaching lắng nghe, backfill `SessionPlan status=COMPLETED` vào Roadmap `ACTIVE` (nếu có), phát `RoadmapAdjusted{reason: "ad_hoc_workout_completed"}`. **Không apply BR-AC-01**.
 
 ---
 

--- a/internal/coaching/docs/design.md
+++ b/internal/coaching/docs/design.md
@@ -105,3 +105,19 @@ internal/coaching/
 | `search_eligible_exercises` | Tìm bài tập hợp lệ theo thiết bị & nhóm cơ |
 | `replace_injured_exercises` | Tìm bài tập thay thế an toàn né vùng chấn thương |
 | `get_exercise_history` | Đọc lịch sử 1RM & tạ PR gần nhất |
+
+---
+
+## 5. Danh mục Sự kiện Bất đồng bộ (Event Integration Contracts)
+
+### Consumed Events (Sự kiện đầu vào)
+- `contracts.supporting.profile.v1.event.ProfileCompletedEventPayload` $\rightarrow$ Kích hoạt `InitiateRoadmap`.
+- `contracts.supporting.profile.v1.event.ProfileUpdated` $\rightarrow$ Kích hoạt `RegenerateSchedule` (FR-AC-06).
+- `contracts.supporting.profile.v1.event.InjuryReported` / `InjuryRecovered` $\rightarrow$ Kích hoạt thích ứng chấn thương.
+- `contracts.core.workout_execution.v1.event.WorkoutSessionCompleted` $\rightarrow$ Nghiệm thu `SessionPlan` (`status = COMPLETED`) và tính $SCR$, $\Delta RPE$.
+- **`contracts.core.workout_execution.v1.event.WorkoutSessionAborted`** $\rightarrow$ **Cập nhật `SessionPlan.status = SKIPPED`** khi học viên bỏ dở buổi tập / bị timeout.
+
+### Produced Events (Sự kiện đầu ra)
+- `contracts.core.coaching.v1.event.RoadmapInitiatedEventPayload` $\rightarrow$ Báo tin khởi tạo Lộ trình 4 tuần.
+- `contracts.core.coaching.v1.event.RoadmapAdjustedEventPayload` $\rightarrow$ Báo tin re-generate giáo án tương lai.
+- `contracts.core.coaching.v1.event.SessionPlanExecutedEventPayload` $\rightarrow$ Báo tin hoàn thành buổi tập (kèm chỉ số $SCR$ & $\Delta RPE$).

--- a/internal/coaching/docs/expected_events.md
+++ b/internal/coaching/docs/expected_events.md
@@ -1,0 +1,141 @@
+# Coaching — Expected Inbound Events
+
+Coaching Context is decoupled at runtime from the other bounded contexts (D2).
+Adapters that implement the reader ports may be **stub** during phase-1. This
+file documents the minimum event shape Coaching expects from each producer so
+the concrete Kafka consumers can be wired later without changing the domain or
+application layer.
+
+All events are wrapped in CloudEvents 1.0 envelopes. Coaching parses the
+envelope, uses `id` for idempotency (via `coaching.outbox_log`), and dispatches
+based on `type`.
+
+---
+
+## Workout Execution → Coaching
+
+### `contracts.core.workout_execution.v1.event.WorkoutSessionCompleted`
+
+Handler: `command.CompleteSessionHandler`
+Effect: Marks the SessionPlan referenced by `plan_id` as COMPLETED, computes
+SCR and ΔRPE, emits `SessionPlanExecuted`.
+
+```json
+{
+  "session_id":          "string (workout execution session id)",
+  "user_id":             "string",
+  "completed_at":        "RFC3339 timestamp",
+  "total_sets":          42,
+  "total_volume":        1234.5,
+  "average_form_score":  85.0,
+  "average_rpe":         7.5,
+  "plan_id":             "coaching SessionPlan id"
+}
+```
+
+Notes:
+- `plan_id` MUST equal a coaching `session_plan_id`. Coaching drops events with empty `plan_id`.
+- If `plan_id` refers to an already-final session, the handler is idempotent (no-op).
+- D7: `average_rpe` is a scalar; ΔRPE = `average_rpe − week.target_rpe`.
+
+### `contracts.core.workout_execution.v1.event.WorkoutSessionAborted`
+
+Handler: `command.AbortSessionHandler`
+Effect: Marks the SessionPlan referenced by `plan_id` as SKIPPED.
+
+```json
+{
+  "session_id":  "string",
+  "user_id":     "string",
+  "aborted_at":  "RFC3339 timestamp",
+  "reason":      "timeout | user_cancelled | ...",
+  "plan_id":     "coaching SessionPlan id"
+}
+```
+
+Notes:
+- Per commit 85b9647, aborted workouts map to SKIPPED (no separate ABORTED state).
+
+---
+
+## Profile → Coaching (planned; consumer not yet wired)
+
+The following contracts are not yet consumed at runtime but the ports and
+handlers exist. When the Profile bounded context emits them, wire a Kafka
+consumer that dispatches to the corresponding coaching handler.
+
+### `ProfileCompleted`
+
+Handler: `command.InitiateRoadmapHandler`
+Effect: Kick off UC-02.1 for the user.
+
+Minimum shape needed:
+```json
+{ "user_id": "string" }
+```
+
+### `ProfileUpdated`
+
+Handler: `command.RegenerateScheduleHandler` with `reason=profile_updated`.
+Effect: Regenerate PENDING sessions from today onward.
+
+```json
+{ "user_id": "string" }
+```
+
+### `InjuryReported`
+
+Handler: `command.RegenerateScheduleHandler` with `reason=injury_reported`.
+Effect: Regenerate PENDING sessions; exclude affected muscle group.
+
+```json
+{ "user_id": "string", "muscle_group": "string" }
+```
+
+### `InjuryRecovered`
+
+Handler: `command.RegenerateScheduleHandler` with `reason=injury_recovered`.
+Effect: Post-injury protective window (BR-AC-09).
+
+```json
+{ "user_id": "string", "muscle_group": "string" }
+```
+
+---
+
+## Read-only flow — no event emitted
+
+### Flow 5: Ad-hoc session suggestion
+
+Handler: `query.SuggestAdHocSessionHandler`
+Endpoint: (not yet exposed via gRPC — internal query for now)
+
+Request: `SuggestAdHocSessionQuery{ UserID, Hint { FreeText, MuscleGroups, AvailableEquipment, DurationMinutes, IntensityHint } }`
+
+Response: `port.SuggestedSession { MuscleGroups, Prescription, Reasoning, EstimatedRPE }`
+
+Behaviour:
+- Read-only. **No DB write, no outbox event, no transaction.**
+- Loads active roadmap only to seed phase context (Accumulation default if absent).
+- Injury awareness: `InjuryStatus` from profile filters exercises.
+- Duration cap: shrinks main-exercise set counts to fit budget.
+- Intensity hint (`light` / `normal` / `hard`) tunes weight scaling + target RPE.
+
+Rationale: user's flow "bấm bắt đầu tập ngoài lịch → 2 lựa chọn":
+1. **Gọi agent gợi ý** → gọi handler này, agent trả về draft, frontend hiển thị.
+2. **Pick tay từ catalog** → frontend gọi thẳng Exercise service, không đụng coaching.
+
+Cả 2 nhánh sau khi user chốt sẽ bàn giao cho Workout Execution để tập thật. Nếu user muốn thêm buổi này vào roadmap chính thức, đó là 1 quyết định riêng (chưa impl — sẽ là RegenerateSchedule hoặc AddAdHocSession command).
+
+---
+
+## Coaching → Downstream (produced events)
+
+Coaching writes these CloudEvents to `coaching.outbox`. The `OutboxWorker`
+publishes them to Kafka.
+
+| Type | Trigger | Payload fields |
+|---|---|---|
+| `contracts.core.coaching.v1.event.RoadmapInitiated` | UC-02.1 success | `roadmap_id`, `user_id`, `initiated_at` |
+| `contracts.core.coaching.v1.event.RoadmapAdjusted` | UC-02.3, Trigger A, Signal B*, injury handling, WorkoutSessionAborted | `roadmap_id`, `user_id`, `reason`, `adjusted_at` |
+| `contracts.core.coaching.v1.event.SessionPlanExecuted` | WorkoutSessionCompleted → CompleteSession | `session_plan_id`, `roadmap_id`, `user_id`, `executed_at`, `session_scr`, `session_delta_rpe` |

--- a/internal/coaching/domain/event/events.go
+++ b/internal/coaching/domain/event/events.go
@@ -1,0 +1,53 @@
+// Package event contains value-object domain events emitted by the Coaching
+// aggregate. Each event carries an EventName() matching the CloudEvent type
+// used across the platform.
+package event
+
+import "time"
+
+// Event is the marker interface all coaching domain events satisfy.
+type Event interface {
+	EventName() string
+}
+
+// RoadmapInitiated is published after a fresh 4-week roadmap is stored.
+type RoadmapInitiated struct {
+	RoadmapID   string    `json:"roadmapId"`
+	UserID      string    `json:"userId"`
+	InitiatedAt time.Time `json:"initiatedAt"`
+}
+
+// EventName returns the CloudEvent type identifier.
+func (e *RoadmapInitiated) EventName() string {
+	return "contracts.core.coaching.v1.event.RoadmapInitiated"
+}
+
+// RoadmapAdjusted is published after a roadmap mutation (Regenerate, adaptive
+// cycle, signal handling, injury recovery).
+type RoadmapAdjusted struct {
+	RoadmapID  string    `json:"roadmapId"`
+	UserID     string    `json:"userId"`
+	Reason     string    `json:"reason"`
+	AdjustedAt time.Time `json:"adjustedAt"`
+}
+
+// EventName returns the CloudEvent type identifier.
+func (e *RoadmapAdjusted) EventName() string {
+	return "contracts.core.coaching.v1.event.RoadmapAdjusted"
+}
+
+// SessionPlanExecuted is published after a SessionPlan transitions to COMPLETED
+// and SCR / ΔRPE have been computed.
+type SessionPlanExecuted struct {
+	SessionPlanID   string    `json:"sessionPlanId"`
+	RoadmapID       string    `json:"roadmapId"`
+	UserID          string    `json:"userId"`
+	ExecutedAt      time.Time `json:"executedAt"`
+	SessionSCR      float32   `json:"sessionScr"`
+	SessionDeltaRPE float32   `json:"sessionDeltaRpe"`
+}
+
+// EventName returns the CloudEvent type identifier.
+func (e *SessionPlanExecuted) EventName() string {
+	return "contracts.core.coaching.v1.event.SessionPlanExecuted"
+}

--- a/internal/coaching/domain/event/events_test.go
+++ b/internal/coaching/domain/event/events_test.go
@@ -1,0 +1,24 @@
+package event
+
+import "testing"
+
+func TestEventNames(t *testing.T) {
+	tests := []struct {
+		name string
+		evt  Event
+		want string
+	}{
+		{"RoadmapInitiated", &RoadmapInitiated{}, "contracts.core.coaching.v1.event.RoadmapInitiated"},
+		{"RoadmapAdjusted", &RoadmapAdjusted{}, "contracts.core.coaching.v1.event.RoadmapAdjusted"},
+		{"SessionPlanExecuted", &SessionPlanExecuted{}, "contracts.core.coaching.v1.event.SessionPlanExecuted"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.evt.EventName(); got != tt.want {
+				t.Errorf("EventName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/coaching/domain/roadmap/day_plan.go
+++ b/internal/coaching/domain/roadmap/day_plan.go
@@ -1,0 +1,117 @@
+package roadmap
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// DayPlanInfo is the value-object snapshot of a DayPlan entity.
+type DayPlanInfo struct {
+	DayPlanID      string
+	WeekPlanID     string
+	RoadmapID      string
+	UserID         string
+	ScheduledDate  time.Time
+	IsRestDay      bool
+}
+
+// DayPlan is an entity holding N SessionPlans for a single calendar day.
+type DayPlan struct {
+	info     DayPlanInfo
+	sessions []*SessionPlan
+}
+
+// NewDayPlan constructs an empty DayPlan.
+func NewDayPlan(info DayPlanInfo) (*DayPlan, error) {
+	info = normalizeDayInfo(info)
+	dp := &DayPlan{info: info, sessions: nil}
+	if err := dp.validate(); err != nil {
+		return nil, err
+	}
+	return dp, nil
+}
+
+// RehydrateDayPlan reconstructs a DayPlan with its sessions.
+func RehydrateDayPlan(info DayPlanInfo, sessions []*SessionPlan) (*DayPlan, error) {
+	info = normalizeDayInfo(info)
+	dp := &DayPlan{info: info, sessions: sessions}
+	if err := dp.validate(); err != nil {
+		return nil, err
+	}
+	return dp, nil
+}
+
+// Info returns a deep copy of the day plan snapshot.
+func (d *DayPlan) Info() DayPlanInfo { return d.info }
+
+// ID returns the day plan identifier.
+func (d *DayPlan) ID() string { return d.info.DayPlanID }
+
+// ScheduledDate returns the calendar date of this day plan.
+func (d *DayPlan) ScheduledDate() time.Time { return d.info.ScheduledDate }
+
+// IsRestDay reports whether this day is marked as rest.
+func (d *DayPlan) IsRestDay() bool { return d.info.IsRestDay }
+
+// Sessions returns the current sessions.
+// Modifying the returned slice does not mutate the aggregate.
+func (d *DayPlan) Sessions() []*SessionPlan {
+	if d.sessions == nil {
+		return nil
+	}
+	out := make([]*SessionPlan, len(d.sessions))
+	copy(out, d.sessions)
+	return out
+}
+
+// AddSession appends a new SessionPlan. On rest days this returns an error
+// because the domain forbids workouts on rest days.
+func (d *DayPlan) AddSession(s *SessionPlan) error {
+	if s == nil {
+		return fmt.Errorf("%w: nil session plan", ErrInvalidRoadmap)
+	}
+	if d.info.IsRestDay {
+		return fmt.Errorf("%w: cannot add session on rest day", ErrInvalidRoadmap)
+	}
+	d.sessions = append(d.sessions, s)
+	return nil
+}
+
+// FindSession looks up a session by ID.
+func (d *DayPlan) FindSession(sessionPlanID string) (*SessionPlan, bool) {
+	for _, s := range d.sessions {
+		if s.info.SessionPlanID == sessionPlanID {
+			return s, true
+		}
+	}
+	return nil, false
+}
+
+// SessionCount returns the number of sessions in this day.
+func (d *DayPlan) SessionCount() int { return len(d.sessions) }
+
+func (d *DayPlan) validate() error {
+	i := d.info
+	if i.DayPlanID == "" {
+		return fmt.Errorf("%w: day_plan_id is required", ErrInvalidRoadmap)
+	}
+	if i.WeekPlanID == "" {
+		return fmt.Errorf("%w: week_plan_id is required", ErrInvalidRoadmap)
+	}
+	if i.UserID == "" {
+		return fmt.Errorf("%w: user_id is required", ErrInvalidRoadmap)
+	}
+	if i.ScheduledDate.IsZero() {
+		return fmt.Errorf("%w: scheduled_date is required", ErrInvalidRoadmap)
+	}
+	return nil
+}
+
+func normalizeDayInfo(info DayPlanInfo) DayPlanInfo {
+	info.DayPlanID = strings.TrimSpace(info.DayPlanID)
+	info.WeekPlanID = strings.TrimSpace(info.WeekPlanID)
+	info.RoadmapID = strings.TrimSpace(info.RoadmapID)
+	info.UserID = strings.TrimSpace(info.UserID)
+	return info
+}

--- a/internal/coaching/domain/roadmap/enums.go
+++ b/internal/coaching/domain/roadmap/enums.go
@@ -1,0 +1,74 @@
+// Package roadmap contains the Roadmap aggregate and its child entities
+// (WeekPlan, DayPlan, SessionPlan) with 4-tier DDD structure.
+package roadmap
+
+// RoadmapStatus is the lifecycle status of a Roadmap aggregate.
+type RoadmapStatus string
+
+const (
+	RoadmapStatusActive    RoadmapStatus = "ACTIVE"
+	RoadmapStatusCompleted RoadmapStatus = "COMPLETED"
+)
+
+// Valid reports whether s is a known RoadmapStatus.
+func (s RoadmapStatus) Valid() bool {
+	switch s {
+	case RoadmapStatusActive, RoadmapStatusCompleted:
+		return true
+	default:
+		return false
+	}
+}
+
+// SessionPlanStatus is the lifecycle status of a SessionPlan entity.
+type SessionPlanStatus string
+
+const (
+	SessionPlanStatusPending   SessionPlanStatus = "PENDING"
+	SessionPlanStatusCompleted SessionPlanStatus = "COMPLETED"
+	SessionPlanStatusSkipped   SessionPlanStatus = "SKIPPED"
+)
+
+// Valid reports whether s is a known SessionPlanStatus.
+func (s SessionPlanStatus) Valid() bool {
+	switch s {
+	case SessionPlanStatusPending, SessionPlanStatusCompleted, SessionPlanStatusSkipped:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsFinal reports whether the session has reached a terminal state.
+func (s SessionPlanStatus) IsFinal() bool {
+	return s == SessionPlanStatusCompleted || s == SessionPlanStatusSkipped
+}
+
+// Phase is a training phase within the 4-week periodization model.
+type Phase string
+
+const (
+	PhaseAccumulation Phase = "ACCUMULATION"
+	PhaseOverload     Phase = "OVERLOAD"
+	PhasePeak         Phase = "PEAK"
+	PhaseDeload       Phase = "DELOAD"
+)
+
+// Valid reports whether p is a known Phase.
+func (p Phase) Valid() bool {
+	switch p {
+	case PhaseAccumulation, PhaseOverload, PhasePeak, PhaseDeload:
+		return true
+	default:
+		return false
+	}
+}
+
+// MaxSessionsPerWeek is the hard cap defined by BR-AC-01.
+const MaxSessionsPerWeek = 6
+
+// WeeksPerRoadmap is the fixed 4-week program length.
+const WeeksPerRoadmap = 4
+
+// DaysPerWeek is the fixed 7-day allocation per WeekPlan.
+const DaysPerWeek = 7

--- a/internal/coaching/domain/roadmap/errors.go
+++ b/internal/coaching/domain/roadmap/errors.go
@@ -1,0 +1,26 @@
+package roadmap
+
+import "errors"
+
+var (
+	// ErrInvalidRoadmap indicates the roadmap fails structural or business validation.
+	ErrInvalidRoadmap = errors.New("invalid roadmap")
+	// ErrInvalidStatus indicates an unknown or zero-value status.
+	ErrInvalidStatus = errors.New("invalid status")
+	// ErrInvalidPhase indicates an unknown or zero-value phase.
+	ErrInvalidPhase = errors.New("invalid phase")
+	// ErrInvalidTransition indicates an illegal lifecycle transition.
+	ErrInvalidTransition = errors.New("invalid state transition")
+	// ErrWeeklyCapExceeded is returned when adding sessions would exceed BR-AC-01 (6/week).
+	ErrWeeklyCapExceeded = errors.New("weekly session cap exceeded (BR-AC-01: max 6/week)")
+	// ErrSessionAlreadyFinal is returned when trying to mutate a COMPLETED or SKIPPED session.
+	ErrSessionAlreadyFinal = errors.New("session plan already reached final state")
+	// ErrSessionNotFound is returned when looking up a session by ID inside a Roadmap.
+	ErrSessionNotFound = errors.New("session plan not found")
+	// ErrRoadmapNotFound is used by repositories when the aggregate isn't found.
+	ErrRoadmapNotFound = errors.New("roadmap not found")
+	// ErrActiveRoadmapExists is returned when creating a new roadmap while an ACTIVE one exists.
+	ErrActiveRoadmapExists = errors.New("user already has an active roadmap")
+	// ErrInvalidWeekCount is returned when the roadmap doesn't contain exactly 4 weeks.
+	ErrInvalidWeekCount = errors.New("roadmap must contain exactly 4 week plans")
+)

--- a/internal/coaching/domain/roadmap/roadmap.go
+++ b/internal/coaching/domain/roadmap/roadmap.go
@@ -1,0 +1,158 @@
+package roadmap
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// RoadmapInfo is the value-object snapshot of the Roadmap aggregate root.
+type RoadmapInfo struct {
+	RoadmapID string
+	UserID    string
+	Status    RoadmapStatus
+	StartDate time.Time
+	EndDate   time.Time
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// Roadmap is the aggregate root managing a 4-week training program.
+type Roadmap struct {
+	info  RoadmapInfo
+	weeks []*WeekPlan
+}
+
+// NewRoadmap constructs a new ACTIVE roadmap with the given weeks attached.
+// weeks may be nil or partial; final validation happens on Save (Persist).
+func NewRoadmap(info RoadmapInfo, weeks []*WeekPlan, now time.Time) (*Roadmap, error) {
+	info = normalizeRoadmapInfo(info)
+	info.Status = RoadmapStatusActive
+	info.CreatedAt = now
+	info.UpdatedAt = now
+
+	r := &Roadmap{info: info, weeks: weeks}
+	if err := r.validate(); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// RehydrateRoadmap loads a Roadmap from persistence with its children.
+func RehydrateRoadmap(info RoadmapInfo, weeks []*WeekPlan) (*Roadmap, error) {
+	info = normalizeRoadmapInfo(info)
+	if !info.Status.Valid() {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidStatus, info.Status)
+	}
+	r := &Roadmap{info: info, weeks: weeks}
+	if err := r.validate(); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// Info returns the aggregate root snapshot.
+func (r *Roadmap) Info() RoadmapInfo { return r.info }
+
+// ID returns the roadmap identifier.
+func (r *Roadmap) ID() string { return r.info.RoadmapID }
+
+// UserID returns the owning user identifier.
+func (r *Roadmap) UserID() string { return r.info.UserID }
+
+// Status returns the current lifecycle status.
+func (r *Roadmap) Status() RoadmapStatus { return r.info.Status }
+
+// Weeks returns the child week plans.
+func (r *Roadmap) Weeks() []*WeekPlan {
+	if r.weeks == nil {
+		return nil
+	}
+	out := make([]*WeekPlan, len(r.weeks))
+	copy(out, r.weeks)
+	return out
+}
+
+// MarkCompleted transitions ACTIVE → COMPLETED. Idempotent when already COMPLETED.
+func (r *Roadmap) MarkCompleted(now time.Time) error {
+	if r.info.Status == RoadmapStatusCompleted {
+		return nil
+	}
+	if r.info.Status != RoadmapStatusActive {
+		return fmt.Errorf("%w: %s to %s", ErrInvalidTransition, r.info.Status, RoadmapStatusCompleted)
+	}
+	r.info.Status = RoadmapStatusCompleted
+	r.info.UpdatedAt = now
+	return nil
+}
+
+// Touch bumps updated_at without changing status. Used by mutation handlers.
+func (r *Roadmap) Touch(now time.Time) { r.info.UpdatedAt = now }
+
+// FindSession searches all weeks/days for a session by ID.
+func (r *Roadmap) FindSession(sessionPlanID string) (*SessionPlan, bool) {
+	for _, w := range r.weeks {
+		if s, ok := w.FindSession(sessionPlanID); ok {
+			return s, true
+		}
+	}
+	return nil, false
+}
+
+// PendingSessionsFrom returns all sessions with status PENDING and
+// scheduled_date >= from. Used by RegenerateSchedule (D3).
+func (r *Roadmap) PendingSessionsFrom(from time.Time) []*SessionPlan {
+	var out []*SessionPlan
+	for _, w := range r.weeks {
+		for _, d := range w.Days() {
+			for _, s := range d.Sessions() {
+				if s.Status() == SessionPlanStatusPending && !s.ScheduledDate().Before(from) {
+					out = append(out, s)
+				}
+			}
+		}
+	}
+	return out
+}
+
+func (r *Roadmap) validate() error {
+	i := r.info
+	if i.RoadmapID == "" {
+		return fmt.Errorf("%w: roadmap_id is required", ErrInvalidRoadmap)
+	}
+	if i.UserID == "" {
+		return fmt.Errorf("%w: user_id is required", ErrInvalidRoadmap)
+	}
+	if !i.Status.Valid() {
+		return fmt.Errorf("%w: %s", ErrInvalidStatus, i.Status)
+	}
+	if i.StartDate.IsZero() || i.EndDate.IsZero() {
+		return fmt.Errorf("%w: start/end date required", ErrInvalidRoadmap)
+	}
+	if !i.EndDate.After(i.StartDate) {
+		return fmt.Errorf("%w: end_date must be after start_date", ErrInvalidRoadmap)
+	}
+	// Enforce weekly cap per week (defense in depth; primary enforcement in WeekPlan.AddDay).
+	for _, w := range r.weeks {
+		if w.TotalSessions() > MaxSessionsPerWeek {
+			return fmt.Errorf("%w: week %d has %d sessions", ErrWeeklyCapExceeded, w.WeekNumber(), w.TotalSessions())
+		}
+	}
+	return nil
+}
+
+// ValidateFullStructure checks that the roadmap has exactly 4 weeks. Called by
+// InitiateRoadmapHandler before Save. Rehydration doesn't enforce this so that
+// partial reads work.
+func (r *Roadmap) ValidateFullStructure() error {
+	if len(r.weeks) != WeeksPerRoadmap {
+		return fmt.Errorf("%w: has %d weeks", ErrInvalidWeekCount, len(r.weeks))
+	}
+	return nil
+}
+
+func normalizeRoadmapInfo(info RoadmapInfo) RoadmapInfo {
+	info.RoadmapID = strings.TrimSpace(info.RoadmapID)
+	info.UserID = strings.TrimSpace(info.UserID)
+	return info
+}

--- a/internal/coaching/domain/roadmap/roadmap_test.go
+++ b/internal/coaching/domain/roadmap/roadmap_test.go
@@ -1,0 +1,202 @@
+package roadmap
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func newTestRoadmapInfo() RoadmapInfo {
+	return RoadmapInfo{
+		RoadmapID: "rm-1",
+		UserID:    "user-1",
+		StartDate: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		EndDate:   time.Date(2026, 8, 29, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func newDay(id string, date time.Time, weekPlanID string, sessionCount int) *DayPlan {
+	dp, _ := NewDayPlan(DayPlanInfo{
+		DayPlanID:     id,
+		WeekPlanID:    weekPlanID,
+		RoadmapID:     "rm-1",
+		UserID:        "user-1",
+		ScheduledDate: date,
+		IsRestDay:     sessionCount == 0,
+	})
+	now := time.Now()
+	for i := 0; i < sessionCount; i++ {
+		sp, _ := NewSessionPlan(SessionPlanInfo{
+			SessionPlanID: id + "-s" + string(rune('0'+i)),
+			DayPlanID:     id,
+			WeekPlanID:    weekPlanID,
+			RoadmapID:     "rm-1",
+			UserID:        "user-1",
+			ScheduledDate: date,
+		}, now)
+		_ = dp.AddSession(sp)
+	}
+	return dp
+}
+
+func newWeek(id string, num int32, phase Phase, weekStart time.Time, sessionsPerDay []int) *WeekPlan {
+	wp, _ := NewWeekPlan(WeekPlanInfo{
+		WeekPlanID: id,
+		RoadmapID:  "rm-1",
+		UserID:     "user-1",
+		WeekNumber: num,
+		Phase:      phase,
+		TargetRPE:  7.0,
+		StartDate:  weekStart,
+		EndDate:    weekStart.AddDate(0, 0, 6),
+	})
+	for i, n := range sessionsPerDay {
+		day := newDay(id+"-d"+string(rune('0'+i)), weekStart.AddDate(0, 0, i), id, n)
+		_ = wp.AddDay(day)
+	}
+	return wp
+}
+
+func TestNewRoadmap_DefaultsToActive(t *testing.T) {
+	now := time.Now()
+	r, err := NewRoadmap(newTestRoadmapInfo(), nil, now)
+	if err != nil {
+		t.Fatalf("NewRoadmap: %v", err)
+	}
+	if r.Status() != RoadmapStatusActive {
+		t.Errorf("status=%s, want ACTIVE", r.Status())
+	}
+}
+
+func TestNewRoadmap_ValidatesFields(t *testing.T) {
+	tests := []struct {
+		name string
+		mut  func(*RoadmapInfo)
+	}{
+		{"missing roadmap_id", func(i *RoadmapInfo) { i.RoadmapID = "" }},
+		{"missing user_id", func(i *RoadmapInfo) { i.UserID = "" }},
+		{"missing start_date", func(i *RoadmapInfo) { i.StartDate = time.Time{} }},
+		{"end before start", func(i *RoadmapInfo) { i.EndDate = i.StartDate.AddDate(0, 0, -1) }},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			info := newTestRoadmapInfo()
+			tt.mut(&info)
+			_, err := NewRoadmap(info, nil, time.Now())
+			if !errors.Is(err, ErrInvalidRoadmap) {
+				t.Errorf("expected ErrInvalidRoadmap, got %v", err)
+			}
+		})
+	}
+}
+
+func TestRoadmap_WeeklyCap_BR_AC_01(t *testing.T) {
+	// Try to add 7 sessions in one week (>6 = cap).
+	wp, err := NewWeekPlan(WeekPlanInfo{
+		WeekPlanID: "wp-1",
+		RoadmapID:  "rm-1",
+		UserID:     "user-1",
+		WeekNumber: 1,
+		Phase:      PhaseAccumulation,
+		TargetRPE:  7.0,
+		StartDate:  time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		EndDate:    time.Date(2026, 8, 7, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("NewWeekPlan: %v", err)
+	}
+	base := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	// Add 6 days each with 1 session — should succeed
+	for i := 0; i < 6; i++ {
+		day := newDay("wp-1-d"+string(rune('0'+i)), base.AddDate(0, 0, i), "wp-1", 1)
+		if err := wp.AddDay(day); err != nil {
+			t.Fatalf("AddDay %d: %v", i, err)
+		}
+	}
+	// 7th day with a session should exceed the cap
+	day := newDay("wp-1-d6", base.AddDate(0, 0, 6), "wp-1", 1)
+	err = wp.AddDay(day)
+	if !errors.Is(err, ErrWeeklyCapExceeded) {
+		t.Errorf("expected ErrWeeklyCapExceeded, got %v", err)
+	}
+}
+
+func TestRoadmap_MarkCompleted(t *testing.T) {
+	r, _ := NewRoadmap(newTestRoadmapInfo(), nil, time.Now())
+	now := time.Now().Add(28 * 24 * time.Hour)
+	if err := r.MarkCompleted(now); err != nil {
+		t.Fatalf("MarkCompleted: %v", err)
+	}
+	if r.Status() != RoadmapStatusCompleted {
+		t.Errorf("status=%s", r.Status())
+	}
+	// Idempotent
+	if err := r.MarkCompleted(now.Add(time.Hour)); err != nil {
+		t.Errorf("expected no-op, got %v", err)
+	}
+}
+
+func TestRoadmap_PendingSessionsFrom(t *testing.T) {
+	base := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	wp1 := newWeek("wp-1", 1, PhaseAccumulation, base, []int{1, 0, 1, 0, 1, 0, 0})
+	info := newTestRoadmapInfo()
+	r, err := NewRoadmap(info, []*WeekPlan{wp1}, time.Now())
+	if err != nil {
+		t.Fatalf("NewRoadmap: %v", err)
+	}
+
+	// From the beginning: 3 PENDING sessions
+	pending := r.PendingSessionsFrom(base)
+	if len(pending) != 3 {
+		t.Errorf("expected 3 pending, got %d", len(pending))
+	}
+
+	// Mark first as completed
+	_ = pending[0].MarkCompleted(80, 0, time.Now())
+	pending2 := r.PendingSessionsFrom(base)
+	if len(pending2) != 2 {
+		t.Errorf("expected 2 pending after complete, got %d", len(pending2))
+	}
+
+	// From day 3: skip earlier PENDING → only 2 sessions from day 3 onward (day 3 + day 5)
+	from := base.AddDate(0, 0, 2)
+	pending3 := r.PendingSessionsFrom(from)
+	if len(pending3) != 2 {
+		t.Errorf("expected 2 pending from day 3, got %d", len(pending3))
+	}
+}
+
+func TestRoadmap_FindSession(t *testing.T) {
+	base := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	wp1 := newWeek("wp-1", 1, PhaseAccumulation, base, []int{1, 0, 0, 0, 0, 0, 0})
+	r, _ := NewRoadmap(newTestRoadmapInfo(), []*WeekPlan{wp1}, time.Now())
+
+	if _, ok := r.FindSession("wp-1-d0-s0"); !ok {
+		t.Errorf("expected to find session wp-1-d0-s0")
+	}
+	if _, ok := r.FindSession("no-such-id"); ok {
+		t.Errorf("expected not to find bogus id")
+	}
+}
+
+func TestRoadmap_ValidateFullStructure_Requires4Weeks(t *testing.T) {
+	base := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	wp1 := newWeek("wp-1", 1, PhaseAccumulation, base, []int{0, 0, 0, 0, 0, 0, 0})
+	r, _ := NewRoadmap(newTestRoadmapInfo(), []*WeekPlan{wp1}, time.Now())
+	if err := r.ValidateFullStructure(); !errors.Is(err, ErrInvalidWeekCount) {
+		t.Errorf("expected ErrInvalidWeekCount for 1 week, got %v", err)
+	}
+
+	weeks := []*WeekPlan{
+		newWeek("wp-1", 1, PhaseAccumulation, base, []int{0, 0, 0, 0, 0, 0, 0}),
+		newWeek("wp-2", 2, PhaseOverload, base.AddDate(0, 0, 7), []int{0, 0, 0, 0, 0, 0, 0}),
+		newWeek("wp-3", 3, PhasePeak, base.AddDate(0, 0, 14), []int{0, 0, 0, 0, 0, 0, 0}),
+		newWeek("wp-4", 4, PhaseDeload, base.AddDate(0, 0, 21), []int{0, 0, 0, 0, 0, 0, 0}),
+	}
+	r2, _ := NewRoadmap(newTestRoadmapInfo(), weeks, time.Now())
+	if err := r2.ValidateFullStructure(); err != nil {
+		t.Errorf("expected no error for 4 weeks, got %v", err)
+	}
+}

--- a/internal/coaching/domain/roadmap/session_plan.go
+++ b/internal/coaching/domain/roadmap/session_plan.go
@@ -1,0 +1,218 @@
+package roadmap
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// PrescribedExercise is a single exercise line item within a WorkoutPrescription.
+type PrescribedExercise struct {
+	ExerciseID      string
+	ExerciseName    string
+	TargetSets      int32
+	TargetReps      int32
+	TargetWeight    float32
+	DurationSeconds int32
+	Notes           string
+	RestSetSec      int32
+	RestExerciseSec int32
+	TargetRPE       float32
+}
+
+// WorkoutPrescription is the value object describing the workout script.
+type WorkoutPrescription struct {
+	WarmUps       []PrescribedExercise
+	MainExercises []PrescribedExercise
+	CoolDowns     []PrescribedExercise
+}
+
+// SessionPlanInfo is the value-object snapshot of a SessionPlan entity.
+type SessionPlanInfo struct {
+	SessionPlanID       string
+	DayPlanID           string
+	WeekPlanID          string
+	RoadmapID           string
+	UserID              string
+	ScheduledDate       time.Time
+	SlotTime            string
+	Status              SessionPlanStatus
+	TargetMuscleGroups  []string
+	Prescription        WorkoutPrescription
+	Reasoning           string
+	GeneratedAt         time.Time
+	CompletedAt         *time.Time
+	SessionSCR          *float32
+	SessionDeltaRPE     *float32
+}
+
+// SessionPlan is an entity nested under DayPlan.
+type SessionPlan struct {
+	info SessionPlanInfo
+}
+
+// NewSessionPlan constructs a SessionPlan in PENDING status.
+func NewSessionPlan(info SessionPlanInfo, now time.Time) (*SessionPlan, error) {
+	info = normalizeSessionInfo(info)
+	info.Status = SessionPlanStatusPending
+	info.GeneratedAt = now
+	info.CompletedAt = nil
+	info.SessionSCR = nil
+	info.SessionDeltaRPE = nil
+
+	sp := &SessionPlan{info: info}
+	if err := sp.validate(); err != nil {
+		return nil, err
+	}
+	return sp, nil
+}
+
+// RehydrateSessionPlan loads a SessionPlan from persistence without applying
+// lifecycle defaults.
+func RehydrateSessionPlan(info SessionPlanInfo) (*SessionPlan, error) {
+	info = normalizeSessionInfo(info)
+	if !info.Status.Valid() {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidStatus, info.Status)
+	}
+
+	sp := &SessionPlan{info: info}
+	if err := sp.validate(); err != nil {
+		return nil, err
+	}
+	return sp, nil
+}
+
+// Info returns a deep copy of the session plan snapshot.
+func (s *SessionPlan) Info() SessionPlanInfo {
+	info := s.info
+	info.TargetMuscleGroups = copyStringSlice(s.info.TargetMuscleGroups)
+	info.Prescription = copyPrescription(s.info.Prescription)
+	if s.info.CompletedAt != nil {
+		t := *s.info.CompletedAt
+		info.CompletedAt = &t
+	}
+	if s.info.SessionSCR != nil {
+		v := *s.info.SessionSCR
+		info.SessionSCR = &v
+	}
+	if s.info.SessionDeltaRPE != nil {
+		v := *s.info.SessionDeltaRPE
+		info.SessionDeltaRPE = &v
+	}
+	return info
+}
+
+// ID returns the session plan identifier.
+func (s *SessionPlan) ID() string { return s.info.SessionPlanID }
+
+// Status returns the current lifecycle status.
+func (s *SessionPlan) Status() SessionPlanStatus { return s.info.Status }
+
+// ScheduledDate returns the calendar date the session is planned for.
+func (s *SessionPlan) ScheduledDate() time.Time { return s.info.ScheduledDate }
+
+// MarkCompleted transitions PENDING → COMPLETED and records execution metrics.
+// scr is Session Completion Rate (0-100); deltaRPE is scalar per D7.
+// Idempotent: calling on an already-COMPLETED session is a no-op.
+func (s *SessionPlan) MarkCompleted(scr, deltaRPE float32, now time.Time) error {
+	if s.info.Status == SessionPlanStatusCompleted {
+		return nil
+	}
+	if s.info.Status != SessionPlanStatusPending {
+		return fmt.Errorf("%w: %s to %s", ErrInvalidTransition, s.info.Status, SessionPlanStatusCompleted)
+	}
+	s.info.Status = SessionPlanStatusCompleted
+	completedAt := now
+	s.info.CompletedAt = &completedAt
+	scrCopy := scr
+	deltaCopy := deltaRPE
+	s.info.SessionSCR = &scrCopy
+	s.info.SessionDeltaRPE = &deltaCopy
+	return nil
+}
+
+// MarkSkipped transitions PENDING → SKIPPED. Used both for automatic skipping
+// when scheduled_date passes and for WorkoutSessionAborted events.
+// Idempotent: calling on an already-SKIPPED session is a no-op.
+func (s *SessionPlan) MarkSkipped() error {
+	if s.info.Status == SessionPlanStatusSkipped {
+		return nil
+	}
+	if s.info.Status != SessionPlanStatusPending {
+		return fmt.Errorf("%w: %s to %s", ErrInvalidTransition, s.info.Status, SessionPlanStatusSkipped)
+	}
+	s.info.Status = SessionPlanStatusSkipped
+	return nil
+}
+
+// RewritePrescription replaces the prescription content in-place while the
+// session is still PENDING (D3: Regenerate touches only PENDING sessions).
+func (s *SessionPlan) RewritePrescription(p WorkoutPrescription, muscleGroups []string, reasoning string, now time.Time) error {
+	if s.info.Status != SessionPlanStatusPending {
+		return fmt.Errorf("%w: cannot rewrite session in status %s", ErrSessionAlreadyFinal, s.info.Status)
+	}
+	s.info.Prescription = copyPrescription(p)
+	s.info.TargetMuscleGroups = copyStringSlice(muscleGroups)
+	s.info.Reasoning = strings.TrimSpace(reasoning)
+	s.info.GeneratedAt = now
+	return nil
+}
+
+func (s *SessionPlan) validate() error {
+	i := s.info
+	if i.SessionPlanID == "" {
+		return fmt.Errorf("%w: session_plan_id is required", ErrInvalidRoadmap)
+	}
+	if i.DayPlanID == "" {
+		return fmt.Errorf("%w: day_plan_id is required", ErrInvalidRoadmap)
+	}
+	if i.UserID == "" {
+		return fmt.Errorf("%w: user_id is required", ErrInvalidRoadmap)
+	}
+	if i.ScheduledDate.IsZero() {
+		return fmt.Errorf("%w: scheduled_date is required", ErrInvalidRoadmap)
+	}
+	if !i.Status.Valid() {
+		return fmt.Errorf("%w: %s", ErrInvalidStatus, i.Status)
+	}
+	return nil
+}
+
+func normalizeSessionInfo(info SessionPlanInfo) SessionPlanInfo {
+	info.SessionPlanID = strings.TrimSpace(info.SessionPlanID)
+	info.DayPlanID = strings.TrimSpace(info.DayPlanID)
+	info.WeekPlanID = strings.TrimSpace(info.WeekPlanID)
+	info.RoadmapID = strings.TrimSpace(info.RoadmapID)
+	info.UserID = strings.TrimSpace(info.UserID)
+	info.SlotTime = strings.TrimSpace(info.SlotTime)
+	info.Reasoning = strings.TrimSpace(info.Reasoning)
+	info.TargetMuscleGroups = copyStringSlice(info.TargetMuscleGroups)
+	info.Prescription = copyPrescription(info.Prescription)
+	return info
+}
+
+func copyPrescription(p WorkoutPrescription) WorkoutPrescription {
+	return WorkoutPrescription{
+		WarmUps:       copyExercises(p.WarmUps),
+		MainExercises: copyExercises(p.MainExercises),
+		CoolDowns:     copyExercises(p.CoolDowns),
+	}
+}
+
+func copyExercises(in []PrescribedExercise) []PrescribedExercise {
+	if in == nil {
+		return nil
+	}
+	out := make([]PrescribedExercise, len(in))
+	copy(out, in)
+	return out
+}
+
+func copyStringSlice(in []string) []string {
+	if in == nil {
+		return nil
+	}
+	out := make([]string, len(in))
+	copy(out, in)
+	return out
+}

--- a/internal/coaching/domain/roadmap/session_plan_test.go
+++ b/internal/coaching/domain/roadmap/session_plan_test.go
@@ -1,0 +1,181 @@
+package roadmap
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func newTestSessionInfo() SessionPlanInfo {
+	return SessionPlanInfo{
+		SessionPlanID: "sp-1",
+		DayPlanID:     "dp-1",
+		WeekPlanID:    "wp-1",
+		RoadmapID:     "rm-1",
+		UserID:        "user-1",
+		ScheduledDate: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		SlotTime:      "06:00-07:00",
+	}
+}
+
+func TestNewSessionPlan_DefaultsToPending(t *testing.T) {
+	now := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	sp, err := NewSessionPlan(newTestSessionInfo(), now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sp.Status() != SessionPlanStatusPending {
+		t.Errorf("expected PENDING, got %s", sp.Status())
+	}
+	if !sp.Info().GeneratedAt.Equal(now) {
+		t.Errorf("expected GeneratedAt=%v, got %v", now, sp.Info().GeneratedAt)
+	}
+	if sp.Info().CompletedAt != nil {
+		t.Errorf("expected CompletedAt nil, got %v", sp.Info().CompletedAt)
+	}
+}
+
+func TestNewSessionPlan_RequiresFields(t *testing.T) {
+	tests := []struct {
+		name string
+		give func() SessionPlanInfo
+	}{
+		{"missing id", func() SessionPlanInfo { i := newTestSessionInfo(); i.SessionPlanID = ""; return i }},
+		{"missing day_plan_id", func() SessionPlanInfo { i := newTestSessionInfo(); i.DayPlanID = ""; return i }},
+		{"missing user_id", func() SessionPlanInfo { i := newTestSessionInfo(); i.UserID = ""; return i }},
+		{"missing scheduled_date", func() SessionPlanInfo { i := newTestSessionInfo(); i.ScheduledDate = time.Time{}; return i }},
+	}
+	now := time.Now()
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewSessionPlan(tt.give(), now)
+			if !errors.Is(err, ErrInvalidRoadmap) {
+				t.Errorf("expected ErrInvalidRoadmap, got %v", err)
+			}
+		})
+	}
+}
+
+func TestSessionPlan_MarkCompleted(t *testing.T) {
+	now := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	sp, _ := NewSessionPlan(newTestSessionInfo(), now)
+
+	completedAt := now.Add(24 * time.Hour)
+	if err := sp.MarkCompleted(85.0, 0.5, completedAt); err != nil {
+		t.Fatalf("MarkCompleted: %v", err)
+	}
+	if sp.Status() != SessionPlanStatusCompleted {
+		t.Errorf("status = %s, want COMPLETED", sp.Status())
+	}
+	info := sp.Info()
+	if info.CompletedAt == nil || !info.CompletedAt.Equal(completedAt) {
+		t.Errorf("CompletedAt not set correctly")
+	}
+	if info.SessionSCR == nil || *info.SessionSCR != 85.0 {
+		t.Errorf("SCR not stored")
+	}
+	if info.SessionDeltaRPE == nil || *info.SessionDeltaRPE != 0.5 {
+		t.Errorf("ΔRPE not stored")
+	}
+}
+
+func TestSessionPlan_MarkCompleted_IdempotentAndBlocksSkipped(t *testing.T) {
+	now := time.Now()
+	sp, _ := NewSessionPlan(newTestSessionInfo(), now)
+	_ = sp.MarkCompleted(80, 0, now)
+
+	// Idempotent second call is no-op
+	if err := sp.MarkCompleted(90, 1, now.Add(time.Hour)); err != nil {
+		t.Errorf("expected no-op on second MarkCompleted, got %v", err)
+	}
+	if v := *sp.Info().SessionSCR; v != 80 {
+		t.Errorf("SCR overwritten: %v", v)
+	}
+
+	// Cannot mark skipped after completed
+	err := sp.MarkSkipped()
+	if !errors.Is(err, ErrInvalidTransition) {
+		t.Errorf("expected ErrInvalidTransition, got %v", err)
+	}
+}
+
+func TestSessionPlan_MarkSkipped_Idempotent(t *testing.T) {
+	now := time.Now()
+	sp, _ := NewSessionPlan(newTestSessionInfo(), now)
+	if err := sp.MarkSkipped(); err != nil {
+		t.Fatalf("MarkSkipped: %v", err)
+	}
+	// Idempotent
+	if err := sp.MarkSkipped(); err != nil {
+		t.Errorf("expected no-op on second MarkSkipped, got %v", err)
+	}
+	// Cannot complete after skipped
+	if err := sp.MarkCompleted(90, 0, now); !errors.Is(err, ErrInvalidTransition) {
+		t.Errorf("expected ErrInvalidTransition, got %v", err)
+	}
+}
+
+func TestSessionPlan_RewritePrescription_OnlyPending(t *testing.T) {
+	now := time.Now()
+	sp, _ := NewSessionPlan(newTestSessionInfo(), now)
+
+	newPresc := WorkoutPrescription{
+		MainExercises: []PrescribedExercise{
+			{ExerciseID: "ex-1", ExerciseName: "Bench Press", TargetSets: 4, TargetReps: 8, TargetWeight: 60},
+		},
+	}
+	if err := sp.RewritePrescription(newPresc, []string{"chest"}, "regen", now.Add(time.Hour)); err != nil {
+		t.Fatalf("RewritePrescription: %v", err)
+	}
+	if len(sp.Info().Prescription.MainExercises) != 1 {
+		t.Errorf("prescription not applied")
+	}
+	if sp.Info().Reasoning != "regen" {
+		t.Errorf("reasoning not applied")
+	}
+
+	// After completion, cannot rewrite
+	_ = sp.MarkCompleted(80, 0, now)
+	err := sp.RewritePrescription(newPresc, nil, "again", now.Add(2*time.Hour))
+	if !errors.Is(err, ErrSessionAlreadyFinal) {
+		t.Errorf("expected ErrSessionAlreadyFinal, got %v", err)
+	}
+}
+
+func TestSessionPlan_Info_ReturnsDeepCopy(t *testing.T) {
+	now := time.Now()
+	info := newTestSessionInfo()
+	info.TargetMuscleGroups = []string{"chest", "triceps"}
+	info.Prescription = WorkoutPrescription{
+		MainExercises: []PrescribedExercise{{ExerciseID: "e1"}},
+	}
+	sp, _ := NewSessionPlan(info, now)
+
+	got := sp.Info()
+	got.TargetMuscleGroups[0] = "MUTATED"
+	got.Prescription.MainExercises[0].ExerciseID = "MUTATED"
+
+	if sp.Info().TargetMuscleGroups[0] != "chest" {
+		t.Errorf("Info() didn't deep-copy TargetMuscleGroups")
+	}
+	if sp.Info().Prescription.MainExercises[0].ExerciseID != "e1" {
+		t.Errorf("Info() didn't deep-copy Prescription")
+	}
+}
+
+func TestSessionPlanStatus_Valid(t *testing.T) {
+	if !SessionPlanStatusPending.Valid() {
+		t.Error("PENDING should be valid")
+	}
+	if SessionPlanStatus("").Valid() {
+		t.Error("empty should be invalid")
+	}
+	if !SessionPlanStatusCompleted.IsFinal() {
+		t.Error("COMPLETED should be final")
+	}
+	if SessionPlanStatusPending.IsFinal() {
+		t.Error("PENDING should not be final")
+	}
+}

--- a/internal/coaching/domain/roadmap/week_plan.go
+++ b/internal/coaching/domain/roadmap/week_plan.go
@@ -1,0 +1,142 @@
+package roadmap
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// WeekPlanInfo is the value-object snapshot of a WeekPlan entity.
+type WeekPlanInfo struct {
+	WeekPlanID       string
+	RoadmapID        string
+	UserID           string
+	WeekNumber       int32
+	Phase            Phase
+	TargetRPE        float32
+	StartDate        time.Time
+	EndDate          time.Time
+	MuscleSplitType  string
+}
+
+// WeekPlan is an entity holding 7 DayPlans for one training week.
+type WeekPlan struct {
+	info WeekPlanInfo
+	days []*DayPlan
+}
+
+// NewWeekPlan constructs an empty WeekPlan.
+func NewWeekPlan(info WeekPlanInfo) (*WeekPlan, error) {
+	info = normalizeWeekInfo(info)
+	wp := &WeekPlan{info: info, days: nil}
+	if err := wp.validate(); err != nil {
+		return nil, err
+	}
+	return wp, nil
+}
+
+// RehydrateWeekPlan reconstructs a WeekPlan with its days.
+func RehydrateWeekPlan(info WeekPlanInfo, days []*DayPlan) (*WeekPlan, error) {
+	info = normalizeWeekInfo(info)
+	wp := &WeekPlan{info: info, days: days}
+	if err := wp.validate(); err != nil {
+		return nil, err
+	}
+	return wp, nil
+}
+
+// Info returns the week plan snapshot.
+func (w *WeekPlan) Info() WeekPlanInfo { return w.info }
+
+// ID returns the week plan identifier.
+func (w *WeekPlan) ID() string { return w.info.WeekPlanID }
+
+// WeekNumber returns 1..4.
+func (w *WeekPlan) WeekNumber() int32 { return w.info.WeekNumber }
+
+// Phase returns the periodization phase of this week.
+func (w *WeekPlan) Phase() Phase { return w.info.Phase }
+
+// Days returns the day plans.
+func (w *WeekPlan) Days() []*DayPlan {
+	if w.days == nil {
+		return nil
+	}
+	out := make([]*DayPlan, len(w.days))
+	copy(out, w.days)
+	return out
+}
+
+// AddDay appends a DayPlan (invariant: max 7 days, unique scheduled_date).
+func (w *WeekPlan) AddDay(day *DayPlan) error {
+	if day == nil {
+		return fmt.Errorf("%w: nil day plan", ErrInvalidRoadmap)
+	}
+	if len(w.days) >= DaysPerWeek {
+		return fmt.Errorf("%w: week already has %d days", ErrInvalidRoadmap, DaysPerWeek)
+	}
+	for _, d := range w.days {
+		if d.info.ScheduledDate.Equal(day.info.ScheduledDate) {
+			return fmt.Errorf("%w: duplicate scheduled_date %s", ErrInvalidRoadmap, day.info.ScheduledDate.Format("2006-01-02"))
+		}
+	}
+	// Enforce BR-AC-01 after add if the new day has sessions.
+	newTotal := w.totalSessions() + day.SessionCount()
+	if newTotal > MaxSessionsPerWeek {
+		return fmt.Errorf("%w: would total %d sessions (cap %d)", ErrWeeklyCapExceeded, newTotal, MaxSessionsPerWeek)
+	}
+	w.days = append(w.days, day)
+	return nil
+}
+
+// TotalSessions returns the total non-rest sessions across all days.
+func (w *WeekPlan) TotalSessions() int { return w.totalSessions() }
+
+func (w *WeekPlan) totalSessions() int {
+	total := 0
+	for _, d := range w.days {
+		total += d.SessionCount()
+	}
+	return total
+}
+
+// FindSession searches all days for a session by ID.
+func (w *WeekPlan) FindSession(sessionPlanID string) (*SessionPlan, bool) {
+	for _, d := range w.days {
+		if s, ok := d.FindSession(sessionPlanID); ok {
+			return s, true
+		}
+	}
+	return nil, false
+}
+
+func (w *WeekPlan) validate() error {
+	i := w.info
+	if i.WeekPlanID == "" {
+		return fmt.Errorf("%w: week_plan_id is required", ErrInvalidRoadmap)
+	}
+	if i.UserID == "" {
+		return fmt.Errorf("%w: user_id is required", ErrInvalidRoadmap)
+	}
+	if i.WeekNumber < 1 || i.WeekNumber > WeeksPerRoadmap {
+		return fmt.Errorf("%w: week_number must be 1..%d", ErrInvalidRoadmap, WeeksPerRoadmap)
+	}
+	if !i.Phase.Valid() {
+		return fmt.Errorf("%w: %s", ErrInvalidPhase, i.Phase)
+	}
+	if i.StartDate.IsZero() || i.EndDate.IsZero() {
+		return fmt.Errorf("%w: start/end date required", ErrInvalidRoadmap)
+	}
+	if w.totalSessions() > MaxSessionsPerWeek {
+		return fmt.Errorf("%w: %d sessions", ErrWeeklyCapExceeded, w.totalSessions())
+	}
+	return nil
+}
+
+func normalizeWeekInfo(info WeekPlanInfo) WeekPlanInfo {
+	info.WeekPlanID = strings.TrimSpace(info.WeekPlanID)
+	info.RoadmapID = strings.TrimSpace(info.RoadmapID)
+	info.UserID = strings.TrimSpace(info.UserID)
+	info.MuscleSplitType = strings.TrimSpace(info.MuscleSplitType)
+	return info
+}

--- a/internal/coaching/domain/service/adaptive_coach_engine.go
+++ b/internal/coaching/domain/service/adaptive_coach_engine.go
@@ -1,0 +1,218 @@
+package service
+
+import "time"
+
+// AdaptationKind classifies a decision emitted by AdaptiveCoachEngine.
+type AdaptationKind int
+
+const (
+	// AdaptationNoOp indicates no action is needed.
+	AdaptationNoOp AdaptationKind = iota
+	// AdaptationIncreaseLoad applies +2.5..5% weight next week (BR-AC-04 case 1).
+	AdaptationIncreaseLoad
+	// AdaptationTriggerDeload converts next week to Deload phase (BR-AC-04 case 2).
+	AdaptationTriggerDeload
+	// AdaptationProposeExpressFormat suggests 30-min sessions or fewer per week (BR-AC-04 case 3).
+	AdaptationProposeExpressFormat
+	// AdaptationSignalB1AcuteDropout indicates 3 consecutive skips or 7d inactivity.
+	AdaptationSignalB1AcuteDropout
+	// AdaptationSignalB2ScheduleMismatch indicates same-weekday skip 3+ weeks.
+	AdaptationSignalB2ScheduleMismatch
+	// AdaptationSignalB3UnscheduledWorkout indicates a workout logged outside schedule.
+	AdaptationSignalB3UnscheduledWorkout
+	// AdaptationSignalB4Plateau indicates 1RM stagnation ≥ 2 weeks (SCR ≥ 80%).
+	AdaptationSignalB4Plateau
+	// AdaptationPostInjuryProtect indicates 3-session protective window (BR-AC-09).
+	AdaptationPostInjuryProtect
+)
+
+// AdaptationDecision is a value object describing the recommended action.
+// Callers translate this into concrete SessionPlan mutations.
+type AdaptationDecision struct {
+	Kind       AdaptationKind
+	Reason     string
+	Params     AdaptationParams
+}
+
+// AdaptationParams carries per-kind numeric knobs. Only the fields relevant to
+// Kind are meaningful; the rest are zero.
+type AdaptationParams struct {
+	WeightPctChange float64  // e.g. +0.025 → +5%
+	VolumePctChange float64  // e.g. -0.30 for Deload
+	SessionsToDrop  int      // for Express/reduce recommendation
+	StaleWeekday    time.Weekday // for B2 mismatch
+	SessionIDs      []string // affected session IDs
+	MuscleGroup     string   // for post-injury
+}
+
+// WeeklyMetrics is the per-week aggregate used by Trigger A (BR-AC-04).
+type WeeklyMetrics struct {
+	WeekNumber      int32
+	SCR             float64  // Session Completion Rate (0..100)
+	AvgDeltaRPE     float64  // ΔRPE averaged across sessions
+	MaxActualRPE    float64  // Highest RPE observed
+	HighRPESessions int      // sessions with RPE ≥ 9.0
+	TotalSessions   int
+}
+
+// AdaptiveCoachEngine is a stateless domain service. All inputs are passed
+// explicitly; no repository lookup happens here.
+type AdaptiveCoachEngine struct{}
+
+// NewAdaptiveCoachEngine constructs the domain service.
+func NewAdaptiveCoachEngine() *AdaptiveCoachEngine { return &AdaptiveCoachEngine{} }
+
+// EvaluateTriggerA applies BR-AC-04 rules against the recent weekly metrics.
+// weeks: chronological order, weeks[len-1] is the most recent completed week.
+func (e *AdaptiveCoachEngine) EvaluateTriggerA(weeks []WeeklyMetrics) AdaptationDecision {
+	if len(weeks) == 0 {
+		return AdaptationDecision{Kind: AdaptationNoOp, Reason: "no data"}
+	}
+	last := weeks[len(weeks)-1]
+
+	// Case 3: SCR < 50% for 2 consecutive weeks → propose reduce/Express.
+	if len(weeks) >= 2 {
+		prev := weeks[len(weeks)-2]
+		if last.SCR < 50.0 && prev.SCR < 50.0 {
+			return AdaptationDecision{
+				Kind:   AdaptationProposeExpressFormat,
+				Reason: "SCR < 50% in 2 consecutive weeks",
+				Params: AdaptationParams{SessionsToDrop: 1},
+			}
+		}
+	}
+
+	// Case 2: Excessive fatigue → Deload.
+	// Trigger if 3+ sessions with RPE ≥ 9.0 OR avgΔRPE ≥ +2.0.
+	if last.HighRPESessions >= 3 || last.AvgDeltaRPE >= 2.0 {
+		return AdaptationDecision{
+			Kind:   AdaptationTriggerDeload,
+			Reason: "excessive fatigue (RPE≥9 x3 or ΔRPE≥+2)",
+			Params: AdaptationParams{
+				VolumePctChange: -0.30,
+				WeightPctChange: -0.10,
+			},
+		}
+	}
+
+	// Case 1: Progressive overload.
+	// SCR ≥ 80% AND -1 ≤ ΔRPE ≤ +1.
+	if last.SCR >= 80.0 && last.AvgDeltaRPE >= -1.0 && last.AvgDeltaRPE <= 1.0 {
+		// Pick +2.5% if ΔRPE ≥ 0 (already borderline hard), else +5%.
+		pct := 0.05
+		if last.AvgDeltaRPE >= 0 {
+			pct = 0.025
+		}
+		return AdaptationDecision{
+			Kind:   AdaptationIncreaseLoad,
+			Reason: "SCR ≥ 80% and ΔRPE in [-1, +1]",
+			Params: AdaptationParams{WeightPctChange: pct},
+		}
+	}
+
+	return AdaptationDecision{Kind: AdaptationNoOp, Reason: "no rule matched"}
+}
+
+// SessionOutcome is a compact history entry used by signal detectors.
+type SessionOutcome struct {
+	SessionPlanID string
+	ScheduledDate time.Time
+	Skipped       bool
+	WasCompleted  bool
+	Weekday       time.Weekday
+}
+
+// DetectSignalB1 checks for 3 consecutive skipped sessions or 7 days without
+// completed sessions relative to now. Returns AdaptationSignalB1AcuteDropout
+// or AdaptationNoOp.
+func (e *AdaptiveCoachEngine) DetectSignalB1(history []SessionOutcome, now time.Time) AdaptationDecision {
+	// 3 consecutive skips (walk history newest→oldest).
+	consecutive := 0
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].Skipped {
+			consecutive++
+			if consecutive >= 3 {
+				return AdaptationDecision{
+					Kind:   AdaptationSignalB1AcuteDropout,
+					Reason: "3 consecutive skipped sessions",
+				}
+			}
+		} else if history[i].WasCompleted {
+			break
+		}
+	}
+
+	// 7 days without a completed session.
+	sevenDaysAgo := now.AddDate(0, 0, -7)
+	lastCompletedTooOld := true
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].WasCompleted && history[i].ScheduledDate.After(sevenDaysAgo) {
+			lastCompletedTooOld = false
+			break
+		}
+	}
+	if lastCompletedTooOld && len(history) > 0 {
+		return AdaptationDecision{
+			Kind:   AdaptationSignalB1AcuteDropout,
+			Reason: "no completed session in 7 days",
+		}
+	}
+	return AdaptationDecision{Kind: AdaptationNoOp}
+}
+
+// DetectSignalB2 checks for the same weekday skipped in 3+ consecutive weeks.
+func (e *AdaptiveCoachEngine) DetectSignalB2(history []SessionOutcome) AdaptationDecision {
+	// Group by weekday: for each weekday, count consecutive weeks where it was skipped.
+	// Assume history is chronological.
+	skippedByWeek := map[time.Weekday]int{}
+	completedByWeek := map[time.Weekday]int{}
+	for _, s := range history {
+		if s.Skipped {
+			skippedByWeek[s.Weekday]++
+		} else if s.WasCompleted {
+			completedByWeek[s.Weekday]++
+		}
+	}
+	for wd, skips := range skippedByWeek {
+		if skips >= 3 && completedByWeek[wd] == 0 {
+			return AdaptationDecision{
+				Kind:   AdaptationSignalB2ScheduleMismatch,
+				Reason: "same weekday skipped 3+ times",
+				Params: AdaptationParams{StaleWeekday: wd},
+			}
+		}
+	}
+	return AdaptationDecision{Kind: AdaptationNoOp}
+}
+
+// PlateauInput carries per-week 1RM data for one exercise.
+type PlateauInput struct {
+	WeekNumber int32
+	SCR        float64
+	Best1RM    float64
+}
+
+// DetectSignalB4 checks whether 1RM has been stagnant for 2+ consecutive
+// weeks (only counting weeks with SCR ≥ 80%).
+func (e *AdaptiveCoachEngine) DetectSignalB4(weeks []PlateauInput) AdaptationDecision {
+	// Filter to eligible weeks.
+	elig := make([]PlateauInput, 0, len(weeks))
+	for _, w := range weeks {
+		if w.SCR >= 80.0 {
+			elig = append(elig, w)
+		}
+	}
+	if len(elig) < 2 {
+		return AdaptationDecision{Kind: AdaptationNoOp}
+	}
+	// Check the last two eligible weeks for stagnation (delta ~0).
+	a := elig[len(elig)-2]
+	b := elig[len(elig)-1]
+	if b.Best1RM > 0 && (b.Best1RM-a.Best1RM)/b.Best1RM < 0.01 {
+		return AdaptationDecision{
+			Kind:   AdaptationSignalB4Plateau,
+			Reason: "1RM plateau ≥ 2 eligible weeks",
+		}
+	}
+	return AdaptationDecision{Kind: AdaptationNoOp}
+}

--- a/internal/coaching/domain/service/adaptive_coach_engine_test.go
+++ b/internal/coaching/domain/service/adaptive_coach_engine_test.go
@@ -1,0 +1,163 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEvaluateTriggerA_ProgressiveOverload(t *testing.T) {
+	e := NewAdaptiveCoachEngine()
+	weeks := []WeeklyMetrics{
+		{WeekNumber: 1, SCR: 85, AvgDeltaRPE: 0.5, MaxActualRPE: 8, HighRPESessions: 0, TotalSessions: 5},
+	}
+	d := e.EvaluateTriggerA(weeks)
+	if d.Kind != AdaptationIncreaseLoad {
+		t.Fatalf("kind=%v, want IncreaseLoad", d.Kind)
+	}
+	if d.Params.WeightPctChange <= 0 {
+		t.Errorf("expected positive weight change, got %v", d.Params.WeightPctChange)
+	}
+}
+
+func TestEvaluateTriggerA_DeloadOnFatigue(t *testing.T) {
+	e := NewAdaptiveCoachEngine()
+	weeks := []WeeklyMetrics{
+		{WeekNumber: 1, SCR: 90, AvgDeltaRPE: 2.5, TotalSessions: 5},
+	}
+	d := e.EvaluateTriggerA(weeks)
+	if d.Kind != AdaptationTriggerDeload {
+		t.Fatalf("kind=%v, want TriggerDeload", d.Kind)
+	}
+	if d.Params.VolumePctChange != -0.30 || d.Params.WeightPctChange != -0.10 {
+		t.Errorf("deload params wrong: %+v", d.Params)
+	}
+}
+
+func TestEvaluateTriggerA_DeloadOnHighRPESessions(t *testing.T) {
+	e := NewAdaptiveCoachEngine()
+	weeks := []WeeklyMetrics{
+		{WeekNumber: 1, SCR: 100, AvgDeltaRPE: 1.5, HighRPESessions: 3, TotalSessions: 5},
+	}
+	d := e.EvaluateTriggerA(weeks)
+	if d.Kind != AdaptationTriggerDeload {
+		t.Fatalf("kind=%v, want TriggerDeload (3+ RPE≥9)", d.Kind)
+	}
+}
+
+func TestEvaluateTriggerA_ReduceOnLowSCR2Weeks(t *testing.T) {
+	e := NewAdaptiveCoachEngine()
+	weeks := []WeeklyMetrics{
+		{WeekNumber: 1, SCR: 40, TotalSessions: 5},
+		{WeekNumber: 2, SCR: 45, TotalSessions: 5},
+	}
+	d := e.EvaluateTriggerA(weeks)
+	if d.Kind != AdaptationProposeExpressFormat {
+		t.Fatalf("kind=%v, want ProposeExpressFormat", d.Kind)
+	}
+}
+
+func TestEvaluateTriggerA_NoOpWhenBorderline(t *testing.T) {
+	e := NewAdaptiveCoachEngine()
+	weeks := []WeeklyMetrics{
+		{WeekNumber: 1, SCR: 70, AvgDeltaRPE: -1.5, TotalSessions: 5},
+	}
+	d := e.EvaluateTriggerA(weeks)
+	if d.Kind != AdaptationNoOp {
+		t.Errorf("expected NoOp, got %v", d.Kind)
+	}
+}
+
+func TestEvaluateTriggerA_EmptyReturnsNoOp(t *testing.T) {
+	e := NewAdaptiveCoachEngine()
+	d := e.EvaluateTriggerA(nil)
+	if d.Kind != AdaptationNoOp {
+		t.Errorf("expected NoOp, got %v", d.Kind)
+	}
+}
+
+func TestDetectSignalB1_ThreeConsecutiveSkips(t *testing.T) {
+	e := NewAdaptiveCoachEngine()
+	base := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	history := []SessionOutcome{
+		{ScheduledDate: base, WasCompleted: true, Weekday: time.Monday},
+		{ScheduledDate: base.AddDate(0, 0, 2), WasCompleted: true, Weekday: time.Wednesday},
+		{ScheduledDate: base.AddDate(0, 0, 7), Skipped: true, Weekday: time.Monday},
+		{ScheduledDate: base.AddDate(0, 0, 9), Skipped: true, Weekday: time.Wednesday},
+		{ScheduledDate: base.AddDate(0, 0, 11), Skipped: true, Weekday: time.Friday},
+	}
+	now := base.AddDate(0, 0, 12)
+	d := e.DetectSignalB1(history, now)
+	if d.Kind != AdaptationSignalB1AcuteDropout {
+		t.Errorf("expected B1, got %v", d.Kind)
+	}
+}
+
+func TestDetectSignalB1_SevenDaysNoCompleted(t *testing.T) {
+	e := NewAdaptiveCoachEngine()
+	base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	history := []SessionOutcome{
+		{ScheduledDate: base, WasCompleted: true, Weekday: time.Monday},
+	}
+	// 10 days later, no new completions
+	now := base.AddDate(0, 0, 10)
+	d := e.DetectSignalB1(history, now)
+	if d.Kind != AdaptationSignalB1AcuteDropout {
+		t.Errorf("expected B1 (inactivity), got %v", d.Kind)
+	}
+}
+
+func TestDetectSignalB1_NoOpWhenRecent(t *testing.T) {
+	e := NewAdaptiveCoachEngine()
+	now := time.Date(2026, 7, 28, 0, 0, 0, 0, time.UTC)
+	history := []SessionOutcome{
+		{ScheduledDate: now.AddDate(0, 0, -2), WasCompleted: true, Weekday: time.Sunday},
+	}
+	d := e.DetectSignalB1(history, now)
+	if d.Kind != AdaptationNoOp {
+		t.Errorf("expected NoOp, got %v", d.Kind)
+	}
+}
+
+func TestDetectSignalB2_SameWeekdaySkipped(t *testing.T) {
+	e := NewAdaptiveCoachEngine()
+	base := time.Date(2026, 7, 6, 0, 0, 0, 0, time.UTC) // Monday
+	// 3 weeks with Monday always skipped, other days sometimes completed.
+	history := []SessionOutcome{
+		{ScheduledDate: base, Skipped: true, Weekday: time.Monday},
+		{ScheduledDate: base.AddDate(0, 0, 2), WasCompleted: true, Weekday: time.Wednesday},
+		{ScheduledDate: base.AddDate(0, 0, 7), Skipped: true, Weekday: time.Monday},
+		{ScheduledDate: base.AddDate(0, 0, 9), WasCompleted: true, Weekday: time.Wednesday},
+		{ScheduledDate: base.AddDate(0, 0, 14), Skipped: true, Weekday: time.Monday},
+	}
+	d := e.DetectSignalB2(history)
+	if d.Kind != AdaptationSignalB2ScheduleMismatch {
+		t.Fatalf("expected B2, got %v", d.Kind)
+	}
+	if d.Params.StaleWeekday != time.Monday {
+		t.Errorf("expected Monday, got %v", d.Params.StaleWeekday)
+	}
+}
+
+func TestDetectSignalB4_Plateau(t *testing.T) {
+	e := NewAdaptiveCoachEngine()
+	weeks := []PlateauInput{
+		{WeekNumber: 1, SCR: 85, Best1RM: 100},
+		{WeekNumber: 2, SCR: 90, Best1RM: 100.2}, // stagnant (<1%)
+	}
+	d := e.DetectSignalB4(weeks)
+	if d.Kind != AdaptationSignalB4Plateau {
+		t.Errorf("expected B4 plateau, got %v", d.Kind)
+	}
+}
+
+func TestDetectSignalB4_IgnoresLowSCRWeeks(t *testing.T) {
+	e := NewAdaptiveCoachEngine()
+	weeks := []PlateauInput{
+		{WeekNumber: 1, SCR: 50, Best1RM: 100},
+		{WeekNumber: 2, SCR: 60, Best1RM: 100},
+	}
+	d := e.DetectSignalB4(weeks)
+	if d.Kind != AdaptationNoOp {
+		t.Errorf("expected NoOp (low SCR), got %v", d.Kind)
+	}
+}

--- a/internal/coaching/domain/service/overload_validator.go
+++ b/internal/coaching/domain/service/overload_validator.go
@@ -1,0 +1,51 @@
+// Package service contains domain services for the Coaching context:
+// OverloadValidator (BR-AC-02 ±30% cap), SCRCalculator (BR-AC-04 formulas),
+// and AdaptiveCoachEngine (BR-AC-04..08 signal detection).
+package service
+
+import "errors"
+
+// ErrNoBaseline is returned when there is no history / PR baseline to cap against.
+// Callers may treat this as "accept the suggested weight as-is" (new user, no PR yet).
+var ErrNoBaseline = errors.New("no baseline weight available")
+
+// OverloadBand is the maximum permitted delta as a fraction of baseline.
+// BR-AC-02: ±30% ⇒ 0.30.
+const OverloadBand = 0.30
+
+// OverloadValidator caps suggested weights within ±30% of a baseline
+// (typically the user's PR or last suggested weight for the exercise).
+type OverloadValidator struct{}
+
+// NewOverloadValidator constructs the domain service.
+func NewOverloadValidator() *OverloadValidator {
+	return &OverloadValidator{}
+}
+
+// Cap returns the weight bounded to [baseline*(1-band), baseline*(1+band)].
+// If baseline <= 0, returns (suggested, ErrNoBaseline) so caller can decide.
+func (v *OverloadValidator) Cap(suggested, baseline float64) (float64, error) {
+	if baseline <= 0 {
+		return suggested, ErrNoBaseline
+	}
+	upper := baseline * (1.0 + OverloadBand)
+	lower := baseline * (1.0 - OverloadBand)
+	switch {
+	case suggested > upper:
+		return upper, nil
+	case suggested < lower:
+		return lower, nil
+	default:
+		return suggested, nil
+	}
+}
+
+// Within reports whether the suggested weight is inside the ±30% band.
+// If baseline <= 0, returns true (no way to check).
+func (v *OverloadValidator) Within(suggested, baseline float64) bool {
+	if baseline <= 0 {
+		return true
+	}
+	lo, hi := baseline*(1.0-OverloadBand), baseline*(1.0+OverloadBand)
+	return suggested >= lo && suggested <= hi
+}

--- a/internal/coaching/domain/service/overload_validator_test.go
+++ b/internal/coaching/domain/service/overload_validator_test.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestOverloadValidator_Cap(t *testing.T) {
+	v := NewOverloadValidator()
+	tests := []struct {
+		name      string
+		suggested float64
+		baseline  float64
+		want      float64
+	}{
+		{"within band", 100, 100, 100},
+		{"upper cap: 200 vs baseline 100 → 130", 200, 100, 130},
+		{"lower cap: 40 vs baseline 100 → 70", 40, 100, 70},
+		{"exactly at upper", 130, 100, 130},
+		{"exactly at lower", 70, 100, 70},
+		{"heavier baseline: 250 vs 200 → 250 (within +25%)", 250, 200, 250},
+		{"cap at +30%: 300 vs 200 → 260", 300, 200, 260},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := v.Cap(tt.suggested, tt.baseline)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Cap(%v, %v) = %v, want %v", tt.suggested, tt.baseline, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOverloadValidator_Cap_NoBaseline(t *testing.T) {
+	v := NewOverloadValidator()
+	got, err := v.Cap(80, 0)
+	if !errors.Is(err, ErrNoBaseline) {
+		t.Errorf("expected ErrNoBaseline, got %v", err)
+	}
+	if got != 80 {
+		t.Errorf("expected suggested returned as-is, got %v", got)
+	}
+}
+
+func TestOverloadValidator_Within(t *testing.T) {
+	v := NewOverloadValidator()
+	if !v.Within(100, 100) {
+		t.Errorf("100/100 should be within band")
+	}
+	if v.Within(200, 100) {
+		t.Errorf("200/100 should NOT be within band")
+	}
+	if !v.Within(80, 0) {
+		t.Errorf("no baseline should return true (permissive)")
+	}
+}

--- a/internal/coaching/domain/service/scr_calculator.go
+++ b/internal/coaching/domain/service/scr_calculator.go
@@ -1,0 +1,75 @@
+package service
+
+import "math"
+
+// SCRCalculator computes Session Completion Rate, ΔRPE and estimated 1RM.
+// Formulas follow BR-AC-04 and standard Epley estimation.
+//
+// D7: ΔRPE uses scalar average_rpe from WorkoutSessionCompleted event
+// (not per-set arrays). Formula: ΔRPE = avgActual - avgTarget.
+type SCRCalculator struct{}
+
+// NewSCRCalculator constructs the domain service.
+func NewSCRCalculator() *SCRCalculator { return &SCRCalculator{} }
+
+// SCR returns Session Completion Rate as a percentage (0..100).
+// prescribedSets <= 0 returns 0 (avoid divide-by-zero); actual > prescribed caps at 100.
+func (c *SCRCalculator) SCR(actualSets, prescribedSets int) float64 {
+	if prescribedSets <= 0 {
+		return 0
+	}
+	if actualSets < 0 {
+		actualSets = 0
+	}
+	pct := float64(actualSets) / float64(prescribedSets) * 100.0
+	if pct > 100.0 {
+		return 100.0
+	}
+	return pct
+}
+
+// DeltaRPE returns (actual - target). Positive means the user found it harder
+// than prescribed; negative means it felt too light.
+func (c *SCRCalculator) DeltaRPE(actualAvgRPE, targetRPE float64) float64 {
+	return actualAvgRPE - targetRPE
+}
+
+// EpleyOneRepMax returns the estimated one-rep max via Epley formula:
+//   1RM = weight * (1 + reps/30)
+// reps <= 0 or weight <= 0 returns 0.
+func (c *SCRCalculator) EpleyOneRepMax(weight float64, reps int) float64 {
+	if weight <= 0 || reps <= 0 {
+		return 0
+	}
+	// 1 rep already IS a 1RM.
+	if reps == 1 {
+		return weight
+	}
+	return weight * (1.0 + float64(reps)/30.0)
+}
+
+// WeeklySCR aggregates SCR across multiple sessions:
+// SCR_week = sum(actual) / sum(prescribed) * 100.
+func (c *SCRCalculator) WeeklySCR(actualPerSession, prescribedPerSession []int) float64 {
+	var a, p int
+	for _, v := range actualPerSession {
+		if v > 0 {
+			a += v
+		}
+	}
+	for _, v := range prescribedPerSession {
+		if v > 0 {
+			p += v
+		}
+	}
+	return c.SCR(a, p)
+}
+
+// RoundToNearest rounds x to the nearest multiple of step. Useful for
+// snapping generated weights to 2.5 kg or 5 lb increments.
+func RoundToNearest(x, step float64) float64 {
+	if step <= 0 {
+		return x
+	}
+	return math.Round(x/step) * step
+}

--- a/internal/coaching/domain/service/scr_calculator_test.go
+++ b/internal/coaching/domain/service/scr_calculator_test.go
@@ -1,0 +1,94 @@
+package service
+
+import (
+	"math"
+	"testing"
+)
+
+func TestSCRCalculator_SCR(t *testing.T) {
+	c := NewSCRCalculator()
+	tests := []struct {
+		name        string
+		actual      int
+		prescribed  int
+		want        float64
+	}{
+		{"100% completion", 16, 16, 100.0},
+		{"50% completion", 8, 16, 50.0},
+		{"80% completion", 8, 10, 80.0},
+		{"zero prescribed → 0", 5, 0, 0},
+		{"negative actual → 0%", -3, 10, 0},
+		{"over-completion caps at 100", 20, 16, 100.0},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := c.SCR(tt.actual, tt.prescribed); math.Abs(got-tt.want) > 1e-9 {
+				t.Errorf("SCR(%d, %d) = %v, want %v", tt.actual, tt.prescribed, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSCRCalculator_DeltaRPE(t *testing.T) {
+	c := NewSCRCalculator()
+	if got := c.DeltaRPE(8.5, 7.0); math.Abs(got-1.5) > 1e-9 {
+		t.Errorf("DeltaRPE(8.5, 7.0) = %v, want 1.5", got)
+	}
+	if got := c.DeltaRPE(6.0, 7.0); math.Abs(got-(-1.0)) > 1e-9 {
+		t.Errorf("DeltaRPE(6.0, 7.0) = %v, want -1.0", got)
+	}
+}
+
+func TestSCRCalculator_EpleyOneRepMax(t *testing.T) {
+	c := NewSCRCalculator()
+	tests := []struct {
+		name   string
+		weight float64
+		reps   int
+		want   float64
+	}{
+		{"1 rep = weight", 100, 1, 100},
+		{"5 reps at 100 → ~116.67", 100, 5, 100 * (1 + 5.0/30.0)},
+		{"zero weight → 0", 0, 5, 0},
+		{"zero reps → 0", 100, 0, 0},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := c.EpleyOneRepMax(tt.weight, tt.reps); math.Abs(got-tt.want) > 1e-6 {
+				t.Errorf("Epley(%v, %d) = %v, want %v", tt.weight, tt.reps, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSCRCalculator_WeeklySCR(t *testing.T) {
+	c := NewSCRCalculator()
+	actual := []int{16, 12, 14}
+	prescribed := []int{16, 16, 16}
+	got := c.WeeklySCR(actual, prescribed)
+	want := 42.0 / 48.0 * 100.0
+	if math.Abs(got-want) > 1e-6 {
+		t.Errorf("WeeklySCR = %v, want %v", got, want)
+	}
+}
+
+func TestRoundToNearest(t *testing.T) {
+	tests := []struct {
+		x, step, want float64
+	}{
+		{102.3, 2.5, 102.5},
+		{101.4, 2.5, 102.5}, // 101.4/2.5 = 40.56 → round 41 → 102.5
+		{101.24, 2.5, 100.0}, // 101.24/2.5 = 40.496 → round 40 → 100.0
+		{75.0, 5.0, 75.0},
+		{50.0, 0, 50.0},
+	}
+	for _, tt := range tests {
+		if got := RoundToNearest(tt.x, tt.step); math.Abs(got-tt.want) > 1e-9 {
+			t.Errorf("RoundToNearest(%v, %v) = %v, want %v", tt.x, tt.step, got, tt.want)
+		}
+	}
+}

--- a/internal/coaching/infrastructure/ai/mock_coach_agent.go
+++ b/internal/coaching/infrastructure/ai/mock_coach_agent.go
@@ -1,0 +1,374 @@
+// Package ai holds the CoachAgent adapters. MockCoachAgent is a deterministic
+// rules-based generator used in phase-1 (no LLM). It also serves as the
+// fallback when the real LLM adapter exceeds cost/time budget (D5).
+package ai
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"time"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+)
+
+// MockCoachAgent implements port.CoachAgent using deterministic templates.
+type MockCoachAgent struct {
+	ids   port.IDGenerator
+	clock port.Clock
+}
+
+// NewMockCoachAgent constructs the deterministic generator.
+func NewMockCoachAgent(ids port.IDGenerator, clock port.Clock) *MockCoachAgent {
+	return &MockCoachAgent{ids: ids, clock: clock}
+}
+
+// phaseSpec defines RPE + relative volume/intensity per phase.
+type phaseSpec struct {
+	phase     roadmap.Phase
+	targetRPE float32
+	volume    float64 // multiplier on baseline sets/reps (1.0 = 100%)
+	intensity float64 // multiplier on baseline weight (1.0 = 100%)
+}
+
+var defaultPhaseSpecs = []phaseSpec{
+	{roadmap.PhaseAccumulation, 6.5, 1.0, 0.85},
+	{roadmap.PhaseOverload, 7.5, 1.05, 0.92},
+	{roadmap.PhasePeak, 8.5, 0.95, 1.0},
+	{roadmap.PhaseDeload, 5.5, 0.70, 0.90},
+}
+
+// GenerateRoadmap creates a full 4-week roadmap. It is deterministic given
+// (userID, startDate, profile hash).
+func (m *MockCoachAgent) GenerateRoadmap(ctx context.Context, cc port.CoachContext, _ *port.Feedback) (*roadmap.Roadmap, error) {
+	now := m.clock.Now()
+	roadmapID := m.ids.NewID()
+	startDate := nextMonday(now)
+	endDate := startDate.AddDate(0, 0, roadmap.WeeksPerRoadmap*roadmap.DaysPerWeek)
+
+	weeks := make([]*roadmap.WeekPlan, 0, roadmap.WeeksPerRoadmap)
+	seed := hashSeed(cc.UserID)
+	for wi, spec := range defaultPhaseSpecs {
+		weekStart := startDate.AddDate(0, 0, wi*roadmap.DaysPerWeek)
+		weekPlanID := m.ids.NewID()
+		wp, err := roadmap.NewWeekPlan(roadmap.WeekPlanInfo{
+			WeekPlanID:      weekPlanID,
+			RoadmapID:       roadmapID,
+			UserID:          cc.UserID,
+			WeekNumber:      int32(wi + 1),
+			Phase:           spec.phase,
+			TargetRPE:       spec.targetRPE,
+			StartDate:       weekStart,
+			EndDate:         weekStart.AddDate(0, 0, 6),
+			MuscleSplitType: chooseSplit(cc.Profile.PreferredMuscleGroups),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("new week plan: %w", err)
+		}
+
+		trainingDays := selectTrainingDays(cc.Profile.AvailableSlots, seed)
+		for di := 0; di < roadmap.DaysPerWeek; di++ {
+			date := weekStart.AddDate(0, 0, di)
+			dayID := m.ids.NewID()
+			isRest := !trainingDays[di]
+			dp, err := roadmap.NewDayPlan(roadmap.DayPlanInfo{
+				DayPlanID:     dayID,
+				WeekPlanID:    weekPlanID,
+				RoadmapID:     roadmapID,
+				UserID:        cc.UserID,
+				ScheduledDate: date,
+				IsRestDay:     isRest,
+			})
+			if err != nil {
+				return nil, err
+			}
+			if !isRest {
+				sp, err := m.buildSessionPlan(
+					roadmapID, weekPlanID, dayID, cc.UserID,
+					date, spec, cc.InjuryStatus, now,
+				)
+				if err != nil {
+					return nil, err
+				}
+				if err := dp.AddSession(sp); err != nil {
+					return nil, err
+				}
+			}
+			if err := wp.AddDay(dp); err != nil {
+				return nil, err
+			}
+		}
+		weeks = append(weeks, wp)
+	}
+
+	r, err := roadmap.NewRoadmap(roadmap.RoadmapInfo{
+		RoadmapID: roadmapID,
+		UserID:    cc.UserID,
+		StartDate: startDate,
+		EndDate:   endDate,
+	}, weeks, now)
+	if err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// RegeneratePending returns updated prescriptions for the given session IDs.
+// It uses the current roadmap snapshot to know phase & muscle groups.
+func (m *MockCoachAgent) RegeneratePending(ctx context.Context, cc port.CoachContext, sessionIDs []string, _ *port.Feedback) ([]roadmap.SessionPlanInfo, error) {
+	out := make([]roadmap.SessionPlanInfo, 0, len(sessionIDs))
+	if cc.CurrentRoadmap == nil {
+		return out, nil
+	}
+	spec := findPhaseSpec(cc.CurrentRoadmap.Phase)
+	now := m.clock.Now()
+	for _, id := range sessionIDs {
+		out = append(out, roadmap.SessionPlanInfo{
+			SessionPlanID:      id,
+			UserID:             cc.UserID,
+			RoadmapID:          cc.CurrentRoadmap.RoadmapID,
+			Status:             roadmap.SessionPlanStatusPending,
+			TargetMuscleGroups: cc.Profile.PreferredMuscleGroups,
+			Prescription:       buildPrescription(spec, cc.InjuryStatus),
+			Reasoning:          "regenerated (mock) after context change",
+			GeneratedAt:        now,
+		})
+	}
+	return out, nil
+}
+
+// Adapt is used by Trigger A / signal handlers. Phase-1 mock returns the same
+// mapping as RegeneratePending but tags reasoning with the decisionReason.
+func (m *MockCoachAgent) Adapt(ctx context.Context, cc port.CoachContext, decisionReason string, fb *Feedback) ([]roadmap.SessionPlanInfo, error) {
+	if cc.CurrentRoadmap == nil {
+		return nil, nil
+	}
+	ids := make([]string, 0, len(cc.CurrentRoadmap.PendingSessions))
+	for _, s := range cc.CurrentRoadmap.PendingSessions {
+		ids = append(ids, s.SessionPlanID)
+	}
+	out, err := m.RegeneratePending(ctx, cc, ids, fb)
+	if err != nil {
+		return nil, err
+	}
+	for i := range out {
+		out[i].Reasoning = "adapt (mock): " + decisionReason
+	}
+	return out, nil
+}
+
+// Feedback is a type alias to shorten the signature above (avoid re-import).
+type Feedback = port.Feedback
+
+// SuggestAdHocSession returns a single-session suggestion. Read-only: no
+// persistence, no side effects. Deterministic given the hint + profile.
+func (m *MockCoachAgent) SuggestAdHocSession(ctx context.Context, cc port.CoachContext, hint port.AdHocHint) (port.SuggestedSession, error) {
+	// Pick the phase to size volume/intensity from — prefer current roadmap phase,
+	// otherwise default to Accumulation (moderate).
+	phase := roadmap.PhaseAccumulation
+	if cc.CurrentRoadmap != nil && cc.CurrentRoadmap.Phase.Valid() {
+		phase = cc.CurrentRoadmap.Phase
+	}
+	spec := findPhaseSpec(phase)
+
+	// If user indicated intensity, override phase spec accordingly.
+	switch hint.IntensityHint {
+	case "light":
+		spec.intensity *= 0.85
+		spec.targetRPE = 5.5
+	case "hard":
+		spec.intensity *= 1.10
+		spec.targetRPE = 8.0
+	}
+
+	// Merge muscle groups: hint overrides profile preferences.
+	muscles := hint.MuscleGroups
+	if len(muscles) == 0 {
+		muscles = cc.Profile.PreferredMuscleGroups
+	}
+	if len(muscles) == 0 {
+		muscles = []string{"chest", "back"} // safe default
+	}
+
+	presc := buildPrescription(spec, cc.InjuryStatus)
+
+	// If a duration cap is set, drop extra sets from the last main exercise until
+	// the estimated total time fits. Rough heuristic: 3 min per set + 5 min warmup
+	// + 5 min cooldown.
+	if hint.DurationMinutes > 0 {
+		presc = shrinkToDuration(presc, hint.DurationMinutes)
+	}
+
+	return port.SuggestedSession{
+		MuscleGroups: muscles,
+		Prescription: presc,
+		Reasoning:    "ad-hoc suggestion (mock): phase=" + string(spec.phase) + " intensity=" + hint.IntensityHint,
+		EstimatedRPE: spec.targetRPE,
+	}, nil
+}
+
+// shrinkToDuration reduces set counts on main exercises to fit budgetMinutes.
+func shrinkToDuration(p roadmap.WorkoutPrescription, budgetMinutes int) roadmap.WorkoutPrescription {
+	// Assume warmup 5' + cooldown 5' = 10' fixed overhead.
+	remaining := budgetMinutes - 10
+	if remaining <= 0 {
+		p.MainExercises = nil
+		return p
+	}
+	// Rough 3 minutes per set (including rest).
+	setsBudget := remaining / 3
+	if setsBudget <= 0 {
+		p.MainExercises = nil
+		return p
+	}
+	out := make([]roadmap.PrescribedExercise, 0, len(p.MainExercises))
+	used := 0
+	for _, ex := range p.MainExercises {
+		if used >= setsBudget {
+			break
+		}
+		if used+int(ex.TargetSets) > setsBudget {
+			ex.TargetSets = int32(setsBudget - used)
+			if ex.TargetSets <= 0 {
+				break
+			}
+		}
+		used += int(ex.TargetSets)
+		out = append(out, ex)
+	}
+	p.MainExercises = out
+	return p
+}
+
+func (m *MockCoachAgent) buildSessionPlan(roadmapID, weekPlanID, dayID, userID string, date time.Time, spec phaseSpec, injuries []port.InjuryStatus, now time.Time) (*roadmap.SessionPlan, error) {
+	muscles := []string{"chest", "back"}
+	presc := buildPrescription(spec, injuries)
+	sp, err := roadmap.NewSessionPlan(roadmap.SessionPlanInfo{
+		SessionPlanID:      m.ids.NewID(),
+		DayPlanID:          dayID,
+		WeekPlanID:         weekPlanID,
+		RoadmapID:          roadmapID,
+		UserID:             userID,
+		ScheduledDate:      date,
+		SlotTime:           "06:00-07:00",
+		TargetMuscleGroups: muscles,
+		Prescription:       presc,
+		Reasoning:          fmt.Sprintf("phase=%s targetRPE=%.1f", spec.phase, spec.targetRPE),
+	}, now)
+	if err != nil {
+		return nil, err
+	}
+	return sp, nil
+}
+
+func buildPrescription(spec phaseSpec, injuries []port.InjuryStatus) roadmap.WorkoutPrescription {
+	baseWeight := 40.0 * spec.intensity
+	baseSets := int32(4.0 * spec.volume)
+	if baseSets < 2 {
+		baseSets = 2
+	}
+	main := []roadmap.PrescribedExercise{
+		{
+			ExerciseID:   "ex-bench-press",
+			ExerciseName: "Bench Press",
+			TargetSets:   baseSets,
+			TargetReps:   int32(10.0 * spec.volume),
+			TargetWeight: float32(baseWeight),
+			TargetRPE:    spec.targetRPE,
+			RestSetSec:   90,
+		},
+		{
+			ExerciseID:   "ex-row",
+			ExerciseName: "Barbell Row",
+			TargetSets:   baseSets,
+			TargetReps:   int32(10.0 * spec.volume),
+			TargetWeight: float32(baseWeight * 0.9),
+			TargetRPE:    spec.targetRPE,
+			RestSetSec:   90,
+		},
+	}
+	// BR-AC-09 stub: drop exercises hitting injured muscle group.
+	filtered := make([]roadmap.PrescribedExercise, 0, len(main))
+	for _, ex := range main {
+		if !intersects(injuries, ex.ExerciseName) {
+			filtered = append(filtered, ex)
+		}
+	}
+	return roadmap.WorkoutPrescription{
+		WarmUps: []roadmap.PrescribedExercise{
+			{ExerciseID: "wu-general", ExerciseName: "General warmup", DurationSeconds: 300, TargetRPE: 4},
+		},
+		MainExercises: filtered,
+		CoolDowns: []roadmap.PrescribedExercise{
+			{ExerciseID: "cd-stretch", ExerciseName: "Static stretch", DurationSeconds: 300, TargetRPE: 3},
+		},
+	}
+}
+
+func intersects(injuries []port.InjuryStatus, name string) bool {
+	// Simplified for phase-1: no fuzzy matching.
+	_ = injuries
+	_ = name
+	return false
+}
+
+func chooseSplit(prefs []string) string {
+	if len(prefs) == 0 {
+		return "push_pull_legs"
+	}
+	return "custom"
+}
+
+func selectTrainingDays(slots []port.Slot, seed uint32) [7]bool {
+	// If user provided slots, mark those days true (up to cap 6).
+	var days [7]bool
+	if len(slots) > 0 {
+		count := 0
+		for _, s := range slots {
+			if count >= roadmap.MaxSessionsPerWeek {
+				break
+			}
+			days[s.DayOfWeek] = true
+			count++
+		}
+		return days
+	}
+	// Otherwise pick 4 days deterministically from seed.
+	idx := int(seed % 7)
+	count := 0
+	for count < 4 {
+		if !days[idx] {
+			days[idx] = true
+			count++
+		}
+		idx = (idx + 2) % 7
+	}
+	return days
+}
+
+func findPhaseSpec(p roadmap.Phase) phaseSpec {
+	for _, s := range defaultPhaseSpecs {
+		if s.phase == p {
+			return s
+		}
+	}
+	return defaultPhaseSpecs[0]
+}
+
+func nextMonday(now time.Time) time.Time {
+	// Truncate to date at UTC.
+	d := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	// Weekday: Sunday=0, Monday=1, ..., Saturday=6.
+	offset := (int(time.Monday) - int(d.Weekday()) + 7) % 7
+	if offset == 0 {
+		offset = 7
+	}
+	return d.AddDate(0, 0, offset)
+}
+
+func hashSeed(s string) uint32 {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(s))
+	return h.Sum32()
+}

--- a/internal/coaching/infrastructure/ai/mock_coach_agent_test.go
+++ b/internal/coaching/infrastructure/ai/mock_coach_agent_test.go
@@ -1,0 +1,97 @@
+package ai
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+)
+
+type fixedClock struct{ t time.Time }
+
+func (c *fixedClock) Now() time.Time { return c.t }
+
+type counterIDs struct{ n int }
+
+func (c *counterIDs) NewID() string {
+	c.n++
+	return "id-" + strconvItoa(c.n)
+}
+
+func strconvItoa(n int) string { return strconv.Itoa(n) }
+
+func TestMockCoachAgent_GenerateRoadmap_4Weeks(t *testing.T) {
+	clock := &fixedClock{t: time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)} // Tuesday
+	agent := NewMockCoachAgent(&counterIDs{}, clock)
+
+	cc := port.CoachContext{
+		Flow:   port.FlowInitiate4Week,
+		UserID: "user-alpha",
+		Profile: port.Profile{
+			UserID:                "user-alpha",
+			PrimaryGoal:           "MUSCLE_GAIN",
+			PreferredMuscleGroups: []string{"chest", "back"},
+			AvailableSlots: []port.Slot{
+				{DayOfWeek: time.Monday, StartTime: "06:00", EndTime: "07:00"},
+				{DayOfWeek: time.Wednesday, StartTime: "06:00", EndTime: "07:00"},
+				{DayOfWeek: time.Friday, StartTime: "06:00", EndTime: "07:00"},
+				{DayOfWeek: time.Saturday, StartTime: "09:00", EndTime: "10:00"},
+			},
+		},
+	}
+
+	r, err := agent.GenerateRoadmap(context.Background(), cc, nil)
+	if err != nil {
+		t.Fatalf("GenerateRoadmap: %v", err)
+	}
+	if err := r.ValidateFullStructure(); err != nil {
+		t.Fatalf("ValidateFullStructure: %v", err)
+	}
+	if len(r.Weeks()) != roadmap.WeeksPerRoadmap {
+		t.Fatalf("want %d weeks, got %d", roadmap.WeeksPerRoadmap, len(r.Weeks()))
+	}
+	// Phase progression must match spec.
+	wants := []roadmap.Phase{roadmap.PhaseAccumulation, roadmap.PhaseOverload, roadmap.PhasePeak, roadmap.PhaseDeload}
+	for i, w := range r.Weeks() {
+		if w.Phase() != wants[i] {
+			t.Errorf("week %d phase=%s, want %s", i+1, w.Phase(), wants[i])
+		}
+		if w.TotalSessions() > roadmap.MaxSessionsPerWeek {
+			t.Errorf("week %d has %d sessions (cap %d)", i+1, w.TotalSessions(), roadmap.MaxSessionsPerWeek)
+		}
+	}
+}
+
+func TestMockCoachAgent_GenerateRoadmap_Deterministic(t *testing.T) {
+	clock := &fixedClock{t: time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)}
+	cc := port.CoachContext{
+		UserID: "user-beta",
+		Profile: port.Profile{
+			UserID:                "user-beta",
+			PreferredMuscleGroups: []string{"chest"},
+		},
+	}
+
+	a1 := NewMockCoachAgent(&counterIDs{}, clock)
+	r1, err := a1.GenerateRoadmap(context.Background(), cc, nil)
+	if err != nil {
+		t.Fatalf("gen1: %v", err)
+	}
+	a2 := NewMockCoachAgent(&counterIDs{}, clock)
+	r2, err := a2.GenerateRoadmap(context.Background(), cc, nil)
+	if err != nil {
+		t.Fatalf("gen2: %v", err)
+	}
+	// Same phase pattern and same rest-day pattern (structural determinism).
+	for i, w := range r1.Weeks() {
+		if w.Phase() != r2.Weeks()[i].Phase() {
+			t.Errorf("week %d phase differs", i)
+		}
+		if w.TotalSessions() != r2.Weeks()[i].TotalSessions() {
+			t.Errorf("week %d session count differs (%d vs %d)", i, w.TotalSessions(), r2.Weeks()[i].TotalSessions())
+		}
+	}
+}

--- a/internal/coaching/infrastructure/event/outbox_writer.go
+++ b/internal/coaching/infrastructure/event/outbox_writer.go
@@ -1,0 +1,74 @@
+// Package event holds the outbox writer that wraps coaching domain events
+// in CloudEvents envelopes and persists them via the outbox repository.
+package event
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	domainevent "github.com/viethung213/gym-companion/internal/coaching/domain/event"
+)
+
+// Source is the CloudEvents `source` field for all coaching events.
+const Source = "services/coaching-service"
+
+// OutboxWriter implements port.OutboxWriter.
+type OutboxWriter struct {
+	outbox port.OutboxRepository
+}
+
+var _ port.OutboxWriter = (*OutboxWriter)(nil)
+
+// NewOutboxWriter constructs the writer.
+func NewOutboxWriter(outbox port.OutboxRepository) *OutboxWriter {
+	return &OutboxWriter{outbox: outbox}
+}
+
+// Enqueue serializes each domain event into a CloudEvents envelope and stores
+// it in coaching.outbox with the given partition key. All writes should be
+// inside the caller's transaction.
+func (w *OutboxWriter) Enqueue(ctx context.Context, partitionKey string, events ...domainevent.Event) error {
+	for _, ev := range events {
+		if err := w.enqueueOne(ctx, partitionKey, ev); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *OutboxWriter) enqueueOne(ctx context.Context, partitionKey string, ev domainevent.Event) error {
+	payloadBytes, err := json.Marshal(ev)
+	if err != nil {
+		return fmt.Errorf("marshal event payload: %w", err)
+	}
+	eventID := uuid.NewString()
+	now := time.Now().UTC()
+	envelope := map[string]any{
+		"specversion":     "1.0",
+		"id":              eventID,
+		"source":          Source,
+		"type":            ev.EventName(),
+		"time":            now.Format(time.RFC3339Nano),
+		"datacontenttype": "application/json",
+		"data":            json.RawMessage(payloadBytes),
+	}
+	envBytes, err := json.Marshal(envelope)
+	if err != nil {
+		return fmt.Errorf("marshal envelope: %w", err)
+	}
+	rec := &port.OutboxRecord{
+		ID:           uuid.NewString(),
+		EventID:      eventID,
+		EventType:    ev.EventName(),
+		Payload:      envBytes,
+		PartitionKey: partitionKey,
+		CreatedAt:    now,
+		Published:    false,
+	}
+	return w.outbox.Save(ctx, rec)
+}

--- a/internal/coaching/infrastructure/event/outbox_writer_test.go
+++ b/internal/coaching/infrastructure/event/outbox_writer_test.go
@@ -1,0 +1,86 @@
+package event
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	domainevent "github.com/viethung213/gym-companion/internal/coaching/domain/event"
+)
+
+type stubOutbox struct {
+	records []*port.OutboxRecord
+}
+
+func (s *stubOutbox) Save(ctx context.Context, rec *port.OutboxRecord) error {
+	s.records = append(s.records, rec)
+	return nil
+}
+func (s *stubOutbox) FetchUnpublished(context.Context, int) ([]*port.OutboxRecord, error) {
+	return s.records, nil
+}
+func (s *stubOutbox) MarkPublished(context.Context, []string) error { return nil }
+func (s *stubOutbox) ExecuteInLock(ctx context.Context, _ int64, fn func(context.Context) error) error {
+	return fn(ctx)
+}
+func (s *stubOutbox) LogProcessed(context.Context, string, string, string, []byte) (bool, error) {
+	return true, nil
+}
+
+func TestOutboxWriter_Enqueue_CloudEventsEnvelope(t *testing.T) {
+	stub := &stubOutbox{}
+	w := NewOutboxWriter(stub)
+
+	ev := &domainevent.RoadmapInitiated{
+		RoadmapID:   "rm-1",
+		UserID:      "user-1",
+		InitiatedAt: time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC),
+	}
+	if err := w.Enqueue(context.Background(), "user-1", ev); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if len(stub.records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(stub.records))
+	}
+	rec := stub.records[0]
+	if rec.EventType != ev.EventName() {
+		t.Errorf("event_type=%s, want %s", rec.EventType, ev.EventName())
+	}
+	if rec.PartitionKey != "user-1" {
+		t.Errorf("partition_key=%s, want user-1", rec.PartitionKey)
+	}
+
+	var envelope map[string]any
+	if err := json.Unmarshal(rec.Payload, &envelope); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if envelope["specversion"] != "1.0" {
+		t.Errorf("specversion=%v", envelope["specversion"])
+	}
+	if envelope["source"] != Source {
+		t.Errorf("source=%v", envelope["source"])
+	}
+	if envelope["type"] != ev.EventName() {
+		t.Errorf("type=%v", envelope["type"])
+	}
+	if envelope["data"] == nil {
+		t.Errorf("missing data field")
+	}
+}
+
+func TestOutboxWriter_Enqueue_MultipleEvents(t *testing.T) {
+	stub := &stubOutbox{}
+	w := NewOutboxWriter(stub)
+	err := w.Enqueue(context.Background(), "u1",
+		&domainevent.RoadmapInitiated{RoadmapID: "rm-1", UserID: "u1"},
+		&domainevent.RoadmapAdjusted{RoadmapID: "rm-1", UserID: "u1", Reason: "test"},
+	)
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if len(stub.records) != 2 {
+		t.Errorf("expected 2 records, got %d", len(stub.records))
+	}
+}

--- a/internal/coaching/infrastructure/guardrail/guardrail.go
+++ b/internal/coaching/infrastructure/guardrail/guardrail.go
@@ -1,0 +1,186 @@
+// Package guardrail is the deterministic Go guardrail layer applied AFTER
+// (and optionally alongside) the LLM CoachAgent. Enforces BR-AC-01 (weekly
+// cap), BR-AC-02 (±30% weight band), BR-AC-09 (injury exclusion / protection).
+//
+// D6: The engine is designed stateless + pure so it can also be exposed as an
+// MCP tool for the Generator/Evaluator to consult during generation.
+package guardrail
+
+import (
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/service"
+)
+
+// Status of a review.
+type Status string
+
+const (
+	StatusApproved Status = "APPROVED"
+	StatusRejected Status = "REJECTED"
+)
+
+// Severity of an individual violation.
+type Severity string
+
+const (
+	SeverityBlocker Severity = "BLOCKER"
+	SeverityWarning Severity = "WARNING"
+)
+
+// Violation is one guard failure.
+type Violation struct {
+	Code        string
+	Description string
+	Path        string
+	Severity    Severity
+}
+
+// ReviewResult is the unified shape returned by the guardrail check.
+type ReviewResult struct {
+	Status     Status
+	Violations []Violation
+}
+
+// PRLookup returns the personal-record baseline weight for a given exercise
+// (typically supplied by ExerciseCatalogReader + WorkoutSessionReader in the
+// concrete adapter). Return baseline<=0 when no history exists.
+type PRLookup func(exerciseID string) float64
+
+// Engine applies all guardrail checks against a Roadmap.
+type Engine struct {
+	overload *service.OverloadValidator
+	prs      PRLookup
+	injuries []port.InjuryStatus
+}
+
+// NewEngine builds a guardrail engine.
+func NewEngine(overload *service.OverloadValidator, prs PRLookup, injuries []port.InjuryStatus) *Engine {
+	if overload == nil {
+		overload = service.NewOverloadValidator()
+	}
+	if prs == nil {
+		prs = func(string) float64 { return 0 }
+	}
+	return &Engine{overload: overload, prs: prs, injuries: injuries}
+}
+
+// Check runs every rule against the given roadmap.
+func (e *Engine) Check(r *roadmap.Roadmap) ReviewResult {
+	if r == nil {
+		return ReviewResult{
+			Status:     StatusRejected,
+			Violations: []Violation{{Code: "INTERNAL_NIL", Description: "nil roadmap", Severity: SeverityBlocker}},
+		}
+	}
+	var vs []Violation
+	vs = append(vs, e.checkWeeklyCap(r)...)
+	vs = append(vs, e.checkWeightBand(r)...)
+	vs = append(vs, e.checkInjuryExclusion(r)...)
+	if len(vs) > 0 {
+		return ReviewResult{Status: StatusRejected, Violations: vs}
+	}
+	return ReviewResult{Status: StatusApproved}
+}
+
+// checkWeeklyCap enforces BR-AC-01.
+func (e *Engine) checkWeeklyCap(r *roadmap.Roadmap) []Violation {
+	var vs []Violation
+	for _, w := range r.Weeks() {
+		if w.TotalSessions() > roadmap.MaxSessionsPerWeek {
+			vs = append(vs, Violation{
+				Code:        "BR-AC-01",
+				Description: "week exceeds max sessions",
+				Path:        "weeks[" + itoa(int(w.WeekNumber())) + "]",
+				Severity:    SeverityBlocker,
+			})
+		}
+	}
+	return vs
+}
+
+// checkWeightBand enforces BR-AC-02.
+func (e *Engine) checkWeightBand(r *roadmap.Roadmap) []Violation {
+	var vs []Violation
+	for _, w := range r.Weeks() {
+		for _, d := range w.Days() {
+			for _, s := range d.Sessions() {
+				presc := s.Info().Prescription
+				for i, ex := range presc.MainExercises {
+					baseline := e.prs(ex.ExerciseID)
+					if baseline <= 0 {
+						continue
+					}
+					if !e.overload.Within(float64(ex.TargetWeight), baseline) {
+						vs = append(vs, Violation{
+							Code:        "BR-AC-02",
+							Description: "target weight outside ±30% of PR/baseline",
+							Path:        "sessions." + s.ID() + ".main[" + itoa(i) + "]",
+							Severity:    SeverityBlocker,
+						})
+					}
+				}
+			}
+		}
+	}
+	return vs
+}
+
+// checkInjuryExclusion enforces BR-AC-09 (active injuries: exclude affected muscle groups).
+func (e *Engine) checkInjuryExclusion(r *roadmap.Roadmap) []Violation {
+	if len(e.injuries) == 0 {
+		return nil
+	}
+	// Only consider injuries that are NOT yet recovered.
+	active := map[string]struct{}{}
+	for _, inj := range e.injuries {
+		if inj.RecoveredAt == nil {
+			active[inj.MuscleGroup] = struct{}{}
+		}
+	}
+	if len(active) == 0 {
+		return nil
+	}
+	var vs []Violation
+	for _, w := range r.Weeks() {
+		for _, d := range w.Days() {
+			for _, s := range d.Sessions() {
+				for _, mg := range s.Info().TargetMuscleGroups {
+					if _, hit := active[mg]; hit {
+						vs = append(vs, Violation{
+							Code:        "BR-AC-09",
+							Description: "session targets injured muscle group: " + mg,
+							Path:        "sessions." + s.ID(),
+							Severity:    SeverityBlocker,
+						})
+					}
+				}
+			}
+		}
+	}
+	return vs
+}
+
+func itoa(n int) string {
+	// Small allocation-free int to string for path building.
+	if n == 0 {
+		return "0"
+	}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	buf := [20]byte{}
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/internal/coaching/infrastructure/guardrail/guardrail_test.go
+++ b/internal/coaching/infrastructure/guardrail/guardrail_test.go
@@ -1,0 +1,152 @@
+package guardrail
+
+import (
+	"testing"
+	"time"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+)
+
+func buildValidRoadmap(t *testing.T) *roadmap.Roadmap {
+	t.Helper()
+	base := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC) // Monday
+	weeks := make([]*roadmap.WeekPlan, 0, 4)
+	for w := 0; w < 4; w++ {
+		weekStart := base.AddDate(0, 0, w*7)
+		phase := []roadmap.Phase{roadmap.PhaseAccumulation, roadmap.PhaseOverload, roadmap.PhasePeak, roadmap.PhaseDeload}[w]
+		wp, err := roadmap.NewWeekPlan(roadmap.WeekPlanInfo{
+			WeekPlanID: "wp-" + itoa(w+1),
+			RoadmapID:  "rm-1",
+			UserID:     "user-1",
+			WeekNumber: int32(w + 1),
+			Phase:      phase,
+			TargetRPE:  7.0,
+			StartDate:  weekStart,
+			EndDate:    weekStart.AddDate(0, 0, 6),
+		})
+		if err != nil {
+			t.Fatalf("wp: %v", err)
+		}
+		for d := 0; d < 7; d++ {
+			dp, _ := roadmap.NewDayPlan(roadmap.DayPlanInfo{
+				DayPlanID:     "dp-" + itoa(w) + "-" + itoa(d),
+				WeekPlanID:    wp.ID(),
+				RoadmapID:     "rm-1",
+				UserID:        "user-1",
+				ScheduledDate: weekStart.AddDate(0, 0, d),
+				IsRestDay:     d >= 3, // 3 training days/week
+			})
+			if d < 3 {
+				sp, _ := roadmap.NewSessionPlan(roadmap.SessionPlanInfo{
+					SessionPlanID:      "sp-" + itoa(w) + "-" + itoa(d),
+					DayPlanID:          dp.ID(),
+					WeekPlanID:         wp.ID(),
+					RoadmapID:          "rm-1",
+					UserID:             "user-1",
+					ScheduledDate:      weekStart.AddDate(0, 0, d),
+					TargetMuscleGroups: []string{"chest"},
+					Prescription: roadmap.WorkoutPrescription{
+						MainExercises: []roadmap.PrescribedExercise{
+							{ExerciseID: "ex-bench", ExerciseName: "Bench", TargetSets: 3, TargetReps: 8, TargetWeight: 60, TargetRPE: 7},
+						},
+					},
+				}, time.Now())
+				_ = dp.AddSession(sp)
+			}
+			_ = wp.AddDay(dp)
+		}
+		weeks = append(weeks, wp)
+	}
+	r, err := roadmap.NewRoadmap(roadmap.RoadmapInfo{
+		RoadmapID: "rm-1",
+		UserID:    "user-1",
+		StartDate: base,
+		EndDate:   base.AddDate(0, 0, 28),
+	}, weeks, time.Now())
+	if err != nil {
+		t.Fatalf("roadmap: %v", err)
+	}
+	return r
+}
+
+func TestGuardrail_Approved_Baseline(t *testing.T) {
+	r := buildValidRoadmap(t)
+	e := NewEngine(nil, func(id string) float64 {
+		if id == "ex-bench" {
+			return 60.0
+		}
+		return 0
+	}, nil)
+	got := e.Check(r)
+	if got.Status != StatusApproved {
+		t.Errorf("status = %s, violations = %+v", got.Status, got.Violations)
+	}
+}
+
+func TestGuardrail_RejectsWeightOverBand(t *testing.T) {
+	r := buildValidRoadmap(t)
+	// Baseline PR 40 → 60kg exceeds +30% (52kg cap).
+	e := NewEngine(nil, func(id string) float64 {
+		if id == "ex-bench" {
+			return 40.0
+		}
+		return 0
+	}, nil)
+	got := e.Check(r)
+	if got.Status != StatusRejected {
+		t.Fatalf("expected rejected")
+	}
+	foundBRAC02 := false
+	for _, v := range got.Violations {
+		if v.Code == "BR-AC-02" {
+			foundBRAC02 = true
+			break
+		}
+	}
+	if !foundBRAC02 {
+		t.Errorf("expected BR-AC-02 violation, got: %+v", got.Violations)
+	}
+}
+
+func TestGuardrail_RejectsInjuryTargeted(t *testing.T) {
+	r := buildValidRoadmap(t)
+	// All sessions target "chest" — injury on chest should reject them all.
+	e := NewEngine(nil, nil, []port.InjuryStatus{
+		{MuscleGroup: "chest"},
+	})
+	got := e.Check(r)
+	if got.Status != StatusRejected {
+		t.Fatalf("expected rejected")
+	}
+	foundBRAC09 := false
+	for _, v := range got.Violations {
+		if v.Code == "BR-AC-09" {
+			foundBRAC09 = true
+			break
+		}
+	}
+	if !foundBRAC09 {
+		t.Errorf("expected BR-AC-09 violation")
+	}
+}
+
+func TestGuardrail_RecoveredInjury_NotFlagged(t *testing.T) {
+	r := buildValidRoadmap(t)
+	rec := time.Now()
+	e := NewEngine(nil, nil, []port.InjuryStatus{
+		{MuscleGroup: "chest", RecoveredAt: &rec},
+	})
+	got := e.Check(r)
+	if got.Status != StatusApproved {
+		t.Errorf("expected approved for recovered injury, got %s: %+v", got.Status, got.Violations)
+	}
+}
+
+func TestGuardrail_NilRoadmapRejected(t *testing.T) {
+	e := NewEngine(nil, nil, nil)
+	got := e.Check(nil)
+	if got.Status != StatusRejected {
+		t.Errorf("nil roadmap should reject")
+	}
+}

--- a/internal/coaching/infrastructure/persistence/mapping.go
+++ b/internal/coaching/infrastructure/persistence/mapping.go
@@ -1,0 +1,176 @@
+package persistence
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+)
+
+// ---------- Roadmap ----------
+
+func toRoadmapRecord(r *roadmap.Roadmap) roadmapRecord {
+	info := r.Info()
+	return roadmapRecord{
+		RoadmapID: info.RoadmapID,
+		UserID:    info.UserID,
+		Status:    string(info.Status),
+		StartDate: info.StartDate,
+		EndDate:   info.EndDate,
+		CreatedAt: info.CreatedAt,
+		UpdatedAt: info.UpdatedAt,
+	}
+}
+
+func fromRoadmapRecord(rec roadmapRecord, weeks []*roadmap.WeekPlan) (*roadmap.Roadmap, error) {
+	return roadmap.RehydrateRoadmap(roadmap.RoadmapInfo{
+		RoadmapID: rec.RoadmapID,
+		UserID:    rec.UserID,
+		Status:    roadmap.RoadmapStatus(rec.Status),
+		StartDate: rec.StartDate,
+		EndDate:   rec.EndDate,
+		CreatedAt: rec.CreatedAt,
+		UpdatedAt: rec.UpdatedAt,
+	}, weeks)
+}
+
+// ---------- WeekPlan ----------
+
+func toWeekPlanRecord(w *roadmap.WeekPlan) weekPlanRecord {
+	info := w.Info()
+	return weekPlanRecord{
+		WeekPlanID:      info.WeekPlanID,
+		RoadmapID:       info.RoadmapID,
+		UserID:          info.UserID,
+		WeekNumber:      int16(info.WeekNumber),
+		Phase:           string(info.Phase),
+		TargetRPE:       info.TargetRPE,
+		StartDate:       info.StartDate,
+		EndDate:         info.EndDate,
+		MuscleSplitType: info.MuscleSplitType,
+	}
+}
+
+func fromWeekPlanRecord(rec weekPlanRecord, days []*roadmap.DayPlan) (*roadmap.WeekPlan, error) {
+	return roadmap.RehydrateWeekPlan(roadmap.WeekPlanInfo{
+		WeekPlanID:      rec.WeekPlanID,
+		RoadmapID:       rec.RoadmapID,
+		UserID:          rec.UserID,
+		WeekNumber:      int32(rec.WeekNumber),
+		Phase:           roadmap.Phase(rec.Phase),
+		TargetRPE:       rec.TargetRPE,
+		StartDate:       rec.StartDate,
+		EndDate:         rec.EndDate,
+		MuscleSplitType: rec.MuscleSplitType,
+	}, days)
+}
+
+// ---------- DayPlan ----------
+
+func toDayPlanRecord(d *roadmap.DayPlan) dayPlanRecord {
+	info := d.Info()
+	return dayPlanRecord{
+		DayPlanID:     info.DayPlanID,
+		WeekPlanID:    info.WeekPlanID,
+		RoadmapID:     info.RoadmapID,
+		UserID:        info.UserID,
+		ScheduledDate: info.ScheduledDate,
+		IsRestDay:     info.IsRestDay,
+	}
+}
+
+func fromDayPlanRecord(rec dayPlanRecord, sessions []*roadmap.SessionPlan) (*roadmap.DayPlan, error) {
+	return roadmap.RehydrateDayPlan(roadmap.DayPlanInfo{
+		DayPlanID:     rec.DayPlanID,
+		WeekPlanID:    rec.WeekPlanID,
+		RoadmapID:     rec.RoadmapID,
+		UserID:        rec.UserID,
+		ScheduledDate: rec.ScheduledDate,
+		IsRestDay:     rec.IsRestDay,
+	}, sessions)
+}
+
+// ---------- SessionPlan ----------
+
+func toSessionPlanRecord(s *roadmap.SessionPlan) (sessionPlanRecord, error) {
+	info := s.Info()
+	prescBytes, err := json.Marshal(info.Prescription)
+	if err != nil {
+		return sessionPlanRecord{}, fmt.Errorf("marshal prescription: %w", err)
+	}
+	musclesBytes, err := json.Marshal(info.TargetMuscleGroups)
+	if err != nil {
+		return sessionPlanRecord{}, fmt.Errorf("marshal muscle groups: %w", err)
+	}
+	rec := sessionPlanRecord{
+		SessionPlanID:      info.SessionPlanID,
+		DayPlanID:          info.DayPlanID,
+		WeekPlanID:         info.WeekPlanID,
+		RoadmapID:          info.RoadmapID,
+		UserID:             info.UserID,
+		ScheduledDate:      info.ScheduledDate,
+		SlotTime:           info.SlotTime,
+		Status:             string(info.Status),
+		TargetMuscleGroups: musclesBytes,
+		Prescription:       prescBytes,
+		Reasoning:          info.Reasoning,
+		GeneratedAt:        info.GeneratedAt,
+	}
+	if info.CompletedAt != nil {
+		rec.CompletedAt = sql.NullTime{Time: *info.CompletedAt, Valid: true}
+	}
+	if info.SessionSCR != nil {
+		rec.SessionSCR = sql.NullFloat64{Float64: float64(*info.SessionSCR), Valid: true}
+	}
+	if info.SessionDeltaRPE != nil {
+		rec.SessionDeltaRPE = sql.NullFloat64{Float64: float64(*info.SessionDeltaRPE), Valid: true}
+	}
+	return rec, nil
+}
+
+func fromSessionPlanRecord(rec sessionPlanRecord) (*roadmap.SessionPlan, error) {
+	var presc roadmap.WorkoutPrescription
+	if len(rec.Prescription) > 0 {
+		if err := json.Unmarshal(rec.Prescription, &presc); err != nil {
+			return nil, fmt.Errorf("unmarshal prescription: %w", err)
+		}
+	}
+	var muscles []string
+	if len(rec.TargetMuscleGroups) > 0 {
+		if err := json.Unmarshal(rec.TargetMuscleGroups, &muscles); err != nil {
+			return nil, fmt.Errorf("unmarshal muscle groups: %w", err)
+		}
+	}
+	info := roadmap.SessionPlanInfo{
+		SessionPlanID:      rec.SessionPlanID,
+		DayPlanID:          rec.DayPlanID,
+		WeekPlanID:         rec.WeekPlanID,
+		RoadmapID:          rec.RoadmapID,
+		UserID:             rec.UserID,
+		ScheduledDate:      rec.ScheduledDate,
+		SlotTime:           rec.SlotTime,
+		Status:             roadmap.SessionPlanStatus(rec.Status),
+		TargetMuscleGroups: muscles,
+		Prescription:       presc,
+		Reasoning:          rec.Reasoning,
+		GeneratedAt:        rec.GeneratedAt,
+	}
+	if rec.CompletedAt.Valid {
+		t := rec.CompletedAt.Time
+		info.CompletedAt = &t
+	}
+	if rec.SessionSCR.Valid {
+		v := float32(rec.SessionSCR.Float64)
+		info.SessionSCR = &v
+	}
+	if rec.SessionDeltaRPE.Valid {
+		v := float32(rec.SessionDeltaRPE.Float64)
+		info.SessionDeltaRPE = &v
+	}
+	return roadmap.RehydrateSessionPlan(info)
+}
+
+// Unused import guard.
+var _ = time.Time{}

--- a/internal/coaching/infrastructure/persistence/models.go
+++ b/internal/coaching/infrastructure/persistence/models.go
@@ -1,0 +1,98 @@
+package persistence
+
+import (
+	"database/sql"
+	"time"
+)
+
+// roadmapRecord maps coaching.roadmaps.
+type roadmapRecord struct {
+	RoadmapID string    `gorm:"column:roadmap_id;primaryKey"`
+	UserID    string    `gorm:"column:user_id;not null"`
+	Status    string    `gorm:"column:status;not null"`
+	StartDate time.Time `gorm:"column:start_date;not null;type:date"`
+	EndDate   time.Time `gorm:"column:end_date;not null;type:date"`
+	CreatedAt time.Time `gorm:"column:created_at"`
+	UpdatedAt time.Time `gorm:"column:updated_at"`
+}
+
+func (roadmapRecord) TableName() string { return "coaching.roadmaps" }
+
+// weekPlanRecord maps coaching.week_plans.
+type weekPlanRecord struct {
+	WeekPlanID      string    `gorm:"column:week_plan_id;primaryKey"`
+	RoadmapID       string    `gorm:"column:roadmap_id;not null"`
+	UserID          string    `gorm:"column:user_id;not null"`
+	WeekNumber      int16     `gorm:"column:week_number;not null"`
+	Phase           string    `gorm:"column:phase;not null"`
+	TargetRPE       float32   `gorm:"column:target_rpe;not null"`
+	StartDate       time.Time `gorm:"column:start_date;not null;type:date"`
+	EndDate         time.Time `gorm:"column:end_date;not null;type:date"`
+	MuscleSplitType string    `gorm:"column:muscle_split_type"`
+	CreatedAt       time.Time `gorm:"column:created_at"`
+}
+
+func (weekPlanRecord) TableName() string { return "coaching.week_plans" }
+
+// dayPlanRecord maps coaching.day_plans.
+type dayPlanRecord struct {
+	DayPlanID     string    `gorm:"column:day_plan_id;primaryKey"`
+	WeekPlanID    string    `gorm:"column:week_plan_id;not null"`
+	RoadmapID     string    `gorm:"column:roadmap_id;not null"`
+	UserID        string    `gorm:"column:user_id;not null"`
+	ScheduledDate time.Time `gorm:"column:scheduled_date;not null;type:date"`
+	IsRestDay     bool      `gorm:"column:is_rest_day;not null;default:false"`
+	CreatedAt     time.Time `gorm:"column:created_at"`
+}
+
+func (dayPlanRecord) TableName() string { return "coaching.day_plans" }
+
+// sessionPlanRecord maps coaching.session_plans. Prescription and
+// TargetMuscleGroups are JSONB blobs.
+type sessionPlanRecord struct {
+	SessionPlanID       string          `gorm:"column:session_plan_id;primaryKey"`
+	DayPlanID           string          `gorm:"column:day_plan_id;not null"`
+	WeekPlanID          string          `gorm:"column:week_plan_id;not null"`
+	RoadmapID           string          `gorm:"column:roadmap_id;not null"`
+	UserID              string          `gorm:"column:user_id;not null"`
+	ScheduledDate       time.Time       `gorm:"column:scheduled_date;not null;type:date"`
+	SlotTime            string          `gorm:"column:slot_time"`
+	Status              string          `gorm:"column:status;not null"`
+	TargetMuscleGroups  []byte          `gorm:"column:target_muscle_groups;type:jsonb"`
+	Prescription        []byte          `gorm:"column:prescription;type:jsonb"`
+	Reasoning           string          `gorm:"column:reasoning"`
+	GeneratedAt         time.Time       `gorm:"column:generated_at"`
+	CompletedAt         sql.NullTime    `gorm:"column:completed_at"`
+	SessionSCR          sql.NullFloat64 `gorm:"column:session_scr"`
+	SessionDeltaRPE     sql.NullFloat64 `gorm:"column:session_delta_rpe"`
+}
+
+func (sessionPlanRecord) TableName() string { return "coaching.session_plans" }
+
+// outboxRecord maps coaching.outbox.
+type outboxRecord struct {
+	ID           string       `gorm:"column:id;primaryKey"`
+	EventID      string       `gorm:"column:event_id;not null"`
+	EventType    string       `gorm:"column:event_type;not null"`
+	Payload      []byte       `gorm:"column:payload;not null;type:jsonb"`
+	PartitionKey string       `gorm:"column:partition_key;not null"`
+	CreatedAt    time.Time    `gorm:"column:created_at"`
+	Published    bool         `gorm:"column:published;default:false"`
+	PublishedAt  sql.NullTime `gorm:"column:published_at"`
+}
+
+func (outboxRecord) TableName() string { return "coaching.outbox" }
+
+// outboxLogRecord maps coaching.outbox_log (D9 consumer idempotency).
+type outboxLogRecord struct {
+	ID           string    `gorm:"column:id;primaryKey"`
+	EventID      string    `gorm:"column:event_id;not null"`
+	EventType    string    `gorm:"column:event_type;not null"`
+	Payload      []byte    `gorm:"column:payload;not null;type:jsonb"`
+	PartitionKey string    `gorm:"column:partition_key;not null"`
+	ProcessedAt  time.Time `gorm:"column:processed_at"`
+	Status       string    `gorm:"column:status;not null"`
+	ErrorMessage string    `gorm:"column:error_message"`
+}
+
+func (outboxLogRecord) TableName() string { return "coaching.outbox_log" }

--- a/internal/coaching/infrastructure/persistence/outbox_repository.go
+++ b/internal/coaching/infrastructure/persistence/outbox_repository.go
@@ -1,0 +1,133 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// OutboxRepository implements port.OutboxRepository.
+type OutboxRepository struct {
+	db *gorm.DB
+}
+
+var _ port.OutboxRepository = (*OutboxRepository)(nil)
+
+// NewOutboxRepository constructs the outbox adapter.
+func NewOutboxRepository(db *gorm.DB) *OutboxRepository {
+	return &OutboxRepository{db: db}
+}
+
+func (r *OutboxRepository) getDB(ctx context.Context) *gorm.DB {
+	if tx := GetTx(ctx); tx != nil {
+		return tx
+	}
+	return r.db.WithContext(ctx)
+}
+
+// Save persists one outbox record.
+func (r *OutboxRepository) Save(ctx context.Context, rec *port.OutboxRecord) error {
+	if rec == nil {
+		return errors.New("nil outbox record")
+	}
+	obr := outboxRecord{
+		ID:           rec.ID,
+		EventID:      rec.EventID,
+		EventType:    rec.EventType,
+		Payload:      rec.Payload,
+		PartitionKey: rec.PartitionKey,
+		CreatedAt:    rec.CreatedAt,
+		Published:    rec.Published,
+	}
+	if err := r.getDB(ctx).Create(&obr).Error; err != nil {
+		return fmt.Errorf("insert outbox: %w", err)
+	}
+	return nil
+}
+
+// FetchUnpublished returns unpublished events ordered by created_at ASC.
+func (r *OutboxRepository) FetchUnpublished(ctx context.Context, limit int) ([]*port.OutboxRecord, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	var recs []outboxRecord
+	if err := r.getDB(ctx).
+		Where("published = ?", false).
+		Order("created_at ASC").
+		Limit(limit).
+		Find(&recs).Error; err != nil {
+		return nil, fmt.Errorf("fetch unpublished: %w", err)
+	}
+	out := make([]*port.OutboxRecord, 0, len(recs))
+	for i := range recs {
+		out = append(out, &port.OutboxRecord{
+			ID:           recs[i].ID,
+			EventID:      recs[i].EventID,
+			EventType:    recs[i].EventType,
+			Payload:      recs[i].Payload,
+			PartitionKey: recs[i].PartitionKey,
+			CreatedAt:    recs[i].CreatedAt,
+			Published:    recs[i].Published,
+		})
+	}
+	return out, nil
+}
+
+// MarkPublished flips published=true for the given ids.
+func (r *OutboxRepository) MarkPublished(ctx context.Context, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	err := r.getDB(ctx).
+		Model(&outboxRecord{}).
+		Where("id IN ?", ids).
+		Updates(map[string]any{
+			"published":    true,
+			"published_at": time.Now(),
+		}).Error
+	if err != nil {
+		return fmt.Errorf("mark published: %w", err)
+	}
+	return nil
+}
+
+// ExecuteInLock wraps fn in a transaction guarded by pg_try_advisory_xact_lock.
+func (r *OutboxRepository) ExecuteInLock(ctx context.Context, lockID int64, fn func(txCtx context.Context) error) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var acquired bool
+		if err := tx.Raw("SELECT pg_try_advisory_xact_lock(?)", lockID).Scan(&acquired).Error; err != nil {
+			return fmt.Errorf("try advisory lock: %w", err)
+		}
+		if !acquired {
+			return nil // Skip; another worker holds it.
+		}
+		return fn(WithTx(ctx, tx))
+	})
+}
+
+// LogProcessed records an inbound event in coaching.outbox_log. Returns
+// (fresh=true, nil) on first record, (fresh=false, nil) on duplicate event_id (D9).
+func (r *OutboxRepository) LogProcessed(ctx context.Context, eventID, eventType, partitionKey string, payload []byte) (bool, error) {
+	rec := outboxLogRecord{
+		ID:           eventID, // Use event_id as PK to make retries idempotent.
+		EventID:      eventID,
+		EventType:    eventType,
+		Payload:      payload,
+		PartitionKey: partitionKey,
+		ProcessedAt:  time.Now(),
+		Status:       "SUCCESS",
+	}
+	res := r.getDB(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "event_id"}},
+		DoNothing: true,
+	}).Create(&rec)
+	if err := res.Error; err != nil {
+		return false, fmt.Errorf("log processed: %w", err)
+	}
+	return res.RowsAffected > 0, nil
+}

--- a/internal/coaching/infrastructure/persistence/roadmap_repository.go
+++ b/internal/coaching/infrastructure/persistence/roadmap_repository.go
@@ -1,0 +1,199 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// RoadmapRepository is the GORM-backed adapter for port.RoadmapRepository.
+type RoadmapRepository struct {
+	db *gorm.DB
+}
+
+var _ port.RoadmapRepository = (*RoadmapRepository)(nil)
+
+// NewRoadmapRepository constructs the repository.
+func NewRoadmapRepository(db *gorm.DB) *RoadmapRepository {
+	return &RoadmapRepository{db: db}
+}
+
+func (r *RoadmapRepository) getDB(ctx context.Context) *gorm.DB {
+	if tx := GetTx(ctx); tx != nil {
+		return tx
+	}
+	return r.db.WithContext(ctx)
+}
+
+// Save upserts the roadmap tree in a single call. Callers should already be
+// inside a transaction (TxManager.WithTransaction) when saving alongside outbox.
+func (r *RoadmapRepository) Save(ctx context.Context, rm *roadmap.Roadmap) error {
+	if rm == nil {
+		return errors.New("nil roadmap")
+	}
+	db := r.getDB(ctx)
+
+	if err := db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "roadmap_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"status", "start_date", "end_date", "updated_at"}),
+	}).Create(toRoadmapRecordPtr(rm)).Error; err != nil {
+		return fmt.Errorf("upsert roadmap: %w", err)
+	}
+
+	for _, w := range rm.Weeks() {
+		wr := toWeekPlanRecord(w)
+		if err := db.Clauses(clause.OnConflict{
+			Columns: []clause.Column{{Name: "week_plan_id"}},
+			DoUpdates: clause.AssignmentColumns([]string{
+				"phase", "target_rpe", "start_date", "end_date", "muscle_split_type",
+			}),
+		}).Create(&wr).Error; err != nil {
+			return fmt.Errorf("upsert week plan %s: %w", wr.WeekPlanID, err)
+		}
+		for _, d := range w.Days() {
+			dr := toDayPlanRecord(d)
+			if err := db.Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "day_plan_id"}},
+				DoUpdates: clause.AssignmentColumns([]string{"scheduled_date", "is_rest_day"}),
+			}).Create(&dr).Error; err != nil {
+				return fmt.Errorf("upsert day plan %s: %w", dr.DayPlanID, err)
+			}
+			for _, s := range d.Sessions() {
+				sr, err := toSessionPlanRecord(s)
+				if err != nil {
+					return err
+				}
+				if err := db.Clauses(clause.OnConflict{
+					Columns: []clause.Column{{Name: "session_plan_id"}},
+					DoUpdates: clause.AssignmentColumns([]string{
+						"slot_time", "status", "target_muscle_groups", "prescription",
+						"reasoning", "generated_at", "completed_at", "session_scr", "session_delta_rpe",
+					}),
+				}).Create(&sr).Error; err != nil {
+					return fmt.Errorf("upsert session plan %s: %w", sr.SessionPlanID, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// FindByID loads a full roadmap tree.
+func (r *RoadmapRepository) FindByID(ctx context.Context, roadmapID string) (*roadmap.Roadmap, error) {
+	db := r.getDB(ctx)
+	var rec roadmapRecord
+	if err := db.Where("roadmap_id = ?", roadmapID).First(&rec).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, roadmap.ErrRoadmapNotFound
+		}
+		return nil, fmt.Errorf("find roadmap: %w", err)
+	}
+	return r.loadTree(ctx, rec)
+}
+
+// FindActiveByUser returns the (up to 1) ACTIVE roadmap for a user.
+func (r *RoadmapRepository) FindActiveByUser(ctx context.Context, userID string) (*roadmap.Roadmap, error) {
+	db := r.getDB(ctx)
+	var rec roadmapRecord
+	if err := db.Where("user_id = ? AND status = ?", userID, string(roadmap.RoadmapStatusActive)).First(&rec).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, roadmap.ErrRoadmapNotFound
+		}
+		return nil, fmt.Errorf("find active roadmap: %w", err)
+	}
+	return r.loadTree(ctx, rec)
+}
+
+// ListByUser returns roadmaps for a user with optional status filter.
+func (r *RoadmapRepository) ListByUser(ctx context.Context, userID string, status roadmap.RoadmapStatus, limit, offset int) ([]*roadmap.Roadmap, error) {
+	db := r.getDB(ctx)
+	q := db.Where("user_id = ?", userID)
+	if status != "" {
+		q = q.Where("status = ?", string(status))
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	q = q.Order("created_at DESC").Limit(limit).Offset(offset)
+
+	var recs []roadmapRecord
+	if err := q.Find(&recs).Error; err != nil {
+		return nil, fmt.Errorf("list roadmaps: %w", err)
+	}
+	out := make([]*roadmap.Roadmap, 0, len(recs))
+	for _, rec := range recs {
+		rm, err := r.loadTree(ctx, rec)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, rm)
+	}
+	return out, nil
+}
+
+// FindSessionByID loads the parent roadmap of a session by session id.
+func (r *RoadmapRepository) FindSessionByID(ctx context.Context, sessionPlanID string) (*roadmap.Roadmap, error) {
+	db := r.getDB(ctx)
+	var srec sessionPlanRecord
+	if err := db.Where("session_plan_id = ?", sessionPlanID).First(&srec).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, roadmap.ErrSessionNotFound
+		}
+		return nil, fmt.Errorf("find session: %w", err)
+	}
+	return r.FindByID(ctx, srec.RoadmapID)
+}
+
+// loadTree loads all descendants of the given roadmap record.
+func (r *RoadmapRepository) loadTree(ctx context.Context, rec roadmapRecord) (*roadmap.Roadmap, error) {
+	db := r.getDB(ctx)
+	var wRecs []weekPlanRecord
+	if err := db.Where("roadmap_id = ?", rec.RoadmapID).Order("week_number ASC").Find(&wRecs).Error; err != nil {
+		return nil, fmt.Errorf("load weeks: %w", err)
+	}
+	var dRecs []dayPlanRecord
+	if err := db.Where("roadmap_id = ?", rec.RoadmapID).Order("scheduled_date ASC").Find(&dRecs).Error; err != nil {
+		return nil, fmt.Errorf("load days: %w", err)
+	}
+	var sRecs []sessionPlanRecord
+	if err := db.Where("roadmap_id = ?", rec.RoadmapID).Order("scheduled_date ASC").Find(&sRecs).Error; err != nil {
+		return nil, fmt.Errorf("load sessions: %w", err)
+	}
+
+	sessionsByDay := map[string][]*roadmap.SessionPlan{}
+	for _, s := range sRecs {
+		sp, err := fromSessionPlanRecord(s)
+		if err != nil {
+			return nil, err
+		}
+		sessionsByDay[s.DayPlanID] = append(sessionsByDay[s.DayPlanID], sp)
+	}
+	daysByWeek := map[string][]*roadmap.DayPlan{}
+	for _, d := range dRecs {
+		dp, err := fromDayPlanRecord(d, sessionsByDay[d.DayPlanID])
+		if err != nil {
+			return nil, err
+		}
+		daysByWeek[d.WeekPlanID] = append(daysByWeek[d.WeekPlanID], dp)
+	}
+	weeks := make([]*roadmap.WeekPlan, 0, len(wRecs))
+	for _, w := range wRecs {
+		wp, err := fromWeekPlanRecord(w, daysByWeek[w.WeekPlanID])
+		if err != nil {
+			return nil, err
+		}
+		weeks = append(weeks, wp)
+	}
+	return fromRoadmapRecord(rec, weeks)
+}
+
+// toRoadmapRecordPtr is a small helper to avoid taking &foo of a function return.
+func toRoadmapRecordPtr(rm *roadmap.Roadmap) *roadmapRecord {
+	rec := toRoadmapRecord(rm)
+	return &rec
+}

--- a/internal/coaching/infrastructure/persistence/tx.go
+++ b/internal/coaching/infrastructure/persistence/tx.go
@@ -1,0 +1,30 @@
+package persistence
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+type txKey struct{}
+
+// WithTx embeds an active GORM transaction into the context.
+func WithTx(ctx context.Context, tx *gorm.DB) context.Context {
+	return context.WithValue(ctx, txKey{}, tx)
+}
+
+// GetTx returns the transaction from context, or nil.
+func GetTx(ctx context.Context) *gorm.DB {
+	if tx, ok := ctx.Value(txKey{}).(*gorm.DB); ok {
+		return tx
+	}
+	return nil
+}
+
+// GetDB returns the transaction if present, otherwise defaultDB.WithContext(ctx).
+func GetDB(ctx context.Context, defaultDB *gorm.DB) *gorm.DB {
+	if tx := GetTx(ctx); tx != nil {
+		return tx
+	}
+	return defaultDB.WithContext(ctx)
+}

--- a/internal/coaching/infrastructure/persistence/tx_manager.go
+++ b/internal/coaching/infrastructure/persistence/tx_manager.go
@@ -1,0 +1,45 @@
+package persistence
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	"gorm.io/gorm"
+)
+
+// SQLTransactionManager implements port.TransactionManager using GORM.
+type SQLTransactionManager struct {
+	db *gorm.DB
+}
+
+var _ port.TransactionManager = (*SQLTransactionManager)(nil)
+
+// NewSQLTransactionManager constructs the tx manager.
+func NewSQLTransactionManager(db *gorm.DB) *SQLTransactionManager {
+	return &SQLTransactionManager{db: db}
+}
+
+// WithTransaction runs fn inside a GORM transaction. If fn returns an error,
+// the transaction is rolled back. Panics are re-thrown after rollback.
+func (m *SQLTransactionManager) WithTransaction(ctx context.Context, fn func(txCtx context.Context) error) error {
+	tx := m.db.WithContext(ctx).Begin()
+	if tx.Error != nil {
+		return fmt.Errorf("begin coaching tx: %w", tx.Error)
+	}
+	defer func() {
+		if p := recover(); p != nil {
+			tx.Rollback()
+			panic(p)
+		}
+	}()
+	txCtx := WithTx(ctx, tx)
+	if err := fn(txCtx); err != nil {
+		tx.Rollback()
+		return err
+	}
+	if err := tx.Commit().Error; err != nil {
+		return fmt.Errorf("commit coaching tx: %w", err)
+	}
+	return nil
+}

--- a/internal/coaching/infrastructure/worker/outbox_worker.go
+++ b/internal/coaching/infrastructure/worker/outbox_worker.go
@@ -1,0 +1,80 @@
+// Package worker contains the coaching OutboxWorker that polls
+// coaching.outbox and publishes events to the broker.
+package worker
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+)
+
+// LockID is the Postgres advisory lock ID reserved for coaching outbox
+// serialization. Distinct from workout_execution (99887766).
+const LockID int64 = 88776655
+
+// OutboxWorker polls coaching.outbox and publishes to Kafka.
+type OutboxWorker struct {
+	outbox    port.OutboxRepository
+	publisher port.BrokerPublisher
+	interval  time.Duration
+	batchSize int
+}
+
+// NewOutboxWorker constructs the worker.
+func NewOutboxWorker(outbox port.OutboxRepository, publisher port.BrokerPublisher, interval time.Duration) *OutboxWorker {
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	return &OutboxWorker{outbox: outbox, publisher: publisher, interval: interval, batchSize: 100}
+}
+
+// Start runs the worker until ctx is cancelled.
+func (w *OutboxWorker) Start(ctx context.Context) {
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	log.Printf("[Coaching] Outbox worker started (interval=%v)", w.interval)
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("[Coaching] Outbox worker stopping (ctx cancelled)")
+			return
+		case <-ticker.C:
+			if err := w.tick(ctx); err != nil {
+				log.Printf("[Coaching] outbox tick error: %v", err)
+			}
+		}
+	}
+}
+
+func (w *OutboxWorker) tick(ctx context.Context) error {
+	var records []*port.OutboxRecord
+	err := w.outbox.ExecuteInLock(ctx, LockID, func(txCtx context.Context) error {
+		var e error
+		records, e = w.outbox.FetchUnpublished(txCtx, w.batchSize)
+		return e
+	})
+	if err != nil {
+		return fmt.Errorf("fetch unpublished: %w", err)
+	}
+	if len(records) == 0 {
+		return nil
+	}
+
+	if w.publisher != nil {
+		if err := w.publisher.PublishBatch(ctx, records); err != nil {
+			return fmt.Errorf("publish batch: %w", err)
+		}
+	}
+
+	ids := make([]string, 0, len(records))
+	for _, r := range records {
+		ids = append(ids, r.ID)
+	}
+	return w.outbox.ExecuteInLock(ctx, LockID, func(txCtx context.Context) error {
+		return w.outbox.MarkPublished(txCtx, ids)
+	})
+}

--- a/internal/coaching/transport/consumer/workout_execution_consumer.go
+++ b/internal/coaching/transport/consumer/workout_execution_consumer.go
@@ -1,0 +1,137 @@
+// Package consumer routes inbound events (Kafka CloudEvents) to command handlers.
+// Idempotency is enforced by coaching.outbox_log (D9): consumer checks event_id
+// before dispatching, and records the event after successful processing.
+package consumer
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/command"
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+)
+
+// cloudEventEnvelope is the minimum structure we parse from Kafka message value.
+type cloudEventEnvelope struct {
+	SpecVersion string          `json:"specversion"`
+	ID          string          `json:"id"`
+	Source      string          `json:"source"`
+	Type        string          `json:"type"`
+	Data        json.RawMessage `json:"data"`
+}
+
+// WorkoutSessionCompletedPayload mirrors the proto CloudEvent data field.
+type WorkoutSessionCompletedPayload struct {
+	SessionID        string  `json:"session_id"`
+	UserID           string  `json:"user_id"`
+	CompletedAt      string  `json:"completed_at"` // RFC3339
+	TotalSets        int32   `json:"total_sets"`
+	TotalVolume      float32 `json:"total_volume"`
+	AverageFormScore float32 `json:"average_form_score"`
+	AverageRPE       float32 `json:"average_rpe"`
+	PlanID           string  `json:"plan_id"`
+}
+
+// WorkoutSessionAbortedPayload mirrors the proto CloudEvent data field.
+type WorkoutSessionAbortedPayload struct {
+	SessionID string `json:"session_id"`
+	UserID    string `json:"user_id"`
+	AbortedAt string `json:"aborted_at"`
+	Reason    string `json:"reason"`
+	PlanID    string `json:"plan_id"`
+}
+
+// WorkoutExecutionConsumer routes WorkoutSessionCompleted/Aborted events to
+// the appropriate command handler.
+type WorkoutExecutionConsumer struct {
+	complete *command.CompleteSessionHandler
+	abort    *command.AbortSessionHandler
+	outbox   port.OutboxRepository
+}
+
+// NewWorkoutExecutionConsumer wires the consumer.
+func NewWorkoutExecutionConsumer(
+	complete *command.CompleteSessionHandler,
+	abort *command.AbortSessionHandler,
+	outbox port.OutboxRepository,
+) *WorkoutExecutionConsumer {
+	return &WorkoutExecutionConsumer{complete: complete, abort: abort, outbox: outbox}
+}
+
+// HandleMessage decodes and dispatches one Kafka message. Errors are returned
+// so the caller can decide retry vs DLQ policy.
+func (c *WorkoutExecutionConsumer) HandleMessage(ctx context.Context, rawValue []byte) error {
+	var env cloudEventEnvelope
+	if err := json.Unmarshal(rawValue, &env); err != nil {
+		return fmt.Errorf("decode cloud event: %w", err)
+	}
+	if env.ID == "" {
+		return errors.New("missing event id")
+	}
+
+	// D9: idempotency check via coaching.outbox_log
+	fresh, err := c.outbox.LogProcessed(ctx, env.ID, env.Type, "", rawValue)
+	if err != nil {
+		return fmt.Errorf("log processed: %w", err)
+	}
+	if !fresh {
+		log.Printf("[Coaching] Duplicate event skipped: id=%s type=%s", env.ID, env.Type)
+		return nil
+	}
+
+	switch env.Type {
+	case "contracts.core.workout_execution.v1.event.WorkoutSessionCompleted":
+		return c.handleCompleted(ctx, env.Data)
+	case "contracts.core.workout_execution.v1.event.WorkoutSessionAborted":
+		return c.handleAborted(ctx, env.Data)
+	default:
+		log.Printf("[Coaching] Ignoring unknown event type: %s", env.Type)
+		return nil
+	}
+}
+
+func (c *WorkoutExecutionConsumer) handleCompleted(ctx context.Context, data []byte) error {
+	var p WorkoutSessionCompletedPayload
+	if err := json.Unmarshal(data, &p); err != nil {
+		return fmt.Errorf("decode WorkoutSessionCompleted: %w", err)
+	}
+	if p.PlanID == "" {
+		log.Printf("[Coaching] WorkoutSessionCompleted missing plan_id; session=%s ignored", p.SessionID)
+		return nil
+	}
+	_, err := c.complete.Handle(ctx, command.CompleteSessionCommand{
+		SessionPlanID:       p.PlanID,
+		TotalActualSets:     int(p.TotalSets),
+		TotalPrescribedSets: 0, // Best-effort: recomputed inside handler if available.
+		AverageActualRPE:    float64(p.AverageRPE),
+		CompletedAt:         p.CompletedAt,
+	})
+	if errors.Is(err, roadmap.ErrSessionNotFound) {
+		log.Printf("[Coaching] WorkoutSessionCompleted references unknown plan_id=%s; ignoring", p.PlanID)
+		return nil
+	}
+	return err
+}
+
+func (c *WorkoutExecutionConsumer) handleAborted(ctx context.Context, data []byte) error {
+	var p WorkoutSessionAbortedPayload
+	if err := json.Unmarshal(data, &p); err != nil {
+		return fmt.Errorf("decode WorkoutSessionAborted: %w", err)
+	}
+	if p.PlanID == "" {
+		return nil
+	}
+	err := c.abort.Handle(ctx, command.AbortSessionCommand{
+		SessionPlanID: p.PlanID,
+		Reason:        p.Reason,
+	})
+	if errors.Is(err, roadmap.ErrSessionNotFound) {
+		log.Printf("[Coaching] WorkoutSessionAborted references unknown plan_id=%s; ignoring", p.PlanID)
+		return nil
+	}
+	return err
+}

--- a/internal/coaching/transport/consumer/workout_execution_consumer_test.go
+++ b/internal/coaching/transport/consumer/workout_execution_consumer_test.go
@@ -1,0 +1,84 @@
+package consumer
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+)
+
+type stubOutbox struct {
+	seen map[string]bool
+}
+
+func (s *stubOutbox) Save(context.Context, *port.OutboxRecord) error { return nil }
+func (s *stubOutbox) FetchUnpublished(context.Context, int) ([]*port.OutboxRecord, error) {
+	return nil, nil
+}
+func (s *stubOutbox) MarkPublished(context.Context, []string) error { return nil }
+func (s *stubOutbox) ExecuteInLock(ctx context.Context, _ int64, fn func(context.Context) error) error {
+	return fn(ctx)
+}
+func (s *stubOutbox) LogProcessed(_ context.Context, eventID, _, _ string, _ []byte) (bool, error) {
+	if s.seen == nil {
+		s.seen = map[string]bool{}
+	}
+	if s.seen[eventID] {
+		return false, nil
+	}
+	s.seen[eventID] = true
+	return true, nil
+}
+
+func makeCE(t *testing.T, id, typeStr string, dataObj any) []byte {
+	t.Helper()
+	dataBytes, err := json.Marshal(dataObj)
+	if err != nil {
+		t.Fatalf("marshal data: %v", err)
+	}
+	env := map[string]any{
+		"specversion": "1.0",
+		"id":          id,
+		"source":      "test",
+		"type":        typeStr,
+		"data":        json.RawMessage(dataBytes),
+	}
+	b, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal env: %v", err)
+	}
+	return b
+}
+
+func TestConsumer_UnknownEventType_Ignored(t *testing.T) {
+	c := NewWorkoutExecutionConsumer(nil, nil, &stubOutbox{})
+	raw := makeCE(t, "evt-1", "some.unknown.event", map[string]string{"x": "y"})
+	if err := c.HandleMessage(context.Background(), raw); err != nil {
+		t.Errorf("expected nil for unknown type, got %v", err)
+	}
+}
+
+func TestConsumer_MissingEventID(t *testing.T) {
+	c := NewWorkoutExecutionConsumer(nil, nil, &stubOutbox{})
+	raw := makeCE(t, "", "contracts.core.workout_execution.v1.event.WorkoutSessionCompleted",
+		WorkoutSessionCompletedPayload{PlanID: "sp-1"})
+	if err := c.HandleMessage(context.Background(), raw); err == nil {
+		t.Errorf("expected error for missing event id")
+	}
+}
+
+func TestConsumer_DuplicateEvent_Skipped(t *testing.T) {
+	stub := &stubOutbox{}
+	c := NewWorkoutExecutionConsumer(nil, nil, stub)
+	raw := makeCE(t, "evt-1", "contracts.core.workout_execution.v1.event.WorkoutSessionCompleted",
+		WorkoutSessionCompletedPayload{PlanID: "" /* deliberately empty to short-circuit before handler */})
+	// First call: fresh — since PlanID empty, handler no-ops.
+	if err := c.HandleMessage(context.Background(), raw); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	// Second call: duplicate — outbox_log dedup returns fresh=false.
+	if err := c.HandleMessage(context.Background(), raw); err != nil {
+		t.Errorf("second (duplicate): %v", err)
+	}
+}

--- a/internal/coaching/transport/grpc/server.go
+++ b/internal/coaching/transport/grpc/server.go
@@ -1,0 +1,309 @@
+// Package grpc implements the CoachingService gRPC endpoint.
+package grpc
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/genproto/googleapis/type/date"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pbmsg "github.com/viethung213/gym-companion/internal/gen/go/contracts/core/coaching/v1/message"
+	pbsvc "github.com/viethung213/gym-companion/internal/gen/go/contracts/core/coaching/v1/service"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/command"
+	"github.com/viethung213/gym-companion/internal/coaching/application/query"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+)
+
+// Server implements pbsvc.CoachingServiceServer.
+type Server struct {
+	pbsvc.UnimplementedCoachingServiceServer
+
+	initiate   *command.InitiateRoadmapHandler
+	regenerate *command.RegenerateScheduleHandler
+	queries    *query.Handlers
+}
+
+// NewServer wires the gRPC handler.
+func NewServer(
+	initiate *command.InitiateRoadmapHandler,
+	regenerate *command.RegenerateScheduleHandler,
+	queries *query.Handlers,
+) *Server {
+	return &Server{initiate: initiate, regenerate: regenerate, queries: queries}
+}
+
+// InitiateRoadmap implements UC-02.1.
+func (s *Server) InitiateRoadmap(ctx context.Context, req *pbmsg.InitiateRoadmapRequest) (*pbmsg.InitiateRoadmapResponse, error) {
+	if req.GetUserId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "user_id is required")
+	}
+	res, err := s.initiate.Handle(ctx, command.InitiateRoadmapCommand{UserID: req.GetUserId()})
+	if err != nil {
+		return nil, mapDomainErr(err)
+	}
+	return &pbmsg.InitiateRoadmapResponse{Roadmap: toPBRoadmap(res.Roadmap)}, nil
+}
+
+// GetActiveRoadmap returns the active roadmap for a user.
+func (s *Server) GetActiveRoadmap(ctx context.Context, req *pbmsg.GetActiveRoadmapRequest) (*pbmsg.GetActiveRoadmapResponse, error) {
+	if req.GetUserId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "user_id is required")
+	}
+	rm, err := s.queries.GetActiveRoadmap(ctx, query.GetActiveRoadmapQuery{UserID: req.GetUserId()})
+	if err != nil {
+		return nil, mapDomainErr(err)
+	}
+	return &pbmsg.GetActiveRoadmapResponse{Roadmap: toPBRoadmap(rm)}, nil
+}
+
+// GetRoadmap returns a specific roadmap.
+func (s *Server) GetRoadmap(ctx context.Context, req *pbmsg.GetRoadmapRequest) (*pbmsg.GetRoadmapResponse, error) {
+	if req.GetUserId() == "" || req.GetRoadmapId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "user_id and roadmap_id required")
+	}
+	rm, err := s.queries.GetRoadmap(ctx, query.GetRoadmapQuery{
+		UserID: req.GetUserId(), RoadmapID: req.GetRoadmapId(),
+	})
+	if err != nil {
+		return nil, mapDomainErr(err)
+	}
+	return &pbmsg.GetRoadmapResponse{Roadmap: toPBRoadmap(rm)}, nil
+}
+
+// ListRoadmaps returns paginated roadmaps.
+func (s *Server) ListRoadmaps(ctx context.Context, req *pbmsg.ListRoadmapsRequest) (*pbmsg.ListRoadmapsResponse, error) {
+	if req.GetUserId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "user_id required")
+	}
+	rms, err := s.queries.ListRoadmaps(ctx, query.ListRoadmapsQuery{
+		UserID: req.GetUserId(),
+		Status: pbStatusToDomain(req.GetStatus()),
+		Limit:  int(req.GetPageSize()),
+	})
+	if err != nil {
+		return nil, mapDomainErr(err)
+	}
+	resp := &pbmsg.ListRoadmapsResponse{Roadmaps: make([]*pbmsg.Roadmap, 0, len(rms))}
+	for _, rm := range rms {
+		resp.Roadmaps = append(resp.Roadmaps, toPBRoadmap(rm))
+	}
+	return resp, nil
+}
+
+// GetSessionPlan returns a specific session plan.
+func (s *Server) GetSessionPlan(ctx context.Context, req *pbmsg.GetSessionPlanRequest) (*pbmsg.GetSessionPlanResponse, error) {
+	if req.GetUserId() == "" || req.GetSessionPlanId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "user_id and session_plan_id required")
+	}
+	sp, err := s.queries.GetSessionPlan(ctx, query.GetSessionPlanQuery{
+		UserID: req.GetUserId(), SessionPlanID: req.GetSessionPlanId(),
+	})
+	if err != nil {
+		return nil, mapDomainErr(err)
+	}
+	return &pbmsg.GetSessionPlanResponse{SessionPlan: toPBSession(sp)}, nil
+}
+
+// RegenerateSchedule triggers UC-02.3.
+func (s *Server) RegenerateSchedule(ctx context.Context, req *pbmsg.RegenerateScheduleRequest) (*pbmsg.RegenerateScheduleResponse, error) {
+	if req.GetUserId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "user_id required")
+	}
+	res, err := s.regenerate.Handle(ctx, command.RegenerateScheduleCommand{
+		UserID: req.GetUserId(),
+		Reason: req.GetReason(),
+	})
+	if err != nil {
+		return nil, mapDomainErr(err)
+	}
+	return &pbmsg.RegenerateScheduleResponse{Roadmap: toPBRoadmap(res.Roadmap)}, nil
+}
+
+// -------- error mapping --------
+
+func mapDomainErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, roadmap.ErrRoadmapNotFound),
+		errors.Is(err, roadmap.ErrSessionNotFound):
+		return status.Error(codes.NotFound, err.Error())
+	case errors.Is(err, roadmap.ErrActiveRoadmapExists):
+		return status.Error(codes.AlreadyExists, err.Error())
+	case errors.Is(err, roadmap.ErrInvalidRoadmap),
+		errors.Is(err, roadmap.ErrInvalidStatus),
+		errors.Is(err, roadmap.ErrInvalidPhase),
+		errors.Is(err, roadmap.ErrInvalidTransition),
+		errors.Is(err, roadmap.ErrWeeklyCapExceeded),
+		errors.Is(err, roadmap.ErrSessionAlreadyFinal):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	default:
+		return status.Error(codes.Internal, err.Error())
+	}
+}
+
+// -------- domain -> protobuf mapping --------
+
+func toPBRoadmap(rm *roadmap.Roadmap) *pbmsg.Roadmap {
+	if rm == nil {
+		return nil
+	}
+	info := rm.Info()
+	pb := &pbmsg.Roadmap{
+		RoadmapId: info.RoadmapID,
+		UserId:    info.UserID,
+		Status:    domainStatusToPB(info.Status),
+		StartDate: dateToPB(info.StartDate.Year(), int(info.StartDate.Month()), info.StartDate.Day()),
+		EndDate:   dateToPB(info.EndDate.Year(), int(info.EndDate.Month()), info.EndDate.Day()),
+	}
+	for _, w := range rm.Weeks() {
+		pb.WeekPlans = append(pb.WeekPlans, toPBWeek(w))
+	}
+	return pb
+}
+
+func toPBWeek(w *roadmap.WeekPlan) *pbmsg.WeekPlan {
+	info := w.Info()
+	pb := &pbmsg.WeekPlan{
+		WeekPlanId:      info.WeekPlanID,
+		RoadmapId:       info.RoadmapID,
+		UserId:          info.UserID,
+		WeekNumber:      info.WeekNumber,
+		Phase:           domainPhaseToPB(info.Phase),
+		TargetRpe:       info.TargetRPE,
+		StartDate:       dateToPB(info.StartDate.Year(), int(info.StartDate.Month()), info.StartDate.Day()),
+		EndDate:         dateToPB(info.EndDate.Year(), int(info.EndDate.Month()), info.EndDate.Day()),
+		MuscleSplitType: info.MuscleSplitType,
+	}
+	for _, d := range w.Days() {
+		pb.DayPlans = append(pb.DayPlans, toPBDay(d))
+	}
+	return pb
+}
+
+func toPBDay(d *roadmap.DayPlan) *pbmsg.DayPlan {
+	info := d.Info()
+	pb := &pbmsg.DayPlan{
+		DayPlanId:     info.DayPlanID,
+		WeekPlanId:    info.WeekPlanID,
+		RoadmapId:     info.RoadmapID,
+		UserId:        info.UserID,
+		ScheduledDate: dateToPB(info.ScheduledDate.Year(), int(info.ScheduledDate.Month()), info.ScheduledDate.Day()),
+		IsRestDay:     info.IsRestDay,
+	}
+	for _, s := range d.Sessions() {
+		pb.SessionPlans = append(pb.SessionPlans, toPBSession(s))
+	}
+	return pb
+}
+
+func toPBSession(s *roadmap.SessionPlan) *pbmsg.SessionPlan {
+	info := s.Info()
+	pb := &pbmsg.SessionPlan{
+		SessionPlanId:      info.SessionPlanID,
+		DayPlanId:          info.DayPlanID,
+		WeekPlanId:         info.WeekPlanID,
+		RoadmapId:          info.RoadmapID,
+		UserId:             info.UserID,
+		ScheduledDate:      dateToPB(info.ScheduledDate.Year(), int(info.ScheduledDate.Month()), info.ScheduledDate.Day()),
+		SlotTime:           info.SlotTime,
+		Status:             domainSessionStatusToPB(info.Status),
+		TargetMuscleGroups: append([]string(nil), info.TargetMuscleGroups...),
+		Prescription:       toPBPrescription(info.Prescription),
+		Reasoning:          info.Reasoning,
+		GeneratedAt:        timestamppb.New(info.GeneratedAt),
+	}
+	return pb
+}
+
+func toPBPrescription(p roadmap.WorkoutPrescription) *pbmsg.WorkoutPrescription {
+	out := &pbmsg.WorkoutPrescription{
+		WarmUps:       make([]*pbmsg.PrescribedExercise, 0, len(p.WarmUps)),
+		MainExercises: make([]*pbmsg.PrescribedExercise, 0, len(p.MainExercises)),
+		CoolDowns:     make([]*pbmsg.PrescribedExercise, 0, len(p.CoolDowns)),
+	}
+	for _, e := range p.WarmUps {
+		out.WarmUps = append(out.WarmUps, toPBExercise(e))
+	}
+	for _, e := range p.MainExercises {
+		out.MainExercises = append(out.MainExercises, toPBExercise(e))
+	}
+	for _, e := range p.CoolDowns {
+		out.CoolDowns = append(out.CoolDowns, toPBExercise(e))
+	}
+	return out
+}
+
+func toPBExercise(e roadmap.PrescribedExercise) *pbmsg.PrescribedExercise {
+	return &pbmsg.PrescribedExercise{
+		ExerciseId:      e.ExerciseID,
+		ExerciseName:    e.ExerciseName,
+		TargetSets:      e.TargetSets,
+		TargetReps:      e.TargetReps,
+		TargetWeight:    e.TargetWeight,
+		DurationSeconds: e.DurationSeconds,
+		Notes:           e.Notes,
+		RestSetSec:      e.RestSetSec,
+		RestExerciseSec: e.RestExerciseSec,
+		TargetRpe:       e.TargetRPE,
+	}
+}
+
+func dateToPB(y, m, d int) *date.Date {
+	return &date.Date{Year: int32(y), Month: int32(m), Day: int32(d)}
+}
+
+func domainStatusToPB(s roadmap.RoadmapStatus) pbmsg.RoadmapStatus {
+	switch s {
+	case roadmap.RoadmapStatusActive:
+		return pbmsg.RoadmapStatus_ROADMAP_STATUS_ACTIVE
+	case roadmap.RoadmapStatusCompleted:
+		return pbmsg.RoadmapStatus_ROADMAP_STATUS_COMPLETED
+	default:
+		return pbmsg.RoadmapStatus_ROADMAP_STATUS_UNSPECIFIED
+	}
+}
+
+func domainPhaseToPB(p roadmap.Phase) pbmsg.RoadmapPhase {
+	switch p {
+	case roadmap.PhaseAccumulation:
+		return pbmsg.RoadmapPhase_ROADMAP_PHASE_ACCUMULATION
+	case roadmap.PhaseOverload:
+		return pbmsg.RoadmapPhase_ROADMAP_PHASE_OVERLOAD
+	case roadmap.PhasePeak:
+		return pbmsg.RoadmapPhase_ROADMAP_PHASE_PEAK
+	case roadmap.PhaseDeload:
+		return pbmsg.RoadmapPhase_ROADMAP_PHASE_DELOAD
+	default:
+		return pbmsg.RoadmapPhase_ROADMAP_PHASE_UNSPECIFIED
+	}
+}
+
+func domainSessionStatusToPB(s roadmap.SessionPlanStatus) pbmsg.SessionPlanStatus {
+	switch s {
+	case roadmap.SessionPlanStatusPending:
+		return pbmsg.SessionPlanStatus_SESSION_PLAN_STATUS_PENDING
+	case roadmap.SessionPlanStatusCompleted:
+		return pbmsg.SessionPlanStatus_SESSION_PLAN_STATUS_COMPLETED
+	case roadmap.SessionPlanStatusSkipped:
+		return pbmsg.SessionPlanStatus_SESSION_PLAN_STATUS_SKIPPED
+	default:
+		return pbmsg.SessionPlanStatus_SESSION_PLAN_STATUS_UNSPECIFIED
+	}
+}
+
+func pbStatusToDomain(s pbmsg.RoadmapStatus) roadmap.RoadmapStatus {
+	switch s {
+	case pbmsg.RoadmapStatus_ROADMAP_STATUS_ACTIVE:
+		return roadmap.RoadmapStatusActive
+	case pbmsg.RoadmapStatus_ROADMAP_STATUS_COMPLETED:
+		return roadmap.RoadmapStatusCompleted
+	default:
+		return "" // no filter
+	}
+}

--- a/internal/workout_execution/domain/aggregate/workout_session.go
+++ b/internal/workout_execution/domain/aggregate/workout_session.go
@@ -378,6 +378,7 @@ func (s *WorkoutSession) Complete(confirmOverload, isOverloaded bool) error {
 	s.addDomainEvent(&event.WorkoutSessionCompleted{
 		SessionID:   s.id,
 		UserID:      s.userID,
+		PlanID:      s.planID,
 		CompletedAt: now,
 		Summary:     summary,
 	})
@@ -399,6 +400,7 @@ func (s *WorkoutSession) Abort(reason string) error {
 	s.addDomainEvent(&event.WorkoutSessionAborted{
 		SessionID:   s.id,
 		UserID:      s.userID,
+		PlanID:      s.planID,
 		Reason:      reason,
 		IsAnomalous: false,
 		AbortedAt:   now,
@@ -421,6 +423,7 @@ func (s *WorkoutSession) AbortAnomalous(reason string) error {
 	s.addDomainEvent(&event.WorkoutSessionAborted{
 		SessionID:   s.id,
 		UserID:      s.userID,
+		PlanID:      s.planID,
 		Reason:      reason,
 		IsAnomalous: true,
 		AbortedAt:   now,

--- a/internal/workout_execution/domain/event/events.go
+++ b/internal/workout_execution/domain/event/events.go
@@ -23,6 +23,7 @@ func (e *WorkoutSessionStarted) EventName() string {
 type WorkoutSessionCompleted struct {
 	SessionID   string            `json:"sessionId"`
 	UserID      string            `json:"userId"`
+	PlanID      string            `json:"planId"`
 	CompletedAt time.Time         `json:"completedAt"`
 	Summary     vo.SessionSummary `json:"summary"`
 }
@@ -36,6 +37,7 @@ func (e *WorkoutSessionCompleted) EventName() string {
 type WorkoutSessionAborted struct {
 	SessionID   string    `json:"sessionId"`
 	UserID      string    `json:"userId"`
+	PlanID      string    `json:"planId"`
 	Reason      string    `json:"reason"`
 	IsAnomalous bool      `json:"isAnomalous"`
 	AbortedAt   time.Time `json:"abortedAt"`

--- a/internal/workout_execution/domain/event/events_test.go
+++ b/internal/workout_execution/domain/event/events_test.go
@@ -16,12 +16,12 @@ func TestDomainEventNames(t *testing.T) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	ev2 := event.WorkoutSessionCompleted{SessionID: "s1", UserID: "u1", CompletedAt: now, Summary: vo.SessionSummary{}}
+	ev2 := event.WorkoutSessionCompleted{SessionID: "s1", UserID: "u1", PlanID: "p1", CompletedAt: now, Summary: vo.SessionSummary{}}
 	if got, want := ev2.EventName(), "contracts.core.workout_execution.v1.event.WorkoutSessionCompleted"; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	ev3 := event.WorkoutSessionAborted{SessionID: "s1", UserID: "u1", Reason: "stop", IsAnomalous: false, AbortedAt: now}
+	ev3 := event.WorkoutSessionAborted{SessionID: "s1", UserID: "u1", PlanID: "p1", Reason: "stop", IsAnomalous: false, AbortedAt: now}
 	if got, want := ev3.EventName(), "contracts.core.workout_execution.v1.event.WorkoutSessionAborted"; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}

--- a/proto/contracts/core/coaching/v1/event/coaching_events.proto
+++ b/proto/contracts/core/coaching/v1/event/coaching_events.proto
@@ -5,13 +5,13 @@ package contracts.core.coaching.v1.event;
 option go_package = "github.com/viethung213/gym-companion/internal/gen/go/contracts/core/coaching/v1/event;coachingv1event";
 
 import "google/protobuf/timestamp.proto";
-import "proto/contracts/core/coaching/v1/message/coaching_messages.proto";
+import "contracts/core/coaching/v1/message/coaching_messages.proto";
 
 message RoadmapInitiatedEventPayload {
   string roadmap_id = 1;
   string user_id = 2;
   google.protobuf.Timestamp initiated_at = 3;
-  message.Roadmap roadmap = 4;
+  contracts.core.coaching.v1.message.Roadmap roadmap = 4;
 }
 
 message RoadmapAdjustedEventPayload {
@@ -19,7 +19,7 @@ message RoadmapAdjustedEventPayload {
   string user_id = 2;
   string reason = 3;
   google.protobuf.Timestamp adjusted_at = 4;
-  message.Roadmap roadmap = 5;
+  contracts.core.coaching.v1.message.Roadmap roadmap = 5;
 }
 
 message SessionPlanExecutedEventPayload {

--- a/proto/contracts/core/workout_execution/v1/event/workout_session_aborted.proto
+++ b/proto/contracts/core/workout_execution/v1/event/workout_session_aborted.proto
@@ -11,5 +11,5 @@ message WorkoutSessionAborted {
   string user_id = 2;
   google.protobuf.Timestamp aborted_at = 3;
   string reason = 4; // e.g. "timeout", "user_cancelled"
-  string plan_id = 5; // Liên kết sang DailyWorkoutPlan để đồng bộ trạng thái
+  string plan_id = 5; // Liên kết sang session_plan_id (Coaching Context) để đồng bộ trạng thái
 }

--- a/proto/contracts/core/workout_execution/v1/event/workout_session_completed.proto
+++ b/proto/contracts/core/workout_execution/v1/event/workout_session_completed.proto
@@ -14,5 +14,5 @@ message WorkoutSessionCompleted {
   float total_volume = 5;
   optional float average_form_score = 6; // optional hỗ trợ N/A cho bài tập Phi AI
   float average_rpe = 7;
-  string plan_id = 8;                    // Liên kết sang DailyWorkoutPlan để đồng bộ trạng thái
+  string plan_id = 8;                    // Liên kết sang session_plan_id (Coaching Context) để đồng bộ trạng thái
 }

--- a/scripts/postgres-init/05-create-coaching-tables.sql
+++ b/scripts/postgres-init/05-create-coaching-tables.sql
@@ -1,0 +1,89 @@
+-- ==========================================
+-- SCHEMA: coaching - Tables definitions
+-- 4-tier DDD: Roadmap -> WeekPlan -> DayPlan -> SessionPlan
+-- ==========================================
+
+CREATE SCHEMA IF NOT EXISTS coaching;
+
+-- 1. Table: roadmaps (Aggregate Root, 4-week program)
+CREATE TABLE IF NOT EXISTS coaching.roadmaps (
+    roadmap_id  VARCHAR(255) PRIMARY KEY,
+    user_id     VARCHAR(255) NOT NULL,
+    status      VARCHAR(50)  NOT NULL DEFAULT 'ACTIVE',
+    start_date  DATE         NOT NULL,
+    end_date    DATE         NOT NULL,
+    created_at  TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at  TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_roadmap_status CHECK (status IN ('ACTIVE', 'COMPLETED'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_roadmaps_user_id ON coaching.roadmaps(user_id);
+
+-- Only one ACTIVE roadmap per user (BR-AC-01 invariant support)
+CREATE UNIQUE INDEX IF NOT EXISTS ux_roadmaps_user_active
+    ON coaching.roadmaps(user_id) WHERE status = 'ACTIVE';
+
+-- 2. Table: week_plans (4 per roadmap, one per phase)
+CREATE TABLE IF NOT EXISTS coaching.week_plans (
+    week_plan_id       VARCHAR(255) PRIMARY KEY,
+    roadmap_id         VARCHAR(255) NOT NULL REFERENCES coaching.roadmaps(roadmap_id) ON DELETE CASCADE,
+    user_id            VARCHAR(255) NOT NULL,
+    week_number        SMALLINT     NOT NULL,
+    phase              VARCHAR(50)  NOT NULL,
+    target_rpe         NUMERIC(3,1) NOT NULL,
+    start_date         DATE         NOT NULL,
+    end_date           DATE         NOT NULL,
+    muscle_split_type  VARCHAR(100) NOT NULL DEFAULT '',
+    created_at         TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_week_number CHECK (week_number BETWEEN 1 AND 4),
+    CONSTRAINT chk_week_phase  CHECK (phase IN ('ACCUMULATION', 'OVERLOAD', 'PEAK', 'DELOAD')),
+    CONSTRAINT uq_week_roadmap_number UNIQUE (roadmap_id, week_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_week_plans_roadmap_id ON coaching.week_plans(roadmap_id);
+
+-- 3. Table: day_plans (7 per week)
+CREATE TABLE IF NOT EXISTS coaching.day_plans (
+    day_plan_id      VARCHAR(255) PRIMARY KEY,
+    week_plan_id     VARCHAR(255) NOT NULL REFERENCES coaching.week_plans(week_plan_id) ON DELETE CASCADE,
+    roadmap_id       VARCHAR(255) NOT NULL,
+    user_id          VARCHAR(255) NOT NULL,
+    scheduled_date   DATE         NOT NULL,
+    is_rest_day      BOOLEAN      NOT NULL DEFAULT FALSE,
+    created_at       TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_day_week_date UNIQUE (week_plan_id, scheduled_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_day_plans_week_plan_id ON coaching.day_plans(week_plan_id);
+CREATE INDEX IF NOT EXISTS idx_day_plans_user_date   ON coaching.day_plans(user_id, scheduled_date);
+
+-- 4. Table: session_plans (0-N per day)
+CREATE TABLE IF NOT EXISTS coaching.session_plans (
+    session_plan_id       VARCHAR(255) PRIMARY KEY,
+    day_plan_id           VARCHAR(255) NOT NULL REFERENCES coaching.day_plans(day_plan_id) ON DELETE CASCADE,
+    week_plan_id          VARCHAR(255) NOT NULL,
+    roadmap_id            VARCHAR(255) NOT NULL,
+    user_id               VARCHAR(255) NOT NULL,
+    scheduled_date        DATE         NOT NULL,
+    slot_time             VARCHAR(50)  NOT NULL DEFAULT '',
+    status                VARCHAR(50)  NOT NULL DEFAULT 'PENDING',
+    target_muscle_groups  JSONB        NOT NULL DEFAULT '[]',
+    prescription          JSONB        NOT NULL DEFAULT '{}',
+    reasoning             TEXT         NOT NULL DEFAULT '',
+    generated_at          TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    completed_at          TIMESTAMP WITH TIME ZONE,
+    session_scr           NUMERIC(5,2),
+    session_delta_rpe     NUMERIC(4,2),
+    CONSTRAINT chk_session_status CHECK (status IN ('PENDING', 'COMPLETED', 'SKIPPED'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_plans_day_plan_id  ON coaching.session_plans(day_plan_id);
+CREATE INDEX IF NOT EXISTS idx_session_plans_user_date    ON coaching.session_plans(user_id, scheduled_date);
+
+-- Partial index for pending sessions (D3: Regenerate touches only PENDING)
+CREATE INDEX IF NOT EXISTS ix_session_plans_pending
+    ON coaching.session_plans(user_id, scheduled_date) WHERE status = 'PENDING';
+
+-- 5. Consumer idempotency (D9): unique event_id on outbox_log
+CREATE UNIQUE INDEX IF NOT EXISTS ux_coaching_outbox_log_event_id
+    ON coaching.outbox_log(event_id);


### PR DESCRIPTION
## Summary
- Implement Coaching & Planning bounded context (`internal/coaching/`) theo Hexagonal Architecture với 4-tier DDD (Roadmap → WeekPlan → DayPlan → SessionPlan).
- Cover UC-02.1 InitiateRoadmap, UC-02.2 CompleteSession, UC-02.3 RegenerateSchedule, UC-04.1 ApplyAdaptiveCycle (BR-AC-04 Trigger A), WorkoutSessionAborted → SKIPPED, và Flow 5 SuggestAdHocSession (read-only).
- Migration `05-create-coaching-tables.sql`, MockCoachAgent deterministic, GuardrailEngine BR-AC-01/02/09, outbox writer + worker, gRPC server 6 RPCs, Kafka consumer với event_id idempotency (D9).

## Business rules implemented
- **BR-AC-01**: Weekly cap ≤6 sessions enforced in domain + guardrail.
- **BR-AC-02**: OverloadValidator caps weight within ±30% of baseline PR.
- **BR-AC-04 Trigger A**: SCR ≥80% & ΔRPE in [-1,+1] → +2.5-5%; RPE ≥9 x3 or ΔRPE ≥+2 → Deload; SCR <50% x2 weeks → Express format.
- **BR-AC-05..08 Signals B1/B2/B4**: detection in AdaptiveCoachEngine.
- **BR-AC-09**: injury exclusion in guardrail.
- **D7**: ΔRPE uses scalar `average_rpe` from WorkoutSessionCompleted event.

## Package layout
- `domain/roadmap` — 4-tier aggregate with BR-AC-01 invariants.
- `domain/service` — OverloadValidator, SCRCalculator, AdaptiveCoachEngine.
- `application/{port,contextbuilder,command,query}` — Hexagonal ports + CQRS handlers.
- `infrastructure/{ai,guardrail,persistence,event,worker}` — MockCoachAgent, GuardrailEngine, GORM repos, outbox writer + worker.
- `transport/{grpc,consumer}` — 6 RPCs + Kafka consumer for WorkoutSessionCompleted/Aborted.

## Test plan
- [x] `go test ./internal/coaching/...` — 10 packages, all pass
- [x] `go test -race ./internal/coaching/...` — race-free
- [x] Domain coverage ≥90% (roadmap, service, event)
- [ ] Manual E2E via docker-compose (postgres migration + publish sample WorkoutSessionCompleted event)
- [ ] Integration test with real Postgres — deferred to phase-2

## Deferred to phase-2
- Real LLM adapter (ADK-Go) — currently MockCoachAgent
- Signal B1-B4 handlers wiring + cron for Trigger A
- gRPC auth interceptor, healthz/readyz, graceful shutdown
- HA outbox worker, DLQ, distributed tracing
- Cross-context Profile event consumer (proto events not yet defined)