### PR TITLE
🐛 fix(auth): chuẩn hóa claim role dạng chuỗi duy nhất và đảm bảo giao dịch OAuth Login nguyên tử

### DIFF
--- a/internal/auth/application/command/oauth_login.go
+++ b/internal/auth/application/command/oauth_login.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/viethung213/gym-companion/internal/auth/application"
@@ -58,18 +59,24 @@ func (h *OAuthLoginHandler) Handle(ctx context.Context, cmd OAuthLoginCommand) (
 		return "", "", "", fmt.Errorf("unsupported oauth provider: %s", cmd.Provider)
 	}
 
-	// Validate OAuth2 state to prevent CSRF attacks
+	// 1. Validate OAuth2 state to prevent CSRF attacks
 	if err := h.oauthServ.ValidateState(ctx, cmd.State); err != nil {
 		return "", "", "", fmt.Errorf("oauth state validation failed: %w", err)
 	}
 
-	// 1. Exchange OAuth code for User Profile
+	// 2. Pre-check active signing key BEFORE exchanging code or modifying DB
+	activeKey, err := h.keyRepo.GetActiveKey(ctx)
+	if err != nil {
+		return "", "", "", fmt.Errorf("active signing key not found: %w", err)
+	}
+
+	// 3. Exchange OAuth code for User Profile
 	profile, err := h.oauthServ.ExchangeCodeForProfile(ctx, cmd.Provider, cmd.Code, cmd.RedirectURI)
 	if err != nil {
 		return "", "", "", fmt.Errorf("oauth exchange failed: %w", err)
 	}
 
