### PR TITLE
👷 ci(workflow): remove duplicate make proto-gen step

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -36,9 +36,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate API stubs via Make
-        run: make proto-gen
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## Summary
- Removes redundant \make proto-gen\ step in \.github/workflows/golangci-lint.yml\.
- Prevents double execution of protobuf stub clean & generation, optimizing CI build time.

## Verification
- Validated YAML structure of \.github/workflows/golangci-lint.yml\.