### PR TITLE
🐛 fix(workout-execution): chuẩn hóa tên event type và cơ chế protojson marshal outbox payload theo chuẩn SSOT CloudEvent (#181)

### DIFF
--- a/internal/workout_execution/domain/event/events.go
+++ b/internal/workout_execution/domain/event/events.go
@@ -15,8 +15,8 @@ type WorkoutSessionStarted struct {
 }
 
 // EventName returns the CloudEvent type for WorkoutSessionStarted.
-func (e *WorkoutSessionStarted) EventName() string {
-	return "contracts.core.workout_execution.v1.event.WorkoutSessionStarted"
+func (e WorkoutSessionStarted) EventName() string {
+	return "contracts.core.workout_execution.v1.workoutSessionStarted"
 }
 
 // WorkoutSessionCompleted is published when a workout session finishes normally.
@@ -28,8 +28,8 @@ type WorkoutSessionCompleted struct {
 }
 
 // EventName returns the CloudEvent type for WorkoutSessionCompleted.
-func (e *WorkoutSessionCompleted) EventName() string {
-	return "contracts.core.workout_execution.v1.event.WorkoutSessionCompleted"
+func (e WorkoutSessionCompleted) EventName() string {
+	return "contracts.core.workout_execution.v1.workoutSessionCompleted"
 }
 
 // WorkoutSessionAborted is published when a workout session is aborted or marked anomalous.
@@ -42,8 +42,8 @@ type WorkoutSessionAborted struct {
 }
 
 // EventName returns the CloudEvent type for WorkoutSessionAborted.
-func (e *WorkoutSessionAborted) EventName() string {
-	return "contracts.core.workout_execution.v1.event.WorkoutSessionAborted"
+func (e WorkoutSessionAborted) EventName() string {
+	return "contracts.core.workout_execution.v1.workoutSessionAborted"
 }
 
 // NewPersonalRecordAchieved is published when a user beats their previous 1RM record.
@@ -58,8 +58,8 @@ type NewPersonalRecordAchieved struct {
 }
 
 // EventName returns the CloudEvent type for NewPersonalRecordAchieved.
-func (e *NewPersonalRecordAchieved) EventName() string {
-	return "contracts.core.workout_execution.v1.event.NewPersonalRecordAchieved"
+func (e NewPersonalRecordAchieved) EventName() string {
+	return "contracts.core.workout_execution.v1.newPersonalRecordAchieved"
 }
 
 // BodyMetricUpdated is published if user updates weight at the end of a session.
@@ -70,6 +70,6 @@ type BodyMetricUpdated struct {
 }
 
 // EventName returns the CloudEvent type for BodyMetricUpdated.
-func (e *BodyMetricUpdated) EventName() string {
-	return "contracts.core.workout_execution.v1.event.BodyMetricUpdated"
+func (e BodyMetricUpdated) EventName() string {
+	return "contracts.core.workout_execution.v1.bodyMetricUpdated"
 }

--- a/internal/workout_execution/domain/event/events_test.go
+++ b/internal/workout_execution/domain/event/events_test.go
@@ -12,27 +12,27 @@ func TestDomainEventNames(t *testing.T) {
 	now := time.Now().UTC()
 
 	ev1 := event.WorkoutSessionStarted{SessionID: "s1", UserID: "u1", PlanID: "p1", StartedAt: now}
-	if got, want := ev1.EventName(), "contracts.core.workout_execution.v1.event.WorkoutSessionStarted"; got != want {
+	if got, want := ev1.EventName(), "contracts.core.workout_execution.v1.workoutSessionStarted"; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
 	ev2 := event.WorkoutSessionCompleted{SessionID: "s1", UserID: "u1", CompletedAt: now, Summary: vo.SessionSummary{}}
-	if got, want := ev2.EventName(), "contracts.core.workout_execution.v1.event.WorkoutSessionCompleted"; got != want {
+	if got, want := ev2.EventName(), "contracts.core.workout_execution.v1.workoutSessionCompleted"; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
 	ev3 := event.WorkoutSessionAborted{SessionID: "s1", UserID: "u1", Reason: "stop", IsAnomalous: false, AbortedAt: now}
-	if got, want := ev3.EventName(), "contracts.core.workout_execution.v1.event.WorkoutSessionAborted"; got != want {
+	if got, want := ev3.EventName(), "contracts.core.workout_execution.v1.workoutSessionAborted"; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
 	ev4 := event.NewPersonalRecordAchieved{UserID: "u1", ExerciseID: "ex1", OneRepMax: 100, Weight: 100, Reps: 10, FormVerified: true, AchievedAt: now}
-	if got, want := ev4.EventName(), "contracts.core.workout_execution.v1.event.NewPersonalRecordAchieved"; got != want {
+	if got, want := ev4.EventName(), "contracts.core.workout_execution.v1.newPersonalRecordAchieved"; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
 	ev5 := event.BodyMetricUpdated{UserID: "u1", WeightKg: 75.0, RecordedAt: now}
-	if got, want := ev5.EventName(), "contracts.core.workout_execution.v1.event.BodyMetricUpdated"; got != want {
+	if got, want := ev5.EventName(), "contracts.core.workout_execution.v1.bodyMetricUpdated"; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 }

--- a/internal/workout_execution/infrastructure/event/outbox_writer.go
+++ b/internal/workout_execution/infrastructure/event/outbox_writer.go
@@ -7,7 +7,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	workoutexecutionv1event "github.com/viethung213/gym-companion/internal/gen/go/contracts/core/workout_execution/v1/event"
 	"github.com/viethung213/gym-companion/internal/workout_execution/application/port"
+	domainEvent "github.com/viethung213/gym-companion/internal/workout_execution/domain/event"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // NameProvider interface to extract event name string.
@@ -38,14 +43,23 @@ func (w *OutboxWriter) WriteEvents(ctx context.Context, aggregateType, aggregate
 }
 
 func (w *OutboxWriter) writeSingleEvent(ctx context.Context, aggregateType, aggregateID string, ev interface{}) error {
-	eventType := "contracts.core.workout_execution.v1.event.UnknownEvent"
+	eventType := "contracts.core.workout_execution.v1.unknownEvent"
 	if nameProvider, ok := ev.(NameProvider); ok {
 		eventType = nameProvider.EventName()
 	}
 
-	payloadBytes, err := json.Marshal(ev)
-	if err != nil {
-		return fmt.Errorf("failed to marshal event payload: %w", err)
+	var payloadBytes []byte
+	var err error
+	if protoMsg := mapToProtoEvent(ev); protoMsg != nil {
+		payloadBytes, err = protojson.Marshal(protoMsg)
+		if err != nil {
+			return fmt.Errorf("failed to marshal proto event payload: %w", err)
+		}
+	} else {
+		payloadBytes, err = json.Marshal(ev)
+		if err != nil {
+			return fmt.Errorf("failed to marshal event payload: %w", err)
+		}
 	}
 
 	outboxID := uuid.NewString()
@@ -84,4 +98,90 @@ func (w *OutboxWriter) writeSingleEvent(ctx context.Context, aggregateType, aggr
 	}
 
 	return nil
+}
+
+func mapToProtoEvent(ev interface{}) proto.Message {
+	switch e := ev.(type) {
+	case domainEvent.WorkoutSessionStarted:
+		return &workoutexecutionv1event.WorkoutSessionStarted{
+			SessionId: e.SessionID,
+			UserId:    e.UserID,
+			PlanId:    e.PlanID,
+			StartedAt: timestamppb.New(e.StartedAt),
+		}
+	case *domainEvent.WorkoutSessionStarted:
+		if e == nil {
+			return nil
+		}
+		return &workoutexecutionv1event.WorkoutSessionStarted{
+			SessionId: e.SessionID,
+			UserId:    e.UserID,
+			PlanId:    e.PlanID,
+			StartedAt: timestamppb.New(e.StartedAt),
+		}
+	case domainEvent.WorkoutSessionCompleted:
+		return mapWorkoutSessionCompletedToProto(&e)
+	case *domainEvent.WorkoutSessionCompleted:
+		if e == nil {
+			return nil
+		}
+		return mapWorkoutSessionCompletedToProto(e)
+	case domainEvent.WorkoutSessionAborted:
+		return &workoutexecutionv1event.WorkoutSessionAborted{
+			SessionId: e.SessionID,
+			UserId:    e.UserID,
+			AbortedAt: timestamppb.New(e.AbortedAt),
+			Reason:    e.Reason,
+		}
+	case *domainEvent.WorkoutSessionAborted:
+		if e == nil {
+			return nil
+		}
+		return &workoutexecutionv1event.WorkoutSessionAborted{
+			SessionId: e.SessionID,
+			UserId:    e.UserID,
+			AbortedAt: timestamppb.New(e.AbortedAt),
+			Reason:    e.Reason,
+		}
+	case domainEvent.NewPersonalRecordAchieved:
+		return &workoutexecutionv1event.NewPersonalRecordAchieved{
+			UserId:     e.UserID,
+			ExerciseId: e.ExerciseID,
+			OneRepMax:  e.OneRepMax,
+			Weight:     e.Weight,
+			Reps:       int32(e.Reps),
+			AchievedAt: timestamppb.New(e.AchievedAt),
+		}
+	case *domainEvent.NewPersonalRecordAchieved:
+		if e == nil {
+			return nil
+		}
+		return &workoutexecutionv1event.NewPersonalRecordAchieved{
+			UserId:     e.UserID,
+			ExerciseId: e.ExerciseID,
+			OneRepMax:  e.OneRepMax,
+			Weight:     e.Weight,
+			Reps:       int32(e.Reps),
+			AchievedAt: timestamppb.New(e.AchievedAt),
+		}
+	default:
+		return nil
+	}
+}
+
+func mapWorkoutSessionCompletedToProto(e *domainEvent.WorkoutSessionCompleted) *workoutexecutionv1event.WorkoutSessionCompleted {
+	var avgScore *float32
+	if e.Summary.AverageFormScore != nil {
+		score := float32(*e.Summary.AverageFormScore)
+		avgScore = &score
+	}
+	return &workoutexecutionv1event.WorkoutSessionCompleted{
+		SessionId:        e.SessionID,
+		UserId:           e.UserID,
+		CompletedAt:      timestamppb.New(e.CompletedAt),
+		TotalSets:        int32(e.Summary.TotalSets),
+		TotalVolume:      float32(e.Summary.TotalVolume),
+		AverageFormScore: avgScore,
+		AverageRpe:       float32(e.Summary.AverageRPE),
+	}
 }

--- a/internal/workout_execution/infrastructure/event/outbox_writer_test.go
+++ b/internal/workout_execution/infrastructure/event/outbox_writer_test.go
@@ -2,6 +2,7 @@ package event_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -12,10 +13,12 @@ import (
 )
 
 type mockOutboxRepo struct {
-	saveErr error
+	saveErr     error
+	savedRecord *port.OutboxRecord
 }
 
 func (m *mockOutboxRepo) Save(ctx context.Context, record *port.OutboxRecord) error {
+	m.savedRecord = record
 	return m.saveErr
 }
 
@@ -46,6 +49,31 @@ func TestOutboxWriter(t *testing.T) {
 		err := writer.WriteEvents(context.Background(), "WorkoutSession", "sess-1", []interface{}{ev})
 		if err != nil {
 			t.Fatalf("got err = %v, want nil", err)
+		}
+
+		if repo.savedRecord == nil {
+			t.Fatal("savedRecord is nil")
+		}
+		if got, want := repo.savedRecord.EventType, "contracts.core.workout_execution.v1.workoutSessionStarted"; got != want {
+			t.Errorf("got EventType = %v, want %v", got, want)
+		}
+
+		var envelope map[string]interface{}
+		if err := json.Unmarshal(repo.savedRecord.Payload, &envelope); err != nil {
+			t.Fatalf("failed to unmarshal payload: %v", err)
+		}
+		if got, want := envelope["type"], "contracts.core.workout_execution.v1.workoutSessionStarted"; got != want {
+			t.Errorf("got envelope type = %v, want %v", got, want)
+		}
+		dataMap, ok := envelope["data"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected data to be map[string]interface{}, got %T", envelope["data"])
+		}
+		if got, want := dataMap["sessionId"], "sess-1"; got != want {
+			t.Errorf("got data.sessionId = %v, want %v", got, want)
+		}
+		if got, want := dataMap["userId"], "user-1"; got != want {
+			t.Errorf("got data.userId = %v, want %v", got, want)
 		}
 	})
 

--- a/internal/workout_execution/tests/e2e/testutil.go
+++ b/internal/workout_execution/tests/e2e/testutil.go
@@ -180,7 +180,7 @@ func SeedMockData(t *testing.T, db *gorm.DB) string {
 		EventID:       uuid.NewString(),
 		AggregateType: "WorkoutSession",
 		AggregateID:   "sess-seed-1",
-		EventType:     "contracts.core.workout_execution.v1.event.WorkoutSessionStarted",
+		EventType:     "contracts.core.workout_execution.v1.workoutSessionStarted",
 		Payload:       []byte(`{"sessionId":"sess-seed-1"}`),
 		PartitionKey:  "sess-seed-1",
 		Published:     false,


### PR DESCRIPTION
## Tóm tắt các Thay đổi (Summary of Changes)
Giải quyết  #181 nhằm chuẩn hóa loại sự kiện (Event Type) và cơ chế đóng gói dữ liệu Outbox cho phân hệ \workout_execution\ theo đúng chuẩn mẫu SSOT CloudEvent:
1. **Domain Events**: Cập nhật giá trị trả về của \EventName()\ sang chuỗi \camelCase\ không chứa phân đoạn thừa \.event.\ (\contracts.core.workout_execution.v1.<eventName>\).
2. **Cơ chế Outbox Serialization**: Tái cấu trúc \OutboxWriter\ để ánh xạ Go domain events sang Protobuf contract structs (\workoutexecutionv1event.*\) và serialize trường \data\ bằng \protojson.Marshal()\.
3. **Kiểm thử Unit & E2E**: Cập nhật lại các câu lệnh kiểm tra tên event trong Unit Test và dữ liệu seed trong E2E test.

closes #181 
## Kết quả Kiểm thử (Test Verification)
- Tất cả bài test trong gói \domain/event\ và \infrastructure/event\ đã chạy thành công (PASS).
- Toàn bộ unit tests của phân hệ \workout_execution\ đã vượt qua 100%.