### PR TITLE
🐛 fix(exercise): resolve mockIDGenerator name collision in event_test

### DIFF
--- a/internal/exercise/application/command/catalog_test.go
+++ b/internal/exercise/application/command/catalog_test.go
@@ -255,7 +255,7 @@ func TestCreateBodyPart_Success(t *testing.T) {
 	ids := &mockIDGenerator{nextID: "bp-123"}
 	handler := NewCreateBodyPartHandler(repo, ids)
 
-	adminCtx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("x-user-id", "admin-1", "x-user-role", "Admin"))
+	adminCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "admin-1", "x-user-role", "Admin"))
 
 	bp, err := handler.Handle(adminCtx, &CreateBodyPartCommand{Name: "Chest"})
 	if err != nil {
@@ -273,7 +273,7 @@ func TestCreateBodyPart_NoAuthz(t *testing.T) {
 	ids := &mockIDGenerator{nextID: "bp-123"}
 	handler := NewCreateBodyPartHandler(repo, ids)
 
-	userCtx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("x-user-id", "user-1", "x-user-role", "User"))
+	userCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "user-1", "x-user-role", "User"))
 
 	_, err := handler.Handle(userCtx, &CreateBodyPartCommand{Name: "Chest"})
 	if err == nil {
@@ -290,7 +290,7 @@ func TestCreateBodyPart_EmptyName(t *testing.T) {
 	ids := &mockIDGenerator{nextID: "bp-123"}
 	handler := NewCreateBodyPartHandler(repo, ids)
 
-	adminCtx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("x-user-id", "admin-1", "x-user-role", "Admin"))
+	adminCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "admin-1", "x-user-role", "Admin"))
 
 	_, err := handler.Handle(adminCtx, &CreateBodyPartCommand{Name: "  "})
 	if !errors.Is(err, domain.ErrInvalidBodyPart) {
@@ -304,7 +304,7 @@ func TestUpdateBodyPart_Success(t *testing.T) {
 	repo.bp = &port.BodyPart{ID: "bp-123", Name: "Old"}
 	handler := NewUpdateBodyPartHandler(repo)
 
-	adminCtx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("x-user-id", "admin-1", "x-user-role", "Admin"))
+	adminCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "admin-1", "x-user-role", "Admin"))
 
 	bp, err := handler.Handle(adminCtx, &UpdateBodyPartCommand{ID: "bp-123", Name: "Updated"})
 	if err != nil {
@@ -322,7 +322,7 @@ func TestDeleteBodyPart_Success(t *testing.T) {
 	repo.bp = &port.BodyPart{ID: "bp-123", Name: "Chest"}
 	handler := NewDeleteBodyPartHandler(repo)
 
-	adminCtx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("x-user-id", "admin-1", "x-user-role", "Admin"))
+	adminCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "admin-1", "x-user-role", "Admin"))
 
 	err := handler.Handle(adminCtx, &DeleteBodyPartCommand{ID: "bp-123"})
 	if err != nil {

--- a/internal/exercise/application/command/catalog_test.go
+++ b/internal/exercise/application/command/catalog_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/viethung213/gym-companion/internal/exercise/application/port"
 	"github.com/viethung213/gym-companion/internal/exercise/domain"
 	"github.com/viethung213/gym-companion/internal/shared/middleware"
-	"google.golang.org/grpc/metadata"
 )
 
 type mockIDGenerator struct {
@@ -255,7 +254,7 @@ func TestCreateBodyPart_Success(t *testing.T) {
 	ids := &mockIDGenerator{nextID: "bp-123"}
 	handler := NewCreateBodyPartHandler(repo, ids)
 
-	adminCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "admin-1", "x-user-role", "Admin"))
+	adminCtx := context.WithValue(context.WithValue(context.Background(), middleware.UserIDKey, "admin-1"), middleware.UserRoleKey, "Admin")
 
 	bp, err := handler.Handle(adminCtx, &CreateBodyPartCommand{Name: "Chest"})
 	if err != nil {
@@ -273,7 +272,7 @@ func TestCreateBodyPart_NoAuthz(t *testing.T) {
 	ids := &mockIDGenerator{nextID: "bp-123"}
 	handler := NewCreateBodyPartHandler(repo, ids)
 
-	userCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "user-1", "x-user-role", "User"))
+	userCtx := context.WithValue(context.WithValue(context.Background(), middleware.UserIDKey, "user-1"), middleware.UserRoleKey, "User")
 
 	_, err := handler.Handle(userCtx, &CreateBodyPartCommand{Name: "Chest"})
 	if err == nil {
@@ -290,7 +289,7 @@ func TestCreateBodyPart_EmptyName(t *testing.T) {
 	ids := &mockIDGenerator{nextID: "bp-123"}
 	handler := NewCreateBodyPartHandler(repo, ids)
 
-	adminCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "admin-1", "x-user-role", "Admin"))
+	adminCtx := context.WithValue(context.WithValue(context.Background(), middleware.UserIDKey, "admin-1"), middleware.UserRoleKey, "Admin")
 
 	_, err := handler.Handle(adminCtx, &CreateBodyPartCommand{Name: "  "})
 	if !errors.Is(err, domain.ErrInvalidBodyPart) {
@@ -304,7 +303,7 @@ func TestUpdateBodyPart_Success(t *testing.T) {
 	repo.bp = &port.BodyPart{ID: "bp-123", Name: "Old"}
 	handler := NewUpdateBodyPartHandler(repo)
 
-	adminCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "admin-1", "x-user-role", "Admin"))
+	adminCtx := context.WithValue(context.WithValue(context.Background(), middleware.UserIDKey, "admin-1"), middleware.UserRoleKey, "Admin")
 
 	bp, err := handler.Handle(adminCtx, &UpdateBodyPartCommand{ID: "bp-123", Name: "Updated"})
 	if err != nil {
@@ -322,7 +321,7 @@ func TestDeleteBodyPart_Success(t *testing.T) {
 	repo.bp = &port.BodyPart{ID: "bp-123", Name: "Chest"}
 	handler := NewDeleteBodyPartHandler(repo)
 
-	adminCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "admin-1", "x-user-role", "Admin"))
+	adminCtx := context.WithValue(context.WithValue(context.Background(), middleware.UserIDKey, "admin-1"), middleware.UserRoleKey, "Admin")
 
 	err := handler.Handle(adminCtx, &DeleteBodyPartCommand{ID: "bp-123"})
 	if err != nil {

--- a/internal/exercise/application/command/event_test.go
+++ b/internal/exercise/application/command/event_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package command
 
 import (
@@ -9,12 +11,12 @@ import (
 	"github.com/viethung213/gym-companion/internal/exercise/domain"
 )
 
-type mockIDGenerator struct {
+type mockEventIDGenerator struct {
 	id  string
 	err error
 }
 
-func (m mockIDGenerator) NewID() (string, error) {
+func (m mockEventIDGenerator) NewID() (string, error) {
 	return m.id, m.err
 }
 
@@ -46,14 +48,14 @@ func TestNewEvent_CloudEvents(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		generator  mockIDGenerator
+		generator  mockEventIDGenerator
 		eventType  string
 		wantErrIs  error
 		expectType string
 	}{
 		{
 			name: "success created event",
-			generator: mockIDGenerator{
+			generator: mockEventIDGenerator{
 				id: "event-uuid-789",
 			},
 			eventType:  domain.EventTypeExerciseCreated,
@@ -61,7 +63,7 @@ func TestNewEvent_CloudEvents(t *testing.T) {
 		},
 		{
 			name: "success approved event",
-			generator: mockIDGenerator{
+			generator: mockEventIDGenerator{
 				id: "event-uuid-abc",
 			},
 			eventType:  domain.EventTypeExerciseApproved,
@@ -69,7 +71,7 @@ func TestNewEvent_CloudEvents(t *testing.T) {
 		},
 		{
 			name: "generator error",
-			generator: mockIDGenerator{
+			generator: mockEventIDGenerator{
 				err: errors.New("id generator error"),
 			},
 			eventType: domain.EventTypeExerciseCreated,

--- a/internal/exercise/application/query/catalog_test.go
+++ b/internal/exercise/application/query/catalog_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/viethung213/gym-companion/internal/exercise/application/port"
 	"github.com/viethung213/gym-companion/internal/exercise/domain"
 	"github.com/viethung213/gym-companion/internal/shared/middleware"
-	"google.golang.org/grpc/metadata"
 )
 
 type mockQueryRepository struct {
@@ -133,7 +132,7 @@ func TestGetBodyPart_Success(t *testing.T) {
 	}
 	handler := NewGetBodyPartHandler(repo)
 
-	userCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "user-1", "x-user-role", "User"))
+	userCtx := context.WithValue(context.WithValue(context.Background(), middleware.UserIDKey, "user-1"), middleware.UserRoleKey, "User")
 
 	bp, err := handler.Handle(userCtx, GetBodyPartQuery{ID: "bp-123"})
 	if err != nil {
@@ -150,7 +149,7 @@ func TestGetBodyPart_NotFound(t *testing.T) {
 	repo := &mockQueryRepository{bp: nil}
 	handler := NewGetBodyPartHandler(repo)
 
-	userCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "user-1", "x-user-role", "User"))
+	userCtx := context.WithValue(context.WithValue(context.Background(), middleware.UserIDKey, "user-1"), middleware.UserRoleKey, "User")
 
 	_, err := handler.Handle(userCtx, GetBodyPartQuery{ID: "nonexistent"})
 	if !errors.Is(err, domain.ErrBodyPartNotFound) {
@@ -184,7 +183,7 @@ func TestListBodyParts_Success(t *testing.T) {
 	}
 	handler := NewListBodyPartsHandler(repo)
 
-	userCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "user-1", "x-user-role", "User"))
+	userCtx := context.WithValue(context.WithValue(context.Background(), middleware.UserIDKey, "user-1"), middleware.UserRoleKey, "User")
 
 	bps, total, err := handler.Handle(userCtx, ListBodyPartsQuery{Limit: 10, Offset: 0})
 	if err != nil {
@@ -204,7 +203,7 @@ func TestListBodyParts_Empty(t *testing.T) {
 	repo := &mockQueryRepository{bps: []port.BodyPart{}}
 	handler := NewListBodyPartsHandler(repo)
 
-	userCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "user-1", "x-user-role", "User"))
+	userCtx := context.WithValue(context.WithValue(context.Background(), middleware.UserIDKey, "user-1"), middleware.UserRoleKey, "User")
 
 	bps, total, err := handler.Handle(userCtx, ListBodyPartsQuery{Limit: 10, Offset: 0})
 	if err != nil {
@@ -221,7 +220,7 @@ func TestListBodyParts_DefaultLimit(t *testing.T) {
 	repo := &mockQueryRepository{bps: []port.BodyPart{}}
 	handler := NewListBodyPartsHandler(repo)
 
-	userCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "user-1", "x-user-role", "User"))
+	userCtx := context.WithValue(context.WithValue(context.Background(), middleware.UserIDKey, "user-1"), middleware.UserRoleKey, "User")
 
 	_, _, err := handler.Handle(userCtx, ListBodyPartsQuery{Limit: 0, Offset: 0})
 	if err != nil {

--- a/internal/exercise/application/query/catalog_test.go
+++ b/internal/exercise/application/query/catalog_test.go
@@ -93,7 +93,7 @@ func (m *mockQueryRepository) DeleteEquipment(ctx context.Context, id string) er
 	return nil
 }
 
-func (m *mockQueryRepository) CreateMuscle(ctx context.Context, m *port.Muscle) error {
+func (m *mockQueryRepository) CreateMuscle(ctx context.Context, muscle *port.Muscle) error {
 	return nil
 }
 
@@ -101,7 +101,7 @@ func (m *mockQueryRepository) GetMuscle(ctx context.Context, id string) (*port.M
 	return nil, nil
 }
 
-func (m *mockQueryRepository) UpdateMuscle(ctx context.Context, m *port.Muscle) error {
+func (m *mockQueryRepository) UpdateMuscle(ctx context.Context, muscle *port.Muscle) error {
 	return nil
 }
 

--- a/internal/exercise/application/query/catalog_test.go
+++ b/internal/exercise/application/query/catalog_test.go
@@ -133,7 +133,7 @@ func TestGetBodyPart_Success(t *testing.T) {
 	}
 	handler := NewGetBodyPartHandler(repo)
 
-	userCtx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("x-user-id", "user-1", "x-user-role", "User"))
+	userCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "user-1", "x-user-role", "User"))
 
 	bp, err := handler.Handle(userCtx, GetBodyPartQuery{ID: "bp-123"})
 	if err != nil {
@@ -150,7 +150,7 @@ func TestGetBodyPart_NotFound(t *testing.T) {
 	repo := &mockQueryRepository{bp: nil}
 	handler := NewGetBodyPartHandler(repo)
 
-	userCtx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("x-user-id", "user-1", "x-user-role", "User"))
+	userCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "user-1", "x-user-role", "User"))
 
 	_, err := handler.Handle(userCtx, GetBodyPartQuery{ID: "nonexistent"})
 	if !errors.Is(err, domain.ErrBodyPartNotFound) {
@@ -184,7 +184,7 @@ func TestListBodyParts_Success(t *testing.T) {
 	}
 	handler := NewListBodyPartsHandler(repo)
 
-	userCtx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("x-user-id", "user-1", "x-user-role", "User"))
+	userCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "user-1", "x-user-role", "User"))
 
 	bps, total, err := handler.Handle(userCtx, ListBodyPartsQuery{Limit: 10, Offset: 0})
 	if err != nil {
@@ -204,7 +204,7 @@ func TestListBodyParts_Empty(t *testing.T) {
 	repo := &mockQueryRepository{bps: []port.BodyPart{}}
 	handler := NewListBodyPartsHandler(repo)
 
-	userCtx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("x-user-id", "user-1", "x-user-role", "User"))
+	userCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "user-1", "x-user-role", "User"))
 
 	bps, total, err := handler.Handle(userCtx, ListBodyPartsQuery{Limit: 10, Offset: 0})
 	if err != nil {
@@ -221,7 +221,7 @@ func TestListBodyParts_DefaultLimit(t *testing.T) {
 	repo := &mockQueryRepository{bps: []port.BodyPart{}}
 	handler := NewListBodyPartsHandler(repo)
 
-	userCtx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("x-user-id", "user-1", "x-user-role", "User"))
+	userCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-user-id", "user-1", "x-user-role", "User"))
 
 	_, _, err := handler.Handle(userCtx, ListBodyPartsQuery{Limit: 0, Offset: 0})
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add missing //go:build unit tag to internal/exercise/application/command/event_test.go.
- Rename mockIDGenerator struct to mockEventIDGenerator in event_test.go to eliminate symbol collision with catalog_test.go.

## Test Plan
- Run GolangCI-Lint and unit tests in CI.