### PR TITLE
🐛 fix(workout_execution): remove gorm automigrate at startup and fix test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,8 @@ test-all: build-test
 	@-cp -n .env.example .env 2>/dev/null
 	@echo "Running all tests (Unit, Integration, E2E) inside Docker..."
 	@docker run --rm --network fitai-network --env-file .env fitai-app:test sh -c ' \
-		OUT=$$(go test -v -race -p=1 -tags="unit,integration,e2e" ./...); \
+		OUT=$$(go test -v -race -p=1 -tags="unit,integration,e2e" ./... 2>&1); \
+		STATUS=$$?; \
 		echo "$$OUT"; \
 		PASSED=$$(echo "$$OUT" | grep -c -e "--- PASS:"); \
 		FAILED=$$(echo "$$OUT" | grep -c -e "--- FAIL:"); \
@@ -85,7 +86,7 @@ test-all: build-test
 		echo "🟢 ĐẠT (PASSED): $$PASSED"; \
 		echo "🔴 THẤT BẠI (FAILED): $$FAILED"; \
 		echo "=================================================="; \
-		if [ $$FAILED -gt 0 ]; then exit 1; fi'
+		if [ $$STATUS -ne 0 ] || [ $$FAILED -gt 0 ]; then exit 1; fi'
 
 # Chạy tất cả các Unit Tests của toàn dự án bên trong Docker
 test-unit: build-test
@@ -112,7 +113,8 @@ endif
 	@-cp -n .env.example .env 2>/dev/null
 	@echo "Running all tests (Unit, Integration, E2E) for module $(MODULE) sequentially inside Docker..."
 	@docker run --rm --network fitai-network --env-file .env fitai-app:test sh -c ' \
-		OUT=$$(go test -v -race -p=1 -tags="unit,integration,e2e" ./internal/$(MODULE)/...); \
+		OUT=$$(go test -v -race -p=1 -tags="unit,integration,e2e" ./internal/$(MODULE)/... 2>&1); \
+		STATUS=$$?; \
 		echo "$$OUT"; \
 		PASSED=$$(echo "$$OUT" | grep -c -e "--- PASS:"); \
 		FAILED=$$(echo "$$OUT" | grep -c -e "--- FAIL:"); \
@@ -121,7 +123,7 @@ endif
 		echo "🟢 ĐẠT (PASSED): $$PASSED"; \
 		echo "🔴 THẤT BẠI (FAILED): $$FAILED"; \
 		echo "=================================================="; \
-		if [ $$FAILED -gt 0 ]; then exit 1; fi'
+		if [ $$STATUS -ne 0 ] || [ $$FAILED -gt 0 ]; then exit 1; fi'
 
 # Chạy chỉ Unit Tests của một module cụ thể bên trong Docker
 test-unit-module: build-test

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,7 @@ test-all: build-test
 	@-cp -n .env.example .env 2>/dev/null
 	@echo "Running all tests (Unit, Integration, E2E) inside Docker..."
 	@docker run --rm --network fitai-network --env-file .env fitai-app:test sh -c ' \
-		OUT=$$(go test -v -race -p=1 -tags="unit,integration,e2e" ./... 2>&1); \
-		STATUS=$$?; \
+		OUT=$$(go test -v -race -p=1 -tags="unit,integration,e2e" ./...); \
 		echo "$$OUT"; \
 		PASSED=$$(echo "$$OUT" | grep -c -e "--- PASS:"); \
 		FAILED=$$(echo "$$OUT" | grep -c -e "--- FAIL:"); \
@@ -86,7 +85,7 @@ test-all: build-test
 		echo "🟢 ĐẠT (PASSED): $$PASSED"; \
 		echo "🔴 THẤT BẠI (FAILED): $$FAILED"; \
 		echo "=================================================="; \
-		if [ $$STATUS -ne 0 ] || [ $$FAILED -gt 0 ]; then exit 1; fi'
+		if [ $$FAILED -gt 0 ]; then exit 1; fi'
 
 # Chạy tất cả các Unit Tests của toàn dự án bên trong Docker
 test-unit: build-test
@@ -113,8 +112,7 @@ endif
 	@-cp -n .env.example .env 2>/dev/null
 	@echo "Running all tests (Unit, Integration, E2E) for module $(MODULE) sequentially inside Docker..."
 	@docker run --rm --network fitai-network --env-file .env fitai-app:test sh -c ' \
-		OUT=$$(go test -v -race -p=1 -tags="unit,integration,e2e" ./internal/$(MODULE)/... 2>&1); \
-		STATUS=$$?; \
+		OUT=$$(go test -v -race -p=1 -tags="unit,integration,e2e" ./internal/$(MODULE)/...); \
 		echo "$$OUT"; \
 		PASSED=$$(echo "$$OUT" | grep -c -e "--- PASS:"); \
 		FAILED=$$(echo "$$OUT" | grep -c -e "--- FAIL:"); \
@@ -123,7 +121,7 @@ endif
 		echo "🟢 ĐẠT (PASSED): $$PASSED"; \
 		echo "🔴 THẤT BẠI (FAILED): $$FAILED"; \
 		echo "=================================================="; \
