### PR TITLE
🐛 fix(middleware): sửa lỗi rò rỉ bộ nhớ rate limit và lỗ hổng auth bypass trên public route

### DIFF
--- a/internal/shared/middleware/auth.go
+++ b/internal/shared/middleware/auth.go
@@ -289,4 +289,3 @@ func extractToken(ctx context.Context) (string, error) {
 
 	return parts[1], nil
 }
-

--- a/internal/shared/middleware/auth.go
+++ b/internal/shared/middleware/auth.go
@@ -2,9 +2,11 @@ package middleware
 
 import (
 	"context"
+	"crypto/rsa"
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
@@ -33,9 +35,58 @@ const (
 )
 
 var (
-	ErrUnauthorized = errors.New("unauthorized")
-	ErrForbidden    = errors.New("forbidden")
+	ErrUnauthorized      = errors.New("unauthorized")
+	ErrForbidden         = errors.New("forbidden")
+	errMissingMetadata   = errors.New("missing metadata")
+	errMissingAuthHeader = errors.New("missing authorization header")
+	errInvalidAuthFormat = errors.New("invalid authorization format (expected Bearer <token>)")
 )
+
+type rsaKeyCache struct {
+	mu   sync.RWMutex
+	keys map[string]*rsa.PublicKey
+	kp   KeyProvider
+}
+
+func newRSAKeyCache(kp KeyProvider) *rsaKeyCache {
+	return &rsaKeyCache{
+		keys: make(map[string]*rsa.PublicKey),
+		kp:   kp,
+	}
+}
+
+func (c *rsaKeyCache) GetPublicKey(ctx context.Context, kid string) (*rsa.PublicKey, error) {
+	if c.kp == nil {
+		return nil, errors.New("key provider not initialized")
+	}
+
+	c.mu.RLock()
+	pubKey, exists := c.keys[kid]
+	c.mu.RUnlock()
+	if exists {
+		return pubKey, nil
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if pubKey, exists = c.keys[kid]; exists {
+		return pubKey, nil
+	}
+
+	pubKeyPEM, err := c.kp.GetPublicKeyPEM(ctx, kid)
+	if err != nil {
+		return nil, fmt.Errorf("get public key: %w", err)
+	}
+
+	pubKey, err = jwt.ParseRSAPublicKeyFromPEM([]byte(pubKeyPEM))
+	if err != nil {
+		return nil, fmt.Errorf("parse rsa public key: %w", err)
+	}
+
+	c.keys[kid] = pubKey
+	return pubKey, nil
+}
 
 type Actor struct {
 	UserID string
@@ -71,6 +122,8 @@ func RequireAdmin(ctx context.Context) (Actor, error) {
 
 // UnaryAuthInterceptor intercepts unary gRPC requests to validate JWT tokens.
 func UnaryAuthInterceptor(kp KeyProvider) grpc.UnaryServerInterceptor {
+	keyCache := newRSAKeyCache(kp)
+
 	return func(
 		ctx context.Context,
 		req any,
@@ -83,21 +136,21 @@ func UnaryAuthInterceptor(kp KeyProvider) grpc.UnaryServerInterceptor {
 		// 2. Extract token from metadata
 		tokenStr, err := extractToken(ctx)
 		if err != nil {
-			if required {
-				return nil, status.Errorf(codes.Unauthenticated, "authentication required: %v", err)
+			// If auth header is completely missing on a public/optional route, proceed as anonymous
+			if errors.Is(err, errMissingMetadata) || errors.Is(err, errMissingAuthHeader) {
+				if required {
+					return nil, status.Errorf(codes.Unauthenticated, "authentication required: %v", err)
+				}
+				return handler(ctx, req)
 			}
-			// Bypass if not required
-			return handler(ctx, req)
+			// Malformed authorization header (e.g. invalid format) -> always reject
+			return nil, status.Errorf(codes.Unauthenticated, "invalid authorization header format: %v", err)
 		}
 
-		// 3. Validate token
-		userID, role, err := parseAndValidateToken(ctx, tokenStr, kp)
+		// 3. Validate token: If token was provided, it MUST be valid regardless of route auth requirement
+		userID, role, err := parseAndValidateToken(ctx, tokenStr, keyCache)
 		if err != nil {
-			if required {
-				return nil, status.Errorf(codes.Unauthenticated, "invalid token: %v", err)
-			}
-			// Bypass if not required
-			return handler(ctx, req)
+			return nil, status.Errorf(codes.Unauthenticated, "invalid token: %v", err)
 		}
 
 		// 4. Inject identity into context
@@ -111,35 +164,23 @@ func UnaryAuthInterceptor(kp KeyProvider) grpc.UnaryServerInterceptor {
 func parseAndValidateToken(
 	ctx context.Context,
 	tokenStr string,
-	kp KeyProvider,
+	cache *rsaKeyCache,
 ) (userID, role string, err error) {
-	if kp == nil {
-		return "", "", errors.New("key provider not initialized")
+	if cache == nil {
+		return "", "", errors.New("key cache not initialized")
 	}
 
-	var kid string
 	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 
-		var ok bool
-		kid, ok = token.Header["kid"].(string)
+		kid, ok := token.Header["kid"].(string)
 		if !ok || kid == "" {
 			return nil, errors.New("missing kid in token header")
 		}
 
-		pubKeyPEM, getErr := kp.GetPublicKeyPEM(ctx, kid)
-		if getErr != nil {
-			return nil, fmt.Errorf("get public key: %w", getErr)
-		}
-
-		pubKey, parseErr := jwt.ParseRSAPublicKeyFromPEM([]byte(pubKeyPEM))
-		if parseErr != nil {
-			return nil, fmt.Errorf("parse rsa public key: %w", parseErr)
-		}
-
-		return pubKey, nil
+		return cache.GetPublicKey(ctx, kid)
 	})
 
 	if err != nil {
@@ -233,18 +274,19 @@ func isAuthRequired(fullMethod string) bool {
 func extractToken(ctx context.Context) (string, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return "", errors.New("missing metadata")
+		return "", errMissingMetadata
 	}
 
 	authHeaders := md.Get("authorization")
 	if len(authHeaders) == 0 || authHeaders[0] == "" {
-		return "", errors.New("missing authorization header")
+		return "", errMissingAuthHeader
 	}
 
 	parts := strings.SplitN(authHeaders[0], " ", 2)
 	if len(parts) != 2 || !strings.EqualFold(parts[0], "bearer") {
-		return "", errors.New("invalid authorization format (expected Bearer <token>)")
+		return "", errInvalidAuthFormat
 	}
 
 	return parts[1], nil
 }
+

--- a/internal/shared/middleware/middleware_test.go
+++ b/internal/shared/middleware/middleware_test.go
@@ -13,13 +13,12 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	_ "github.com/viethung213/gym-companion/internal/gen/go/contracts/generic/auth/v1/service"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
-
-	_ "github.com/viethung213/gym-companion/internal/gen/go/contracts/generic/auth/v1/service"
 )
 
 var (

--- a/internal/shared/middleware/middleware_test.go
+++ b/internal/shared/middleware/middleware_test.go
@@ -13,12 +13,13 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	_ "github.com/viethung213/gym-companion/internal/gen/go/contracts/generic/auth/v1/service"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
+
+	_ "github.com/viethung213/gym-companion/internal/gen/go/contracts/generic/auth/v1/service"
 )
 
 var (
@@ -426,4 +427,3 @@ func TestRateLimiterRegistry_SweepCleanup(t *testing.T) {
 		t.Errorf("expected new-key to exist in registry")
 	}
 }
-

--- a/internal/shared/middleware/middleware_test.go
+++ b/internal/shared/middleware/middleware_test.go
@@ -53,11 +53,16 @@ func getTestKeys(t *testing.T) (privKey *rsa.PrivateKey, pubKeyPEM string) {
 }
 
 type mockKeyProvider struct {
+	mu     sync.Mutex
+	calls  int
 	keyPEM string
 	err    error
 }
 
 func (m *mockKeyProvider) GetPublicKeyPEM(_ context.Context, kid string) (string, error) {
+	m.mu.Lock()
+	m.calls++
+	m.mu.Unlock()
 	if m.err != nil {
 		return "", m.err
 	}
@@ -65,6 +70,12 @@ func (m *mockKeyProvider) GetPublicKeyPEM(_ context.Context, kid string) (string
 		return m.keyPEM, nil
 	}
 	return "", errors.New("key not found")
+}
+
+func (m *mockKeyProvider) GetCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
 }
 
 func generateTestToken(t *testing.T, userID, role, kid string) string {
@@ -224,6 +235,76 @@ func TestUnaryAuthInterceptor(t *testing.T) {
 	}
 }
 
+func TestUnaryAuthInterceptor_PublicRoute_InvalidToken_Fails(t *testing.T) {
+	t.Parallel()
+	_, pubKeyPEM := getTestKeys(t)
+	mockKP := &mockKeyProvider{
+		keyPEM: pubKeyPEM,
+	}
+	interceptor := UnaryAuthInterceptor(mockKP)
+	infoPublic := &grpc.UnaryServerInfo{
+		FullMethod: "/contracts.generic.auth.v1.service.AuthService/GetOAuthLoginURL",
+	}
+	dummyHandler := func(_ context.Context, _ any) (any, error) {
+		return "public-ok", nil
+	}
+
+	// Invalid token on public route MUST be rejected with Unauthenticated
+	ctxWithBadToken := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("authorization", "Bearer invalid-token-string"),
+	)
+	_, err := interceptor(ctxWithBadToken, nil, infoPublic, dummyHandler)
+	if err == nil || status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("expected Unauthenticated error when invalid token is sent to public route, got %v", err)
+	}
+
+	// Malformed auth header (e.g. Basic auth) on public route MUST be rejected
+	ctxWithMalformedHeader := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("authorization", "Basic dXNlcjpwYXNz"),
+	)
+	_, err = interceptor(ctxWithMalformedHeader, nil, infoPublic, dummyHandler)
+	if err == nil || status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("expected Unauthenticated error when malformed header is sent to public route, got %v", err)
+	}
+}
+
+func TestRSAPublicKeyCache(t *testing.T) {
+	t.Parallel()
+	_, pubKeyPEM := getTestKeys(t)
+	mockKP := &mockKeyProvider{
+		keyPEM: pubKeyPEM,
+	}
+	interceptor := UnaryAuthInterceptor(mockKP)
+
+	infoSecured := &grpc.UnaryServerInfo{
+		FullMethod: "/contracts.generic.auth.v1.service.AuthService/Logout",
+	}
+	goodToken := generateTestToken(t, "user-456", "user", "test-kid")
+	ctxWithGoodToken := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("authorization", "Bearer "+goodToken),
+	)
+
+	dummyHandler := func(_ context.Context, _ any) (any, error) {
+		return "ok", nil
+	}
+
+	// Make 10 requests with the same token/kid
+	for i := 0; i < 10; i++ {
+		resp, err := interceptor(ctxWithGoodToken, nil, infoSecured, dummyHandler)
+		if err != nil || resp != "ok" {
+			t.Fatalf("expected request %d to succeed, got err=%v", i, err)
+		}
+	}
+
+	// Public key provider should only have been called ONCE due to caching
+	if calls := mockKP.GetCalls(); calls != 1 {
+		t.Errorf("expected KeyProvider to be called exactly 1 time, got %d calls", calls)
+	}
+}
+
 func TestUnaryRateLimitInterceptor(t *testing.T) {
 	t.Parallel()
 	interceptor := UnaryRateLimitInterceptor()
@@ -284,3 +365,65 @@ func TestUnaryRateLimitInterceptor_CompleteWorkoutSession(t *testing.T) {
 		t.Fatalf("expected ResourceExhausted, got %v", err2)
 	}
 }
+
+func TestExtractClientIP(t *testing.T) {
+	t.Parallel()
+	// Test A: Strip port from peer address
+	addr, _ := net.ResolveTCPAddr("tcp", "192.168.1.100:54321")
+	ctxPeer := peer.NewContext(context.Background(), &peer.Peer{Addr: addr})
+	ip := extractClientIP(ctxPeer)
+	if ip != "192.168.1.100" {
+		t.Errorf("expected IP 192.168.1.100 without port, got %s", ip)
+	}
+
+	// Test B: X-Forwarded-For header priority
+	ctxXFF := metadata.NewIncomingContext(
+		ctxPeer,
+		metadata.Pairs("x-forwarded-for", "203.0.113.195, 70.41.3.18, 150.172.238.178"),
+	)
+	ipXFF := extractClientIP(ctxXFF)
+	if ipXFF != "203.0.113.195" {
+		t.Errorf("expected client IP from X-Forwarded-For 203.0.113.195, got %s", ipXFF)
+	}
+
+	// Test C: X-Real-IP header priority
+	ctxXRI := metadata.NewIncomingContext(
+		ctxPeer,
+		metadata.Pairs("x-real-ip", "198.51.100.1"),
+	)
+	ipXRI := extractClientIP(ctxXRI)
+	if ipXRI != "198.51.100.1" {
+		t.Errorf("expected client IP from X-Real-IP 198.51.100.1, got %s", ipXRI)
+	}
+}
+
+func TestRateLimiterRegistry_SweepCleanup(t *testing.T) {
+	t.Parallel()
+	reg := &rateLimiterRegistry{
+		limiters:  make(map[string]*limiterEntry),
+		ttl:       50 * time.Millisecond,
+		lastSweep: time.Now().Add(-2 * time.Minute), // Force sweep trigger on next GetLimiter call
+	}
+
+	// Insert an old entry
+	reg.limiters["old-key"] = &limiterEntry{
+		limiter:  nil,
+		lastSeen: time.Now().Add(-100 * time.Millisecond),
+	}
+
+	// Call GetLimiter for a new key, triggering sweep
+	_ = reg.GetLimiter("new-key", 100)
+
+	reg.mu.Lock()
+	_, oldExists := reg.limiters["old-key"]
+	_, newExists := reg.limiters["new-key"]
+	reg.mu.Unlock()
+
+	if oldExists {
+		t.Errorf("expected old-key to be evicted during sweep, but it still exists")
+	}
+	if !newExists {
+		t.Errorf("expected new-key to exist in registry")
+	}
+}
+

--- a/internal/shared/middleware/rate_limit.go
+++ b/internal/shared/middleware/rate_limit.go
@@ -160,4 +160,3 @@ func extractClientIP(ctx context.Context) string {
 
 	return "unknown"
 }
-

--- a/internal/shared/middleware/rate_limit.go
+++ b/internal/shared/middleware/rate_limit.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"net"
 	"strings"
 	"sync"
 	"time"
@@ -9,13 +10,34 @@ import (
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 )
 
+const (
+	defaultLimiterTTL    = 3 * time.Minute
+	defaultSweepInterval = 1 * time.Minute
+)
+
+type limiterEntry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
 type rateLimiterRegistry struct {
-	mu       sync.Mutex
-	limiters map[string]*rate.Limiter
+	mu        sync.Mutex
+	limiters  map[string]*limiterEntry
+	ttl       time.Duration
+	lastSweep time.Time
+}
+
+func newRateLimiterRegistry() *rateLimiterRegistry {
+	return &rateLimiterRegistry{
+		limiters:  make(map[string]*limiterEntry),
+		ttl:       defaultLimiterTTL,
+		lastSweep: time.Now(),
+	}
 }
 
 // GetLimiter returns or creates a rate.Limiter for a given key,
@@ -24,7 +46,15 @@ func (r *rateLimiterRegistry) GetLimiter(key string, reqPerMin int) *rate.Limite
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	limiter, exists := r.limiters[key]
+	now := time.Now()
+
+	// Lazy cleanup sweep to prevent memory leak without unmanaged background goroutines
+	if now.Sub(r.lastSweep) > defaultSweepInterval {
+		r.sweep(now)
+		r.lastSweep = now
+	}
+
+	entry, exists := r.limiters[key]
 	if !exists {
 		limit := rate.Every(time.Minute / time.Duration(reqPerMin))
 		// We allow a burst of 10% of the limit or at least 1
@@ -32,17 +62,28 @@ func (r *rateLimiterRegistry) GetLimiter(key string, reqPerMin int) *rate.Limite
 		if burst < 1 {
 			burst = 1
 		}
-		limiter = rate.NewLimiter(limit, burst)
-		r.limiters[key] = limiter
+		entry = &limiterEntry{
+			limiter:  rate.NewLimiter(limit, burst),
+			lastSeen: now,
+		}
+		r.limiters[key] = entry
+	} else {
+		entry.lastSeen = now
 	}
-	return limiter
+	return entry.limiter
+}
+
+func (r *rateLimiterRegistry) sweep(now time.Time) {
+	for key, entry := range r.limiters {
+		if now.Sub(entry.lastSeen) > r.ttl {
+			delete(r.limiters, key)
+		}
+	}
 }
 
 // UnaryRateLimitInterceptor limits gRPC unary requests based on method rules.
 func UnaryRateLimitInterceptor() grpc.UnaryServerInterceptor {
-	registry := &rateLimiterRegistry{
-		limiters: make(map[string]*rate.Limiter),
-	}
+	registry := newRateLimiterRegistry()
 	return func(
 		ctx context.Context,
 		req any,
@@ -85,9 +126,38 @@ func getClientKey(ctx context.Context, method string) string {
 	}
 
 	// 2. Fallback to Client IP
-	ip := "unknown"
-	if p, ok := peer.FromContext(ctx); ok {
-		ip = p.Addr.String()
-	}
+	ip := extractClientIP(ctx)
 	return ip + ":" + method
 }
+
+func extractClientIP(ctx context.Context) string {
+	// A. Check gRPC metadata for proxy HTTP headers (X-Forwarded-For, X-Real-IP)
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if xff := md.Get("x-forwarded-for"); len(xff) > 0 && xff[0] != "" {
+			ips := strings.Split(xff[0], ",")
+			clientIP := strings.TrimSpace(ips[0])
+			if clientIP != "" {
+				return clientIP
+			}
+		}
+		if xri := md.Get("x-real-ip"); len(xri) > 0 && xri[0] != "" {
+			clientIP := strings.TrimSpace(xri[0])
+			if clientIP != "" {
+				return clientIP
+			}
+		}
+	}
+
+	// B. Peer address from gRPC context (stripped of dynamic client port)
+	if p, ok := peer.FromContext(ctx); ok && p.Addr != nil {
+		addrStr := p.Addr.String()
+		host, _, err := net.SplitHostPort(addrStr)
+		if err == nil && host != "" {
+			return host
+		}
+		return addrStr
+	}
+
+	return "unknown"
+}
+


### PR DESCRIPTION
### 1. Vấn đề cần giải quyết (Problem to Solve)
- **Rò rỉ bộ nhớ & Thất bại Rate Limit theo IP**: `shared/middleware/rate_limit.go` lưu trữ `*rate.Limiter` vô hạn mà không dọn dẹp (no TTL eviction). Ngoài ra, `peer.FromContext(ctx)` lưu cả cặp `IP:Port` (port động client), khiến mỗi kết nối TCP tạo 1 key mới, làm vô hiệu hóa rate limit và tràn RAM.
- **Lỗ hổng Auth Bypass & CPU Bottleneck giải mã RSA**: `shared/middleware/auth.go` cho phép request truyền token bị hỏng/hết hạn đi tiếp dưới dạng anonymous nếu route đó là public/tùy chọn. Đồng thời, việc parse chuỗi PEM RSA Public Key trên mọi gRPC request gây nghẽn CPU và tăng latency nghiêm trọng.

### 2. Giải pháp đề xuất (Proposed Solution)
- **Lazy TTL Eviction Sweep & Bóc tách IP**: Xây dựng `limiterEntry` lưu timestamp với cơ chế quét định kỳ (TTL = 3 phút, lazy sweep 1 phút/lần). Cập nhật logic bóc tách IP tách bỏ port động (`net.SplitHostPort`) và ưu tiên đọc gRPC proxy headers (`x-forwarded-for`, `x-real-ip`).
- **Xác thực Token nghiêm ngặt & Caching RSA Key**: Cập nhật `UnaryAuthInterceptor` để **bắt buộc từ chối tất cả token không hợp lệ với gRPC status `Unauthenticated` (401)** trên mọi route. Triển khai `rsaKeyCache` thread-safe lưu trữ `*rsa.PublicKey` đã parse theo `kid`.

### 3. Thay đổi & Ảnh hưởng (Changes & Impact)
- `[internal/shared/middleware/rate_limit.go](internal/shared/middleware/rate_limit.go)`: Thêm `limiterEntry`, cơ chế dọn dẹp TTL, bóc tách IP loại bỏ port và hỗ trợ metadata proxy header.
- `[internal/shared/middleware/auth.go](internal/shared/middleware/auth.go)`: Bắt lỗi token sai trên public route và bổ sung `rsaKeyCache` cho RSA public key.
- `[internal/shared/middleware/middleware_test.go](internal/shared/middleware/middleware_test.go)`: Thêm 4 bộ unit test mới kiểm tra việc từ chối token sai trên public route, caching key RSA, bóc tách IP và dọn dẹp TTL rate limit.

### 4. Kiểm thử & Phê duyệt (Testing & Verification)
- **Automated Tests**:
  - `go test -v ./internal/shared/middleware/...` -> **PASS (10/10 test cases passed)**
  - `go test ./...` -> **PASS (Toàn bộ repository test suite vượt qua thành công)**
- **Manual Verification**: Kiểm tra cơ chế dọn dẹp TTL và số lần gọi key provider khi có cache.
