### PR TITLE
🐛 fix(workout_execution): resolve motion specification test field & constructor mismatches

### DIFF
--- a/internal/workout_execution/infrastructure/persistence/postgres_repository_test.go
+++ b/internal/workout_execution/infrastructure/persistence/postgres_repository_test.go
@@ -454,7 +454,7 @@ func TestPostgresRepository_CanceledContextAndLockConflict(t *testing.T) {
 		t.Error("expected error on canceled context FindByUserIDAndExerciseIDs")
 	}
 
-	motionSpec := aggregate.NewMotionSpecification("ex1", "http://onnx", "http://rules", vo.DialogueEngineConfig{}, "front")
+	motionSpec := aggregate.RestoreMotionSpecification("ex1", "http://onnx_detector", "http://onnx_skeleton", "http://rules", "http://dialogue", "front", true, time.Now().UTC(), time.Now().UTC())
 	if err := motionRepo.Save(ctxCancel, motionSpec); err == nil {
 		t.Error("expected error on canceled context Save MotionSpec")
 	}

--- a/internal/workout_execution/module.go
+++ b/internal/workout_execution/module.go
@@ -45,12 +45,6 @@ func Initialize(ctx context.Context, deps ModuleDeps) (func(), error) {
 		return nil, fmt.Errorf("wrap connection pool in gorm: %w", err)
 	}
 
-	// AutoMigrate models to sync schema changes (e.g. dialogue_engine_url, outbox_log)
-	_ = gormDB.AutoMigrate(
-		&persistence.MotionSpecificationModel{},
-		&persistence.OutboxLogModel{},
-	)
-
 	// Initialize Repositories & Storage & Transaction Manager
 	txManager := persistence.NewSQLTransactionManager(gormDB)
 	sessionRepo := persistence.NewPostgresWorkoutSessionRepository(gormDB)

--- a/internal/workout_execution/tests/e2e/testutil.go
+++ b/internal/workout_execution/tests/e2e/testutil.go
@@ -150,7 +150,7 @@ func SeedMockData(t *testing.T, db *gorm.DB) string {
 		OnnxDetectorURL:        "http://storage.fitai.com/models/detector.onnx",
 		OnnxSkeletonURL:        "http://storage.fitai.com/models/skeleton.onnx",
 		LocalRulesURL:          "http://storage.fitai.com/rules/bench_press.json",
-		DialogueEngineJSON:     []byte(`{"personalityId":"coach-pro"}`),
+		DialogueEngineURL:      "http://storage.fitai.com/dialogue/bench_press.json",
 		RecommendedCameraAngle: "front",
 		CreatedAt:              now,
 		UpdatedAt:              now,

--- a/internal/workout_execution/tests/e2e/workout_execution_e2e_test.go
+++ b/internal/workout_execution/tests/e2e/workout_execution_e2e_test.go
@@ -33,7 +33,7 @@ func TestWorkoutExecution_FullLifecycle_E2E(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetMotionSpecification for seeded mock data failed: %v", err)
 	}
-	if motionResp.GetOnnxDetectorUrl() == "" || motionResp.GetDialogueEngine().GetPersonalityId() != "coach-pro" {
+	if motionResp.GetOnnxDetectorUrl() == "" || motionResp.GetDialogueEngineUrl() == "" {
 		t.Errorf("Unexpected GetMotionSpecification response: %+v", motionResp)
 	}
 


### PR DESCRIPTION
## Connected & Resolved Issues
- Resolves #201: 🐛 [WORKOUT_EXECUTION] Fix test suite runtime failure & AutoMigrate error

## Summary
- Remove runtime AutoMigrate call in internal/workout_execution/module.go per AGENTS.md database conventions, fixing pq: got 2 parameters but the statement requires 1 runtime database error.
- Update postgres_repository_test.go to use ggregate.RestoreMotionSpecification.
- Update 	estutil.go to use DialogueEngineURL in MotionSpecificationModel.
- Update workout_execution_e2e_test.go to use GetDialogueEngineUrl().

## Test Plan
- go test -tags=unit,e2e,integration ./internal/workout_execution/... — 100% PASS.