### PR TITLE
🐛 fix(profile): loại bỏ filter is_recovered = false khi tái tạo UserProfile aggregate

### DIFF
--- a/internal/profile/infrastructure/persistence/postgres_repository.go
+++ b/internal/profile/infrastructure/persistence/postgres_repository.go
@@ -73,10 +73,9 @@ func (r *PostgresUserProfileRepository) FindByUserID(ctx context.Context, userID
 		return nil, fmt.Errorf("query body metrics: %w", err)
 	}
 
-	// Only query active injuries (is_recovered = false) for active profile state
 	var injuryModels []*InjuryModel
-	if err := db.Find(&injuryModels, "user_id = ? AND is_recovered = ?", userID, false).Error; err != nil {
-		return nil, fmt.Errorf("query active injuries: %w", err)
+	if err := db.Find(&injuryModels, "user_id = ?", userID).Error; err != nil {
+		return nil, fmt.Errorf("query injuries: %w", err)
 	}
 
 	domain, err := ToDomainAggregate(&userModel, metricModels, injuryModels)

--- a/internal/profile/infrastructure/persistence/postgres_repository_test.go
+++ b/internal/profile/infrastructure/persistence/postgres_repository_test.go
@@ -133,6 +133,19 @@ func TestPostgresUserProfileRepository(t *testing.T) {
 	assert.Equal(t, 175.0, fetched.BiologicalMetrics().HeightCm())
 	assert.Len(t, fetched.Injuries(), 1)
 	assert.Equal(t, "Shoulder", fetched.Injuries()[0].MuscleGroup())
+	assert.False(t, fetched.Injuries()[0].IsRecovered())
+
+	// Recover injury and update profile
+	err = fetched.RecoverInjury("inj-101", time.Now())
+	require.NoError(t, err)
+	err = repo.Update(ctx, fetched)
+	require.NoError(t, err)
+
+	// FindByUserID must still reconstitute recovered injury
+	fetchedAfterRecover, err := repo.FindByUserID(ctx, "user-infra-1")
+	require.NoError(t, err)
+	assert.Len(t, fetchedAfterRecover.Injuries(), 1)
+	assert.True(t, fetchedAfterRecover.Injuries()[0].IsRecovered())
 
 	// FindBodyMetricsHistory
 	metricsHist, err := repo.FindBodyMetricsHistory(ctx, "user-infra-1")


### PR DESCRIPTION
## Summary of Changes
- **Fixed Aggregate Reconstitution Bug**: Removed \AND is_recovered = false\ SQL condition in \FindByUserID\ so that \UserProfile\ aggregate root reconstitutes all injuries (both active and recovered).
- **Added Integration Tests**: Added assertions in \TestPostgresUserProfileRepository\ to verify that recovering an injury and re-fetching the aggregate properly retains the recovered injury in the in-memory aggregate.

## Verification
- Executed full test suite: \go test -v ./internal/profile/...\ — 100% PASS.