-	// 2. Query user by GoogleID / FacebookID / Email
+	// 4. Query user by GoogleID / FacebookID / Email
 	var user *aggregate.User
 	if cmd.Provider == "google" {
 		user, err = h.userRepo.FindByGoogleID(ctx, profile.ID)
@@ -77,29 +84,28 @@ func (h *OAuthLoginHandler) Handle(ctx context.Context, cmd OAuthLoginCommand) (
 		user, err = h.userRepo.FindByFacebookID(ctx, profile.ID)
 	}
 
-	// 3. Register user or link account inside database transaction
-	if err != nil || user == nil {
-		// Try to find user by email to link social provider
-		user, err = h.userRepo.FindByEmail(ctx, profile.Email)
-		if err == nil && user != nil {
-			// Link account
-			if cmd.Provider == "google" {
-				user.LinkGoogle(profile.ID)
-			} else if cmd.Provider == "facebook" {
-				user.LinkFacebook(profile.ID)
-			}
+	var accessToken, refreshTokenStr string
+	var expiresAt time.Time
 
-			err = h.txManager.WithTransaction(ctx, func(txCtx context.Context) error {
-				return h.userRepo.Update(txCtx, user)
-			})
-			if err != nil {
-				return "", "", "", fmt.Errorf("link oauth account: %w", err)
-			}
-		} else {
-			// Register new user
-			err = h.txManager.WithTransaction(ctx, func(txCtx context.Context) error {
-				var regErr error
+	// 5. Execute User registration/linking, Token generation, and Session saving in a SINGLE Atomic Transaction
+	err = h.txManager.WithTransaction(ctx, func(txCtx context.Context) error {
+		if err != nil || user == nil {
+			// Try to find user by email to link social provider
+			existingUser, findErr := h.userRepo.FindByEmail(txCtx, profile.Email)
+			if findErr == nil && existingUser != nil {
+				user = existingUser
+				if cmd.Provider == "google" {
+					user.LinkGoogle(profile.ID)
+				} else if cmd.Provider == "facebook" {
+					user.LinkFacebook(profile.ID)
+				}
+				if updateErr := h.userRepo.Update(txCtx, user); updateErr != nil {
+					return fmt.Errorf("link oauth account: %w", updateErr)
+				}
+			} else {
+				// Register new user
 				newUserID := uuid.New().String()
+				var regErr error
 				user, regErr = aggregate.RegisterUser(
 					newUserID,
 					profile.Email,
@@ -116,49 +122,46 @@ func (h *OAuthLoginHandler) Handle(ctx context.Context, cmd OAuthLoginCommand) (
 					user.LinkFacebook(profile.ID)
 				}
 
-				if err := h.userRepo.Create(txCtx, user); err != nil {
-					return fmt.Errorf("save new user: %w", err)
+				if createErr := h.userRepo.Create(txCtx, user); createErr != nil {
+					return fmt.Errorf("save new user: %w", createErr)
 				}
 
 				// Publish domain events
 				for _, ev := range user.DomainEvents() {
-					if err := h.publisher.Write(txCtx, ev); err != nil {
-						return fmt.Errorf("dispatch domain event: %w", err)
+					if pubErr := h.publisher.Write(txCtx, ev); pubErr != nil {
+						return fmt.Errorf("dispatch domain event: %w", pubErr)
 					}
 				}
-
-				return nil
-			})
-			if err != nil {
-				return "", "", "", err
-			}
-			if user != nil {
-				user.ClearDomainEvents()
 			}
 		}
-	}
 
-	// 4. Fetch active key for signing
-	activeKey, err := h.keyRepo.GetActiveKey(ctx)
+		// Generate Access Token
+		var tokenErr error
+		accessToken, _, tokenErr = h.tokenServ.GenerateAccessToken(txCtx, user, activeKey.ID)
+		if tokenErr != nil {
+			return fmt.Errorf("generate access token: %w", tokenErr)
+		}
+
+		// Generate Refresh Token
+		refreshTokenStr, expiresAt, tokenErr = h.tokenServ.GenerateRefreshToken(txCtx, user)
+		if tokenErr != nil {
+			return fmt.Errorf("generate refresh token: %w", tokenErr)
+		}
+
+		// Save Session
+		if sessErr := h.sessRepo.Save(txCtx, refreshTokenStr, user.ID(), expiresAt); sessErr != nil {
+			return fmt.Errorf("save session: %w", sessErr)
+		}
+
+		return nil
+	})
+
 	if err != nil {
-		return "", "", "", fmt.Errorf("active signing key not found: %w", err)
+		return "", "", "", err
 	}
 
-	// 5. Generate Access Token
-	accessToken, _, err := h.tokenServ.GenerateAccessToken(ctx, user, activeKey.ID)
-	if err != nil {
-		return "", "", "", fmt.Errorf("generate access token: %w", err)
-	}
-
-	// 6. Generate Refresh Token
-	refreshTokenStr, expiresAt, err := h.tokenServ.GenerateRefreshToken(ctx, user)
-	if err != nil {
-		return "", "", "", fmt.Errorf("generate refresh token: %w", err)
-	}
-
-	// 7. Save Session
-	if err := h.sessRepo.Save(ctx, refreshTokenStr, user.ID(), expiresAt); err != nil {
-		return "", "", "", fmt.Errorf("save session: %w", err)
+	if user != nil {
+		user.ClearDomainEvents()
 	}
 
 	return accessToken, refreshTokenStr, user.ID(), nil

--- a/internal/auth/infrastructure/jwt/signer.go
+++ b/internal/auth/infrastructure/jwt/signer.go
@@ -64,11 +64,11 @@ func (s *JWTSigner) GenerateAccessToken(ctx context.Context, user *aggregate.Use
 	now := time.Now()
 	expiresAt := now.Add(s.accessTTL)
 	claims := jwt.MapClaims{
-		"iss":   s.issuer,
-		"sub":   user.ID(),
-		"roles": []string{user.Role()},
-		"iat":   now.Unix(),
-		"exp":   expiresAt.Unix(),
+		"iss":  s.issuer,
+		"sub":  user.ID(),
+		"role": user.Role(),
+		"iat":  now.Unix(),
+		"exp":  expiresAt.Unix(),
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)

--- a/internal/auth/infrastructure/jwt/signer_test.go
+++ b/internal/auth/infrastructure/jwt/signer_test.go
@@ -84,7 +84,7 @@ func generateTestKey(t *testing.T) *port.JWKRecord {
 	}
 }
 
-func validateTokenHelper(t *testing.T, tokenStr string, key *port.JWKRecord) (string, []string, error) {
+func validateTokenHelper(t *testing.T, tokenStr string, key *port.JWKRecord) (string, string, error) {
 	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
@@ -96,25 +96,20 @@ func validateTokenHelper(t *testing.T, tokenStr string, key *port.JWKRecord) (st
 		return pubKey, nil
 	})
 	if err != nil {
-		return "", nil, err
+		return "", "", err
 	}
 	if !token.Valid {
-		return "", nil, fmt.Errorf("invalid token")
+		return "", "", fmt.Errorf("invalid token")
 	}
 
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
-		return "", nil, fmt.Errorf("invalid claims")
+		return "", "", fmt.Errorf("invalid claims")
 	}
 
 	userID := claims["sub"].(string)
-	var roles []string
-	if rs, ok := claims["roles"].([]interface{}); ok {
-		for _, r := range rs {
-			roles = append(roles, r.(string))
-		}
-	}
-	return userID, roles, nil
+	role, _ := claims["role"].(string)
+	return userID, role, nil
 }
 
 func TestJWTSigner_GenerateAndValidate(t *testing.T) {
@@ -154,7 +149,7 @@ func TestJWTSigner_GenerateAndValidate(t *testing.T) {
 		t.Error("expected expiresAt to be in the future")
 	}
 
-	gotUserID, gotRoles, err := validateTokenHelper(t, tokenStr, key)
+	gotUserID, gotRole, err := validateTokenHelper(t, tokenStr, key)
 	if err != nil {
 		t.Fatalf("token validation failed: %v", err)
 	}
@@ -163,8 +158,8 @@ func TestJWTSigner_GenerateAndValidate(t *testing.T) {
 		t.Errorf("got userID %s, want %s", got, want)
 	}
 
-	if len(gotRoles) != 1 || gotRoles[0] != user.Role() {
-		t.Errorf("got roles %v, want [%s]", gotRoles, user.Role())
+	if gotRole != user.Role() {
+		t.Errorf("got role %s, want %s", gotRole, user.Role())
 	}
 }
 

--- a/internal/auth/tests/e2e/testutil.go
+++ b/internal/auth/tests/e2e/testutil.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -20,6 +21,7 @@ import (
 
 	"github.com/viethung213/gym-companion/internal/auth"
 	"github.com/viethung213/gym-companion/internal/shared/database"
+	sharedKafka "github.com/viethung213/gym-companion/internal/shared/kafka"
 )
 
 // getTestDB creates a connection to the test database for E2E verification.
@@ -52,6 +54,9 @@ func truncateTables(db *gorm.DB) {
 // startE2ETestServer spins up the full gRPC and HTTP Gateway servers on random ports.
 // Returns HTTP base URL, GORM db instance, and a cleanup function.
 func startE2ETestServer(t *testing.T) (string, *gorm.DB, func()) {
+	if os.Getenv("OAUTH_STATE_SECRET") == "" {
+		os.Setenv("OAUTH_STATE_SECRET", "test-oauth-state-secret-key-32bytes!")
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// 1. Database Connection via Monolith Registry
@@ -91,8 +96,9 @@ func startE2ETestServer(t *testing.T) (string, *gorm.DB, func()) {
 
 	// 4. Bootstrap Auth module via Initialize
 	deps := auth.ModuleDeps{
-		DB:         rawSQL,
-		GRPCServer: grpcServer,
+		DB:            rawSQL,
+		GRPCServer:    grpcServer,
+		KafkaRegistry: sharedKafka.GetRegistry(),
 	}
 	shutdown, err := auth.Initialize(ctx, deps)
 	if err != nil {

--- a/proto/contracts/core/coaching/v1/event/coaching_events.proto
+++ b/proto/contracts/core/coaching/v1/event/coaching_events.proto
@@ -5,13 +5,13 @@ package contracts.core.coaching.v1.event;
 option go_package = "github.com/viethung213/gym-companion/internal/gen/go/contracts/core/coaching/v1/event;coachingv1event";
 
 import "google/protobuf/timestamp.proto";
-import "proto/contracts/core/coaching/v1/message/coaching_messages.proto";
+import "contracts/core/coaching/v1/message/coaching_messages.proto";
 
 message RoadmapInitiatedEventPayload {
   string roadmap_id = 1;
   string user_id = 2;
   google.protobuf.Timestamp initiated_at = 3;
-  message.Roadmap roadmap = 4;
+  contracts.core.coaching.v1.message.Roadmap roadmap = 4;
 }
 
 message RoadmapAdjustedEventPayload {
@@ -19,7 +19,7 @@ message RoadmapAdjustedEventPayload {
   string user_id = 2;
   string reason = 3;
   google.protobuf.Timestamp adjusted_at = 4;
-  message.Roadmap roadmap = 5;
+  contracts.core.coaching.v1.message.Roadmap roadmap = 5;
 }
 
 message SessionPlanExecutedEventPayload {


### PR DESCRIPTION
## 📝 Tóm tắt các thay đổi (Summary of Changes)

### 🔑 Sửa lỗi JWT & OAuth

- **Chuẩn hóa JWT Claim Role**: Cập nhật `JWTSigner` để tạo claim `"role": user.Role()` dạng chuỗi duy nhất thay cho mảng `"roles"`, đồng thời cập nhật JWT Middleware kiểm tra claim chuỗi `"role"`. Khắc phục lỗi `invalid token: missing role claim` khi người dùng gọi API.
- **Giao dịch OAuth Login nguyên tử (Atomic OAuth Login Transaction)**:
  - Đưa kiểm tra khóa ký RSA (`GetActiveKey`) lên trước làm Guard Clause để tránh làm cháy mã OAuth `code` khi hệ thống chưa sẵn sàng khóa ký.
  - Bọc toàn bộ quy trình: Tạo/Liên kết User, Ghi sự kiện Outbox, Sinh Access/Refresh Token và Lưu Session vào **1 Giao dịch DB Nguyên tử duy nhất (`txManager.WithTransaction`)**. Nếu bất kỳ bước nào (như tạo Session) bị lỗi, thao tác tạo User sẽ tự động Rollback 100%, đảm bảo DB không bị lưu rác tài khoản khi Client không nhận được Token.

### 🐛 Sửa lỗi Auth E2E Test

- **Thêm import `os` còn thiếu** trong `internal/auth/tests/e2e/testutil.go` gây `build failed: undefined: os` khi chạy `go test -tags=e2e`.
- **Truyền `KafkaRegistry` vào `ModuleDeps`** trong `startE2ETestServer`: trước đây `KafkaRegistry` là `nil` khiến `auth.Initialize()` bị `panic: nil pointer dereference` tại `shared/kafka.(*Registry).GetWriter`. Sửa bằng cách truyền `sharedKafka.GetRegistry()` vào khi khởi tạo module trong E2E test.
- **Truyền `OAUTH_STATE_SECRET`**: Tự động set fallback `OAUTH_STATE_SECRET` trong test environment để tránh lỗi `required environment variable OAUTH_STATE_SECRET is not set` khi không có file `.env`.

## 🧪 Kiểm thử & Xác nhận (Verification)

- Đã chạy toàn bộ kiểm thử `go test -count=1 -v -p=1 -tags="unit,integration,e2e" ./internal/auth/...` đạt kết quả **PASS 100%** cho tất cả các bài test bao gồm:
  - Unit Tests, Integration Tests, và **E2E Tests** (`TestE2E_JWKS_And_KeyRotation`, `TestE2E_OAuthFlows_Google`, `TestE2E_OAuthFlows_Facebook`, `TestE2E_Logout_BOLA_Prevention`).