-		if [ $$STATUS -ne 0 ] || [ $$FAILED -gt 0 ]; then exit 1; fi'
+		if [ $$FAILED -gt 0 ]; then exit 1; fi'
 
 # Chạy chỉ Unit Tests của một module cụ thể bên trong Docker
 test-unit-module: build-test

--- a/internal/workout_execution/infrastructure/persistence/models.go
+++ b/internal/workout_execution/infrastructure/persistence/models.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/viethung213/gym-companion/internal/workout_execution/application/port"
@@ -203,7 +204,7 @@ func SessionToPersistence(session *aggregate.WorkoutSession) *WorkoutSessionMode
 			errBytes, _ := json.Marshal(r.GetErrorCodes())
 			anglesBytes, _ := json.Marshal(r.GetJointAngles())
 			setModel.Reps = append(setModel.Reps, RepLogModel{
-				ID:            session.ID() + "-" + set.ID,
+				ID:            fmt.Sprintf("%s-%s-%d", session.ID(), set.ID, r.RepNumber),
 				SetLogID:      set.ID,
 				RepNumber:     r.RepNumber,
 				ROMPercentage: r.ROMPercentage,

--- a/internal/workout_execution/infrastructure/persistence/postgres_repository_test.go
+++ b/internal/workout_execution/infrastructure/persistence/postgres_repository_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/viethung213/gym-companion/internal/shared/database"
 	"github.com/viethung213/gym-companion/internal/workout_execution/application/port"
 	"github.com/viethung213/gym-companion/internal/workout_execution/domain/aggregate"
+	"github.com/viethung213/gym-companion/internal/workout_execution/domain/derror"
 	"github.com/viethung213/gym-companion/internal/workout_execution/domain/vo"
 	infraPostgres "github.com/viethung213/gym-companion/internal/workout_execution/infrastructure/persistence"
 	"gorm.io/driver/postgres"
@@ -89,12 +90,12 @@ func ensureTablesExist(db *gorm.DB) {
 
 	db.Exec(`CREATE TABLE IF NOT EXISTS workout_execution.motion_specifications (
 		exercise_id VARCHAR(255) PRIMARY KEY,
-		onnx_model_url VARCHAR(1024),
 		onnx_detector_url VARCHAR(1024),
 		onnx_skeleton_url VARCHAR(1024),
 		local_rules_url VARCHAR(1024),
-		dialogue_engine_json JSONB,
+		dialogue_engine_url VARCHAR(1024),
 		recommended_camera_angle VARCHAR(50),
+		is_ready BOOLEAN NOT NULL DEFAULT FALSE,
 		created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
 		updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 	);`)
@@ -111,12 +112,18 @@ func ensureTablesExist(db *gorm.DB) {
 		published_at TIMESTAMP WITH TIME ZONE,
 		created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 	);`)
-	db.Exec(`ALTER TABLE workout_execution.outbox ADD COLUMN IF NOT EXISTS event_id VARCHAR(255);`)
-	db.Exec(`ALTER TABLE workout_execution.outbox ADD COLUMN IF NOT EXISTS aggregate_type VARCHAR(255);`)
-	db.Exec(`ALTER TABLE workout_execution.outbox ADD COLUMN IF NOT EXISTS aggregate_id VARCHAR(255);`)
-	db.Exec(`ALTER TABLE workout_execution.outbox ADD COLUMN IF NOT EXISTS partition_key VARCHAR(255);`)
-	db.Exec(`ALTER TABLE workout_execution.outbox ADD COLUMN IF NOT EXISTS published_at TIMESTAMP WITH TIME ZONE;`)
 	db.Exec(`CREATE INDEX IF NOT EXISTS idx_workout_execution_outbox_pub_created ON workout_execution.outbox (published, created_at);`)
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS workout_execution.outbox_log (
+		id UUID PRIMARY KEY,
+		event_id UUID NOT NULL,
+		event_type VARCHAR(255) NOT NULL,
+		payload JSONB NOT NULL,
+		partition_key VARCHAR(255) NOT NULL,
+		processed_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+		status VARCHAR(50) NOT NULL,
+		error_message TEXT
+	);`)
 }
 
 func getTestDB(t *testing.T) *gorm.DB {
@@ -314,8 +321,8 @@ func TestPostgresMotionSpecificationRepository_Integration(t *testing.T) {
 	}
 
 	missingSpec, err := repo.FindByExerciseID(ctx, "non-existent-ex")
-	if err != nil || missingSpec != nil {
-		t.Errorf("expected nil, nil for missing MotionSpec, got %v, %v", missingSpec, err)
+	if !errors.Is(err, derror.ErrNotFound) || missingSpec != nil {
+		t.Errorf("expected derror.ErrNotFound for missing MotionSpec, got %v, %v", missingSpec, err)
 	}
 }
 
@@ -455,7 +462,7 @@ func TestPostgresRepository_CanceledContextAndLockConflict(t *testing.T) {
 		t.Error("expected error on canceled context FindByUserIDAndExerciseIDs")
 	}
 
-	motionSpec := aggregate.NewMotionSpecification("ex1", "http://onnx", "http://rules", vo.DialogueEngineConfig{}, "front")
+	motionSpec := aggregate.NewDraftMotionSpecification("ex1", "http://detector.onnx", "http://skeleton.onnx")
 	if err := motionRepo.Save(ctxCancel, motionSpec); err == nil {
 		t.Error("expected error on canceled context Save MotionSpec")
 	}

--- a/internal/workout_execution/module.go
+++ b/internal/workout_execution/module.go
@@ -45,11 +45,6 @@ func Initialize(ctx context.Context, deps ModuleDeps) (func(), error) {
 		return nil, fmt.Errorf("wrap connection pool in gorm: %w", err)
 	}
 
-	// AutoMigrate models to sync schema changes (e.g. dialogue_engine_url, outbox_log)
-	_ = gormDB.AutoMigrate(
-		&persistence.MotionSpecificationModel{},
-		&persistence.OutboxLogModel{},
-	)
 
 	// Initialize Repositories & Storage & Transaction Manager
 	txManager := persistence.NewSQLTransactionManager(gormDB)

--- a/internal/workout_execution/module.go
+++ b/internal/workout_execution/module.go
@@ -45,7 +45,6 @@ func Initialize(ctx context.Context, deps ModuleDeps) (func(), error) {
 		return nil, fmt.Errorf("wrap connection pool in gorm: %w", err)
 	}
 
-
 	// Initialize Repositories & Storage & Transaction Manager
 	txManager := persistence.NewSQLTransactionManager(gormDB)
 	sessionRepo := persistence.NewPostgresWorkoutSessionRepository(gormDB)

--- a/internal/workout_execution/tests/e2e/testutil.go
+++ b/internal/workout_execution/tests/e2e/testutil.go
@@ -96,12 +96,12 @@ func ensureTablesExist(db *gorm.DB) {
 
 	db.Exec(`CREATE TABLE IF NOT EXISTS workout_execution.motion_specifications (
 		exercise_id VARCHAR(255) PRIMARY KEY,
-		onnx_model_url VARCHAR(1024),
 		onnx_detector_url VARCHAR(1024),
 		onnx_skeleton_url VARCHAR(1024),
 		local_rules_url VARCHAR(1024),
-		dialogue_engine_json JSONB,
+		dialogue_engine_url VARCHAR(1024),
 		recommended_camera_angle VARCHAR(50),
+		is_ready BOOLEAN NOT NULL DEFAULT FALSE,
 		created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
 		updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 	);`)
@@ -118,12 +118,18 @@ func ensureTablesExist(db *gorm.DB) {
 		published_at TIMESTAMP WITH TIME ZONE,
 		created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 	);`)
-	db.Exec(`ALTER TABLE workout_execution.outbox ADD COLUMN IF NOT EXISTS event_id VARCHAR(255);`)
-	db.Exec(`ALTER TABLE workout_execution.outbox ADD COLUMN IF NOT EXISTS aggregate_type VARCHAR(255);`)
-	db.Exec(`ALTER TABLE workout_execution.outbox ADD COLUMN IF NOT EXISTS aggregate_id VARCHAR(255);`)
-	db.Exec(`ALTER TABLE workout_execution.outbox ADD COLUMN IF NOT EXISTS partition_key VARCHAR(255);`)
-	db.Exec(`ALTER TABLE workout_execution.outbox ADD COLUMN IF NOT EXISTS published_at TIMESTAMP WITH TIME ZONE;`)
 	db.Exec(`CREATE INDEX IF NOT EXISTS idx_workout_execution_outbox_pub_created ON workout_execution.outbox (published, created_at);`)
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS workout_execution.outbox_log (
+		id UUID PRIMARY KEY,
+		event_id UUID NOT NULL,
+		event_type VARCHAR(255) NOT NULL,
+		payload JSONB NOT NULL,
+		partition_key VARCHAR(255) NOT NULL,
+		processed_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+		status VARCHAR(50) NOT NULL,
+		error_message TEXT
+	);`)
 }
 
 // CleanMockData truncates all tables in workout_execution schema to clean up state.
@@ -135,6 +141,7 @@ func CleanMockData(db *gorm.DB) {
 	db.Exec("TRUNCATE TABLE workout_execution.personal_records CASCADE")
 	db.Exec("TRUNCATE TABLE workout_execution.motion_specifications CASCADE")
 	db.Exec("TRUNCATE TABLE workout_execution.outbox CASCADE")
+	db.Exec("TRUNCATE TABLE workout_execution.outbox_log CASCADE")
 }
 
 // SeedMockData seeds initial mock data into database for testing.
@@ -150,7 +157,7 @@ func SeedMockData(t *testing.T, db *gorm.DB) string {
 		OnnxDetectorURL:        "http://storage.fitai.com/models/detector.onnx",
 		OnnxSkeletonURL:        "http://storage.fitai.com/models/skeleton.onnx",
 		LocalRulesURL:          "http://storage.fitai.com/rules/bench_press.json",
-		DialogueEngineJSON:     []byte(`{"personalityId":"coach-pro"}`),
+		DialogueEngineURL:      "http://storage.fitai.com/dialogue/coach-pro.json",
 		RecommendedCameraAngle: "front",
 		CreatedAt:              now,
 		UpdatedAt:              now,

--- a/internal/workout_execution/tests/e2e/workout_execution_e2e_test.go
+++ b/internal/workout_execution/tests/e2e/workout_execution_e2e_test.go
@@ -33,7 +33,7 @@ func TestWorkoutExecution_FullLifecycle_E2E(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetMotionSpecification for seeded mock data failed: %v", err)
 	}
-	if motionResp.GetOnnxDetectorUrl() == "" || motionResp.GetDialogueEngine().GetPersonalityId() != "coach-pro" {
+	if motionResp.GetOnnxDetectorUrl() == "" || motionResp.GetDialogueEngineUrl() == "" {
 		t.Errorf("Unexpected GetMotionSpecification response: %+v", motionResp)
 	}
 


### PR DESCRIPTION
### 1. Problem to Solve
- Vi phạm quy chuẩn **AGENTS.md** ("Không AutoMigrate GORM ở production; dùng migration SQL đánh số version") do `module.go` gọi `gormDB.AutoMigrate(...)` trực tiếp khi khởi chạy ứng dụng.
- Xảy ra lỗi trùng khóa chính (Duplicate Primary Key) cho `RepLogModel` trong hàm `SessionToPersistence` khi 1 set chứa nhiều reps.

Closes #201

### 2. Proposed Solution
- Loại bỏ hoàn toàn cuộc gọi `gormDB.AutoMigrate` trong `internal/workout_execution/module.go`.
- Sửa hàm `SessionToPersistence` trong `internal/workout_execution/infrastructure/persistence/models.go` để sinh ID duy nhất cho từng RepLog bằng `fmt.Sprintf("%s-%s-%d", session.ID(), set.ID, r.RepNumber)`.
- Giữ nguyên file `Makefile` như bản gốc ban đầu của nhánh `main`.
- Chuẩn hóa DDL và cập nhật các phương thức/assertion trong test helper (`testutil.go`, `postgres_repository_test.go`, `workout_execution_e2e_test.go`).

### 3. Changes & Impact
- `[internal/workout_execution/module.go](internal/workout_execution/module.go)`: Loại bỏ `AutoMigrate` ở runtime.
- `[internal/workout_execution/infrastructure/persistence/models.go](internal/workout_execution/infrastructure/persistence/models.go)`: Sửa ID generation cho `RepLogModel`.
- `[internal/workout_execution/infrastructure/persistence/postgres_repository_test.go](internal/workout_execution/infrastructure/persistence/postgres_repository_test.go)`: Chuẩn hóa DDL và constructor `NewDraftMotionSpecification`.
- `[internal/workout_execution/tests/e2e/testutil.go](internal/workout_execution/tests/e2e/testutil.go)`: Chuẩn hóa DDL và mock seed field.
- `[internal/workout_execution/tests/e2e/workout_execution_e2e_test.go](internal/workout_execution/tests/e2e/workout_execution_e2e_test.go)`: Gọi đúng proto method `GetDialogueEngineUrl`.

### 4. Testing & Verification
- **Automated Tests**: Chạy toàn bộ test suite với đầy đủ build tags:
  ```powershell
  go test -v -tags="unit,integration,e2e" ./internal/workout_execution/...
  ```
  **Kết quả**: 100% test PASSED.
