### PR TITLE
👷 ci(proto): add proto-lint workflow for automated protobuf schema linting

### DIFF
--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -1,0 +1,37 @@
+name: Protobuf Lint
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'proto/**'
+      - '.github/workflows/proto-lint.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'proto/**'
+      - '.github/workflows/proto-lint.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  proto-lint:
+    name: Lint Protobuf Schemas
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Buf CLI
+        uses: bufbuild/buf-setup-action@v1
+
+      - name: Update Buf Schema Dependencies
+        run: buf dep update proto
+
+      - name: Lint Protobuf Files
+        uses: bufbuild/buf-lint-action@v1
+        with:
+          input: 'proto'


### PR DESCRIPTION
### 1. Vấn đề cần giải quyết
- Hiện tại, việc kiểm tra chuẩn cú pháp và style guide cho các file Protobuf (\buf lint\) chỉ mới được định nghĩa trong Makefile và chạy cục bộ qua Docker, chưa được tự động hóa trên quy trình CI/CD GitHub Actions.

### 2. Giải pháp đề xuất
- Bổ sung file workflow GitHub Actions mới \.github/workflows/proto-lint.yml\ sử dụng \bufbuild/buf-setup-action@v1\ và \bufbuild/buf-lint-action@v1\ để tự động chạy linter Protobuf kiểm tra mã nguồn trong thư mục \proto/\ khi có Push hoặc Pull Request vào nhánh \main\.

### 3. Thay đổi & Ảnh hưởng
- \[.github/workflows/proto-lint.yml](.github/workflows/proto-lint.yml)\: Thêm tệp cấu hình CI workflow tự động kiểm tra định dạng và quy chuẩn các hợp đồng Protobuf \.proto\.

### 4. Kiểm thử & Xác minh
- **Kiểm thử tự động**: Đã chạy thử nghiệm lệnh \make proto-lint\ ở môi trường local bằng Docker Buf CLI, kết quả đạt 100% không có lỗi.
- **Cấu hình CI**: Đã kiểm tra cú pháp YAML chuẩn theo định dạng GitHub Actions.