### PR TITLE
🐛 fix(auth): validate null module deps and handle db errors in oauth login

### DIFF
--- a/internal/auth/application/command/mocks_test.go
+++ b/internal/auth/application/command/mocks_test.go
@@ -19,7 +19,9 @@ import (
 // ---------------------------------------------------------------------------
 
 type mockUserRepo struct {
-	users map[string]*aggregate.User
+	users             map[string]*aggregate.User
+	findByEmailErr    error
+	findByGoogleIDErr error
 }
 
 func (m *mockUserRepo) Create(ctx context.Context, u *aggregate.User) error {
@@ -44,6 +46,9 @@ func (m *mockUserRepo) FindByID(ctx context.Context, id string) (*aggregate.User
 }
 
 func (m *mockUserRepo) FindByEmail(ctx context.Context, email string) (*aggregate.User, error) {
+	if m.findByEmailErr != nil {
+		return nil, m.findByEmailErr
+	}
 	for _, u := range m.users {
 		if u.Email() == email {
 			return u, nil
@@ -53,6 +58,9 @@ func (m *mockUserRepo) FindByEmail(ctx context.Context, email string) (*aggregat
 }
 
 func (m *mockUserRepo) FindByGoogleID(ctx context.Context, googleID string) (*aggregate.User, error) {
+	if m.findByGoogleIDErr != nil {
+		return nil, m.findByGoogleIDErr
+	}
 	for _, u := range m.users {
 		if u.GoogleID() == googleID {
 			return u, nil

--- a/internal/auth/application/command/oauth_login.go
+++ b/internal/auth/application/command/oauth_login.go
@@ -2,12 +2,14 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/viethung213/gym-companion/internal/auth/application/port"
 	"github.com/viethung213/gym-companion/internal/auth/domain/aggregate"
+	"github.com/viethung213/gym-companion/internal/auth/domain/derror"
 	"github.com/viethung213/gym-companion/internal/auth/domain/repository"
 )
 
@@ -82,15 +84,21 @@ func (h *OAuthLoginHandler) Handle(ctx context.Context, cmd OAuthLoginCommand) (
 	} else if cmd.Provider == "facebook" {
 		user, err = h.userRepo.FindByFacebookID(ctx, profile.ID)
 	}
+	if err != nil && !errors.Is(err, derror.ErrUserNotFound) {
+		return "", "", "", fmt.Errorf("find user by social id: %w", err)
+	}
 
 	var accessToken, refreshTokenStr string
 	var expiresAt time.Time
 
 	// 5. Execute User registration/linking, Token generation, and Session saving in a SINGLE Atomic Transaction
 	err = h.txManager.WithTransaction(ctx, func(txCtx context.Context) error {
-		if err != nil || user == nil {
+		if user == nil {
 			// Try to find user by email to link social provider
 			existingUser, findErr := h.userRepo.FindByEmail(txCtx, profile.Email)
+			if findErr != nil && !errors.Is(findErr, derror.ErrUserNotFound) {
+				return fmt.Errorf("find user by email: %w", findErr)
+			}
 			if findErr == nil && existingUser != nil {
 				user = existingUser
 				if cmd.Provider == "google" {

--- a/internal/auth/application/command/oauth_login_test.go
+++ b/internal/auth/application/command/oauth_login_test.go
@@ -183,3 +183,87 @@ func TestOAuthLoginHandler_StateValidationFailure(t *testing.T) {
 		t.Errorf("got error %v, expected it to contain 'oauth state validation failed'", err)
 	}
 }
+
+func TestOAuthLoginHandler_FindByEmail_DBError(t *testing.T) {
+	ctx := context.Background()
+	dbErr := errors.New("connection timeout")
+
+	userRepo := &mockUserRepo{
+		users:          make(map[string]*aggregate.User),
+		findByEmailErr: dbErr,
+	}
+	key := &port.JWKRecord{
+		ID:        "active-kid",
+		Status:    port.KeyStatusActive,
+		CreatedAt: time.Now(),
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	keyRepo := &mockKeyRepo{keys: []*port.JWKRecord{key}}
+	sessRepo := &mockSessionRepo{sessions: make(map[string]*port.SessionRecord)}
+	publisher := &mockEventPublisher{}
+
+	handler := NewOAuthLoginHandler(
+		userRepo,
+		keyRepo,
+		sessRepo,
+		mockTokenService{},
+		mockOAuthService{},
+		publisher,
+		&mockTxManager{},
+	)
+
+	_, _, _, err := handler.Handle(ctx, OAuthLoginCommand{
+		Provider: "google",
+		Code:     "valid_code",
+	})
+	if err == nil {
+		t.Fatal("expected error when FindByEmail returns DB error, got nil")
+	}
+	if !strings.Contains(err.Error(), "find user by email") {
+		t.Errorf("got error %v, want error containing 'find user by email'", err)
+	}
+	if len(userRepo.users) != 0 {
+		t.Errorf("expected 0 users created when FindByEmail fails with DB error, got %d", len(userRepo.users))
+	}
+}
+
+func TestOAuthLoginHandler_FindBySocialID_DBError(t *testing.T) {
+	ctx := context.Background()
+	dbErr := errors.New("database locked")
+
+	userRepo := &mockUserRepo{
+		users:             make(map[string]*aggregate.User),
+		findByGoogleIDErr: dbErr,
+	}
+	key := &port.JWKRecord{
+		ID:        "active-kid",
+		Status:    port.KeyStatusActive,
+		CreatedAt: time.Now(),
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	keyRepo := &mockKeyRepo{keys: []*port.JWKRecord{key}}
+	sessRepo := &mockSessionRepo{sessions: make(map[string]*port.SessionRecord)}
+	publisher := &mockEventPublisher{}
+
+	handler := NewOAuthLoginHandler(
+		userRepo,
+		keyRepo,
+		sessRepo,
+		mockTokenService{},
+		mockOAuthService{},
+		publisher,
+		&mockTxManager{},
+	)
+
+	_, _, _, err := handler.Handle(ctx, OAuthLoginCommand{
+		Provider: "google",
+		Code:     "valid_code",
+	})
+	if err == nil {
+		t.Fatal("expected error when FindByGoogleID returns DB error, got nil")
+	}
+	if !strings.Contains(err.Error(), "find user by social id") {
+		t.Errorf("got error %v, want error containing 'find user by social id'", err)
+	}
+}
+

--- a/internal/auth/module.go
+++ b/internal/auth/module.go
@@ -42,6 +42,16 @@ type ModuleDeps struct {
 
 // Initialize bootstraps all layers of the Auth Bounded Context.
 func Initialize(ctx context.Context, deps ModuleDeps) (func(), error) {
+	if deps.DB == nil {
+		return nil, errors.New("deps.DB is required")
+	}
+	if deps.GRPCServer == nil {
+		return nil, errors.New("deps.GRPCServer is required")
+	}
+	if deps.KafkaRegistry == nil {
+		return nil, errors.New("deps.KafkaRegistry is required")
+	}
+
 	cfg, err := config.Load()
 	if err != nil {
 		return nil, fmt.Errorf("load config: %w", err)

--- a/internal/auth/module_test.go
+++ b/internal/auth/module_test.go
@@ -1,0 +1,69 @@
+//go:build unit
+
+package auth
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	sharedKafka "github.com/viethung213/gym-companion/internal/shared/kafka"
+	"google.golang.org/grpc"
+)
+
+func TestInitialize_NilDependencies(t *testing.T) {
+	ctx := context.Background()
+	dummyDB := &sql.DB{}
+	dummyGRPC := grpc.NewServer()
+	dummyKafka := &sharedKafka.Registry{}
+
+	tests := []struct {
+		name    string
+		deps    ModuleDeps
+		wantErr string
+	}{
+		{
+			name: "nil DB",
+			deps: ModuleDeps{
+				DB:            nil,
+				GRPCServer:    dummyGRPC,
+				KafkaRegistry: dummyKafka,
+			},
+			wantErr: "deps.DB is required",
+		},
+		{
+			name: "nil GRPCServer",
+			deps: ModuleDeps{
+				DB:            dummyDB,
+				GRPCServer:    nil,
+				KafkaRegistry: dummyKafka,
+			},
+			wantErr: "deps.GRPCServer is required",
+		},
+		{
+			name: "nil KafkaRegistry",
+			deps: ModuleDeps{
+				DB:            dummyDB,
+				GRPCServer:    dummyGRPC,
+				KafkaRegistry: nil,
+			},
+			wantErr: "deps.KafkaRegistry is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shutdown, err := Initialize(ctx, tt.deps)
+			if err == nil {
+				if shutdown != nil {
+					shutdown()
+				}
+				t.Fatalf("Initialize() got nil error, want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("Initialize() error = %v, want error containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 📝 Mô tả Pull Request

### 1. Vấn đề cần giải quyết
- **[CRITICAL] `auth/module.go`**: Thiếu kiểm tra connection `nil` (`deps.DB`, `deps.GRPCServer`, `deps.KafkaRegistry`) khi khởi tạo module, gây nguy cơ Runtime Panic.
- **[HIGH] `oauth_login.go`**: Bỏ qua lỗi DB trong `FindByEmail` và `FindByGoogleID`/`FindByFacebookID`. Khi `FindByEmail` bị lỗi DB (kết nối/timeout), logic nhảy xuống block `else` cố gắng tạo mới user gây vi phạm Unique Constraint DB.

### 2. Giải pháp kỹ thuật
- **Kiểm tra Null Connection**: Thêm các Guard Clause kiểm tra `deps.DB`, `deps.GRPCServer`, `deps.KafkaRegistry` trong hàm `Initialize` ở [auth/module.go](internal/auth/module.go).
- **Xử lý chính xác lỗi DB trong OAuth Login**: Sử dụng `errors.Is(err, derror.ErrUserNotFound)` để phân biệt giữa trường hợp *"Không tìm thấy User"* và *"Lỗi hệ thống/Cơ sở dữ liệu"*. Khi gặp lỗi DB, lập tức dừng và trả về lỗi để hủy Transaction.

### 3. Chi tiết các thay đổi
- **`[MODIFY]` [internal/auth/module.go](internal/auth/module.go)**: Thêm Guard Clauses kiểm tra `nil` cho `deps.DB`, `deps.GRPCServer`, `deps.KafkaRegistry`.
- **`[NEW]` [internal/auth/module_test.go](internal/auth/module_test.go)**: Bổ sung 3 test cases kiểm tra hành vi trả về lỗi khi truyền dependency `nil`.
- **`[MODIFY]` [internal/auth/application/command/oauth_login.go](internal/auth/application/command/oauth_login.go)**: Xử lý lỗi DB chuẩn xác cho `FindBySocialID` và `FindByEmail`.
- **`[MODIFY]` [internal/auth/application/command/oauth_login_test.go](internal/auth/application/command/oauth_login_test.go)**: Bổ sung unit tests cho trường hợp `FindByEmail` và `FindBySocialID` gặp lỗi DB.
- **`[MODIFY]` [internal/auth/application/command/mocks_test.go](internal/auth/application/command/mocks_test.go)**: Thêm các trường giả lập lỗi DB trong `mockUserRepo`.

### 4. Kết quả kiểm thử
- **Automated Tests**: Đã chạy `go test -v -tags=unit ./internal/auth/...` (**KẾT QUẢ: PASS 100%**).
- **Linter & Code Quality**: Đã kiểm tra qua `go vet ./internal/auth/...` (**KẾT QUẢ: 0 lỗi**).
