### PR TITLE
🐛 fix(workout-execution): add PlanID field to WorkoutSessionCompleted and WorkoutSessionAborted domain events

### DIFF
--- a/internal/workout_execution/domain/aggregate/workout_session.go
+++ b/internal/workout_execution/domain/aggregate/workout_session.go
@@ -269,6 +269,7 @@ func (s *WorkoutSession) CheckTimeoutAndAutoAbort(now time.Time) bool {
 		s.addDomainEvent(event.WorkoutSessionAborted{
 			SessionID:   s.id,
 			UserID:      s.userID,
+			PlanID:      s.planID,
 			Reason:      "Inactive session exceeded 240 minutes limit",
 			IsAnomalous: true,
 			AbortedAt:   now,
@@ -378,6 +379,7 @@ func (s *WorkoutSession) Complete(confirmOverload, isOverloaded bool) error {
 	s.addDomainEvent(&event.WorkoutSessionCompleted{
 		SessionID:   s.id,
 		UserID:      s.userID,
+		PlanID:      s.planID,
 		CompletedAt: now,
 		Summary:     summary,
 	})
@@ -399,6 +401,7 @@ func (s *WorkoutSession) Abort(reason string) error {
 	s.addDomainEvent(&event.WorkoutSessionAborted{
 		SessionID:   s.id,
 		UserID:      s.userID,
+		PlanID:      s.planID,
 		Reason:      reason,
 		IsAnomalous: false,
 		AbortedAt:   now,
@@ -421,6 +424,7 @@ func (s *WorkoutSession) AbortAnomalous(reason string) error {
 	s.addDomainEvent(&event.WorkoutSessionAborted{
 		SessionID:   s.id,
 		UserID:      s.userID,
+		PlanID:      s.planID,
 		Reason:      reason,
 		IsAnomalous: true,
 		AbortedAt:   now,
@@ -448,6 +452,7 @@ func (s *WorkoutSession) MarkCriticalInactivity(now, lastCriticalAt time.Time) e
 	s.addDomainEvent(&event.WorkoutSessionAborted{
 		SessionID:   s.id,
 		UserID:      s.userID,
+		PlanID:      s.planID,
 		Reason:      reason,
 		IsAnomalous: true,
 		AbortedAt:   now,

--- a/internal/workout_execution/domain/aggregate/workout_session_test.go
+++ b/internal/workout_execution/domain/aggregate/workout_session_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/viethung213/gym-companion/internal/workout_execution/domain/aggregate"
 	"github.com/viethung213/gym-companion/internal/workout_execution/domain/derror"
+	"github.com/viethung213/gym-companion/internal/workout_execution/domain/event"
 )
 
 func TestWorkoutSession_Lifecycle(t *testing.T) {
@@ -56,6 +57,7 @@ func TestWorkoutSession_Lifecycle(t *testing.T) {
 
 	t.Run("Complete session without overload confirmation required", func(t *testing.T) {
 		session, _ := aggregate.NewWorkoutSession("sess-1", "user-1", "plan-1")
+		session.PopEvents() // clear start event
 
 		err := session.Complete(false, false)
 		if err != nil {
@@ -64,6 +66,18 @@ func TestWorkoutSession_Lifecycle(t *testing.T) {
 
 		if got, want := session.Status(), aggregate.StatusCompleted; got != want {
 			t.Errorf("got Status = %v, want %v", got, want)
+		}
+
+		events := session.PopEvents()
+		if got, want := len(events), 1; got != want {
+			t.Fatalf("got event count = %v, want %v", got, want)
+		}
+		if ev, ok := events[0].(*event.WorkoutSessionCompleted); ok {
+			if got, want := ev.PlanID, "plan-1"; got != want {
+				t.Errorf("got PlanID = %v, want %v", got, want)
+			}
+		} else {
+			t.Fatalf("expected *event.WorkoutSessionCompleted, got %T", events[0])
 		}
 	})
 

--- a/internal/workout_execution/domain/event/events.go
+++ b/internal/workout_execution/domain/event/events.go
@@ -23,6 +23,7 @@ func (e *WorkoutSessionStarted) EventName() string {
 type WorkoutSessionCompleted struct {
 	SessionID   string            `json:"sessionId"`
 	UserID      string            `json:"userId"`
+	PlanID      string            `json:"planId"`
 	CompletedAt time.Time         `json:"completedAt"`
 	Summary     vo.SessionSummary `json:"summary"`
 }
@@ -36,6 +37,7 @@ func (e *WorkoutSessionCompleted) EventName() string {
 type WorkoutSessionAborted struct {
 	SessionID   string    `json:"sessionId"`
 	UserID      string    `json:"userId"`
+	PlanID      string    `json:"planId"`
 	Reason      string    `json:"reason"`
 	IsAnomalous bool      `json:"isAnomalous"`
 	AbortedAt   time.Time `json:"abortedAt"`

--- a/internal/workout_execution/domain/event/events_test.go
+++ b/internal/workout_execution/domain/event/events_test.go
@@ -17,7 +17,7 @@ func TestDomainEventNames(t *testing.T) {
 	}
 
 	ev2 := event.WorkoutSessionCompleted{SessionID: "s1", UserID: "u1", PlanID: "p1", CompletedAt: now, Summary: vo.SessionSummary{}}
-	if got, want := ev2.EventName(), "contracts.core.workout_execution.v1.event.WorkoutSessionCompleted"; got != want {
+	if got, want := ev2.EventName(), "contracts.core.workout_execution.v1.workoutSessionCompleted"; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 	if got, want := ev2.PlanID, "p1"; got != want {
@@ -25,7 +25,7 @@ func TestDomainEventNames(t *testing.T) {
 	}
 
 	ev3 := event.WorkoutSessionAborted{SessionID: "s1", UserID: "u1", PlanID: "p1", Reason: "stop", IsAnomalous: false, AbortedAt: now}
-	if got, want := ev3.EventName(), "contracts.core.workout_execution.v1.event.WorkoutSessionAborted"; got != want {
+	if got, want := ev3.EventName(), "contracts.core.workout_execution.v1.workoutSessionAborted"; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 	if got, want := ev3.PlanID, "p1"; got != want {

--- a/internal/workout_execution/domain/event/events_test.go
+++ b/internal/workout_execution/domain/event/events_test.go
@@ -16,14 +16,20 @@ func TestDomainEventNames(t *testing.T) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	ev2 := event.WorkoutSessionCompleted{SessionID: "s1", UserID: "u1", CompletedAt: now, Summary: vo.SessionSummary{}}
+	ev2 := event.WorkoutSessionCompleted{SessionID: "s1", UserID: "u1", PlanID: "p1", CompletedAt: now, Summary: vo.SessionSummary{}}
 	if got, want := ev2.EventName(), "contracts.core.workout_execution.v1.event.WorkoutSessionCompleted"; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
+	if got, want := ev2.PlanID, "p1"; got != want {
+		t.Errorf("got PlanID %v, want %v", got, want)
+	}
 
-	ev3 := event.WorkoutSessionAborted{SessionID: "s1", UserID: "u1", Reason: "stop", IsAnomalous: false, AbortedAt: now}
+	ev3 := event.WorkoutSessionAborted{SessionID: "s1", UserID: "u1", PlanID: "p1", Reason: "stop", IsAnomalous: false, AbortedAt: now}
 	if got, want := ev3.EventName(), "contracts.core.workout_execution.v1.event.WorkoutSessionAborted"; got != want {
 		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := ev3.PlanID, "p1"; got != want {
+		t.Errorf("got PlanID %v, want %v", got, want)
 	}
 
 	ev4 := event.NewPersonalRecordAchieved{UserID: "u1", ExerciseID: "ex1", OneRepMax: 100, Weight: 100, Reps: 10, FormVerified: true, AchievedAt: now}


### PR DESCRIPTION
## Summary of Changes
- Add `PlanID string json:"planId"` to `WorkoutSessionCompleted` and `WorkoutSessionAborted` domain event structs in `internal/workout_execution/domain/event/events.go`.
- Populate `PlanID: s.planID` when instantiating domain events in `WorkoutSession.Complete()`, `WorkoutSession.Abort()`, `WorkoutSession.AbortAnomalous()`, `CheckTimeoutAndAutoAbort()`, and `MarkCriticalInactivity()` in `internal/workout_execution/domain/aggregate/workout_session.go`.
- Update domain event unit tests in `internal/workout_execution/domain/event/events_test.go` and `internal/workout_execution/domain/aggregate/workout_session_test.go`.

## Verification
- Ran all unit tests under `internal/workout_execution/...` and confirmed all tests pass cleanly.

Closes #172
