### PR TITLE
🐛 fix(profile): resolve critical auth bypass and enforce admin-only bola checks

### DIFF
--- a/internal/profile/infrastructure/transport/grpc/grpc_handler.go
+++ b/internal/profile/infrastructure/transport/grpc/grpc_handler.go
@@ -54,19 +54,16 @@ func NewGRPCHandler(
 func resolveUserID(ctx context.Context, reqUserID string) (string, error) {
 	actor, err := middleware.RequireAuthenticated(ctx)
 	if err != nil {
-		// Fallback for unauthenticated testing mode if reqUserID is present
-		if reqUserID != "" {
-			return reqUserID, nil
-		}
 		return "", status.Error(codes.Unauthenticated, "authentication required")
 	}
 
-	// Admin user can specify target user_id in request payload/url
-	if actor.IsAdmin() && reqUserID != "" {
+	if reqUserID != "" && reqUserID != actor.UserID {
+		if !actor.IsAdmin() {
+			return "", status.Error(codes.PermissionDenied, "access denied: only admins can view or modify another user's profile")
+		}
 		return reqUserID, nil
 	}
 
-	// Normal user: UserID is extracted strictly from gRPC context metadata (JWT token claim)
 	return actor.UserID, nil
 }
 

--- a/internal/profile/infrastructure/transport/grpc/grpc_handler_test.go
+++ b/internal/profile/infrastructure/transport/grpc/grpc_handler_test.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	profilev1message "github.com/viethung213/gym-companion/internal/gen/go/contracts/supporting/profile/v1/message"
 	"github.com/viethung213/gym-companion/internal/profile/application/command"
 	"github.com/viethung213/gym-companion/internal/profile/application/query"
@@ -299,9 +302,29 @@ func TestGRPCHandler_Endpoints(t *testing.T) {
 		assert.NotEmpty(t, hRes.GetInjuries()[1].GetRecoveredAt())
 	})
 
-	// 7. Unauthenticated resolution
-	t.Run("Unauthenticated error case", func(t *testing.T) {
-		_, err := handler.GetProfile(context.Background(), &profilev1message.GetProfileRequest{})
-		assert.Error(t, err)
+	// 7. Security verification (Auth Bypass & BOLA protection)
+	t.Run("Security Checks", func(t *testing.T) {
+		// Case A: Unauthenticated request with target user_id in payload must return Unauthenticated
+		_, err := handler.GetProfile(context.Background(), &profilev1message.GetProfileRequest{UserId: "victim-user-123"})
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.Unauthenticated, st.Code())
+
+		// Case B: Normal User attempting to access another user's profile must return PermissionDenied (BOLA protection)
+		normalUserCtx := context.WithValue(context.Background(), middleware.UserIDKey, "normal-user-1")
+		normalUserCtx = context.WithValue(normalUserCtx, middleware.UserRoleKey, "User")
+		_, err = handler.GetProfile(normalUserCtx, &profilev1message.GetProfileRequest{UserId: "other-user-999"})
+		require.Error(t, err)
+		st, ok = status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, st.Code())
+
+		// Case C: Admin User accessing another user's profile must succeed
+		adminUserCtx := context.WithValue(context.Background(), middleware.UserIDKey, "admin-1")
+		adminUserCtx = context.WithValue(adminUserCtx, middleware.UserRoleKey, "Admin")
+		res, err := handler.GetProfile(adminUserCtx, &profilev1message.GetProfileRequest{UserId: "grpc-user-1"})
+		require.NoError(t, err)
+		assert.Equal(t, "grpc-user-1", res.GetUserId())
 	})
 }

--- a/internal/profile/infrastructure/transport/grpc/grpc_handler_test.go
+++ b/internal/profile/infrastructure/transport/grpc/grpc_handler_test.go
@@ -7,9 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	profilev1message "github.com/viethung213/gym-companion/internal/gen/go/contracts/supporting/profile/v1/message"
 	"github.com/viethung213/gym-companion/internal/profile/application/command"
 	"github.com/viethung213/gym-companion/internal/profile/application/query"
@@ -19,6 +16,8 @@ import (
 	"github.com/viethung213/gym-companion/internal/profile/domain/vo"
 	grpcProfile "github.com/viethung213/gym-companion/internal/profile/infrastructure/transport/grpc"
 	"github.com/viethung213/gym-companion/internal/shared/middleware"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type mockRepo struct {


### PR DESCRIPTION
### 1. Problem to Solve
- **Lỗ hổng Xác thực Cực kỳ Nghiêm trọng (Auth Bypass)** tại Profile Module (`internal/profile/infrastructure/transport/grpc/grpc_handler.go:L54-71`).
- **Mô tả vấn đề**: Hàm `resolveUserID` chứa logic fallback nguy hiểm `if reqUserID != "" { return reqUserID, nil }` khi request không đính kèm JWT token. Kẻ tấn công unauthenticated có thể đọc toàn bộ dữ liệu hồ sơ cá nhân (cân nặng, chiều cao, chỉ số cơ thể, lịch sử chấn thương) của bất kỳ ai bằng cách gửi `user_id` mục tiêu trong request payload.
- **Nguy cơ BOLA (Broken Object Level Authorization)**: Người dùng thông thường (`Normal User`) có thể gửi `user_id` của người khác để truy vấn thông tin nhạy cảm.

### 2. Proposed Solution
- **Loại bỏ hoàn toàn Fallback Unauthenticated**: Yêu cầu xác thực JWT Token (`middleware.RequireAuthenticated(ctx)`) là bắt buộc với tất cả gRPC endpoints của Profile Module. Nếu thiếu token hoặc token không hợp lệ, lập tức trả về lỗi `codes.Unauthenticated`.
- **Kiểm soát phân quyền nghiêm ngặt (BOLA Protection)**:
  - Chỉ tài khoản **Admin (`actor.IsAdmin() == true`)** mới được phép truyền `reqUserID` của người khác (`reqUserID != actor.UserID`).
  - Nếu **Normal User (`actor.IsAdmin() == false`)** cố tình truyền `reqUserID` của người dùng khác, hệ thống sẽ từ chối và trả về lỗi `codes.PermissionDenied`.
  - Nếu `reqUserID` rỗng hoặc bằng chính `actor.UserID`, hệ thống sẽ trả về hồ sơ của chính người dùng đăng nhập.

### 3. Changes & Impact
- `[internal/profile/infrastructure/transport/grpc/grpc_handler.go](internal/profile/infrastructure/transport/grpc/grpc_handler.go)`: Cập nhật hàm `resolveUserID` để xóa logic fallback unauthenticated và bổ sung kiểm tra phân quyền BOLA đối với người dùng không phải Admin.
- `[internal/profile/infrastructure/transport/grpc/grpc_handler_test.go](internal/profile/infrastructure/transport/grpc/grpc_handler_test.go)`: Thêm test case `Security_Checks` bao phủ 3 kịch bản:
  1. Request không đính kèm JWT token -> `codes.Unauthenticated`.
  2. Normal user cố tình xem profile người khác -> `codes.PermissionDenied`.
  3. Admin user xem profile người khác -> Đọc thành công.

### 4. Testing & Verification
- **Automated Tests**:
  - `go test -v ./internal/profile/infrastructure/transport/grpc/...` (PASS 100%)
  - `go test ./internal/profile/...` (PASS 100%)
  - Static Analysis: `go vet ./internal/profile/...` (0 errors, 0 warnings)
  - Code Formatting: `gofmt -d` (0 diffs, clean formatting)
