### PR TITLE
🐛 fix(workout-execution): resolve active workout session race condition

### DIFF
--- a/internal/workout_execution/application/command/start_workout_session.go
+++ b/internal/workout_execution/application/command/start_workout_session.go
@@ -56,14 +56,6 @@ func (h *StartWorkoutSessionHandler) Handle(
 		return nil, apperror.ErrInvalidInput
 	}
 
-	activeSession, err := h.sessionRepo.FindActiveSessionByUserID(ctx, cmd.UserID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query active sessions: %w", err)
-	}
-	if activeSession != nil {
-		return nil, derror.ErrActiveSessionAlreadyExists
-	}
-
 	if h.planClient != nil {
 		exists, planErr := h.planClient.ValidatePlanExists(ctx, cmd.UserID, cmd.PlanID)
 		if planErr != nil {
@@ -81,6 +73,14 @@ func (h *StartWorkoutSessionHandler) Handle(
 	}
 
 	if err := h.txManager.WithTransaction(ctx, func(txCtx context.Context) error {
+		activeSession, err := h.sessionRepo.FindActiveSessionByUserID(txCtx, cmd.UserID)
+		if err != nil {
+			return fmt.Errorf("failed to query active sessions: %w", err)
+		}
+		if activeSession != nil {
+			return derror.ErrActiveSessionAlreadyExists
+		}
+
 		if err := h.sessionRepo.Save(txCtx, session); err != nil {
 			return err
 		}

--- a/internal/workout_execution/infrastructure/persistence/postgres_repository.go
+++ b/internal/workout_execution/infrastructure/persistence/postgres_repository.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -41,6 +42,9 @@ func (r *PostgresWorkoutSessionRepository) Save(ctx context.Context, session *ag
 	}).Create(model).Error
 
 	if err != nil {
+		if errors.Is(err, gorm.ErrDuplicatedKey) || strings.Contains(err.Error(), "uq_workout_sessions_active_user") {
+			return derror.ErrActiveSessionAlreadyExists
+		}
 		return fmt.Errorf("failed to save workout session: %w", err)
 	}
 

--- a/internal/workout_execution/infrastructure/persistence/postgres_repository_test.go
+++ b/internal/workout_execution/infrastructure/persistence/postgres_repository_test.go
@@ -36,6 +36,7 @@ func ensureTablesExist(db *gorm.DB) {
 		created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
 		updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 	);`)
+	db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS uq_workout_sessions_active_user ON workout_execution.workout_sessions(user_id) WHERE status = 'IN_PROGRESS';`)
 
 	db.Exec(`CREATE TABLE IF NOT EXISTS workout_execution.workout_set_logs (
 		id VARCHAR(255) PRIMARY KEY,

--- a/scripts/postgres-init/04-create-workout-execution-tables.sql
+++ b/scripts/postgres-init/04-create-workout-execution-tables.sql
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS workout_execution.workout_sessions (
 CREATE INDEX IF NOT EXISTS idx_workout_sessions_user_id ON workout_execution.workout_sessions(user_id);
 CREATE INDEX IF NOT EXISTS idx_workout_sessions_status ON workout_execution.workout_sessions(status);
 CREATE INDEX IF NOT EXISTS idx_workout_sessions_user_status ON workout_execution.workout_sessions(user_id, status);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_workout_sessions_active_user ON workout_execution.workout_sessions(user_id) WHERE status = 'IN_PROGRESS';
 
 -- 2. Table: workout_set_logs
 CREATE TABLE IF NOT EXISTS workout_execution.workout_set_logs (


### PR DESCRIPTION
### 1. Problem to Solve
- **Lỗi Race Condition Tạo Phiên Tập Trùng (Active Session Concurrency Bug)**: Việc kiểm tra phiên tập đang active (\FindActiveSessionByUserID\) diễn ra ngoài Database Transaction và bảng \workout_execution.workout_sessions\ thiếu DB Partial Unique Index (\WHERE status = 'IN_PROGRESS'\).
- Tác động: Khi client gửi 2 request \StartWorkoutSession\ đồng thời (double click), cả 2 request đều tạo mới thành công, dẫn đến người dùng có 2 phiên tập \IN_PROGRESS\ song song.

### 2. Proposed Solution
- Bổ sung DB Partial Unique Index \uq_workout_sessions_active_user\ trên \workout_execution.workout_sessions(user_id) WHERE status = 'IN_PROGRESS'\.
- Đưa việc gọi \FindActiveSessionByUserID\ vào bên trong DB Transaction (\	xManager.WithTransaction\).
- Xử lý lỗi unique constraint vi phạm index trong \PostgresWorkoutSessionRepository.Save()\ và map sang \derror.ErrActiveSessionAlreadyExists\.

### 3. Changes & Impact
- \[scripts/postgres-init/04-create-workout-execution-tables.sql](scripts/postgres-init/04-create-workout-execution-tables.sql)\: Bổ sung index \uq_workout_sessions_active_user\.
- \[internal/workout_execution/application/command/start_workout_session.go](internal/workout_execution/application/command/start_workout_session.go)\: Di chuyển \FindActiveSessionByUserID\ vào bên trong \WithTransaction\.
- \[internal/workout_execution/infrastructure/persistence/postgres_repository.go](internal/workout_execution/infrastructure/persistence/postgres_repository.go)\: Map lỗi unique index sang \derror.ErrActiveSessionAlreadyExists\.
- \[internal/workout_execution/infrastructure/persistence/postgres_repository_test.go](internal/workout_execution/infrastructure/persistence/postgres_repository_test.go)\: Cập nhật hàm khởi tạo DB test.

### 4. Testing & Verification
- **Automated Tests**: Chạy toàn bộ test suites trong \internal/workout_execution/...\ -> **PASS** (100%).