### PR TITLE
🐛 fix(workout_execution): khắc phục mất domain event, thiếu Kafka PR consumer và tối ưu S3 connection pool

### DIFF
--- a/internal/workout_execution/application/command/mocks_test.go
+++ b/internal/workout_execution/application/command/mocks_test.go
@@ -162,9 +162,14 @@ func (m *mockTxManager) WithTransaction(ctx context.Context, fn func(ctx context
 }
 
 type mockOutboxWriter struct {
-	err error
+	err          error
+	writtenCount int
 }
 
 func (m *mockOutboxWriter) WriteEvents(ctx context.Context, aggregateType, aggregateID string, events []interface{}) error {
-	return m.err
+	if m.err != nil {
+		return m.err
+	}
+	m.writtenCount += len(events)
+	return nil
 }

--- a/internal/workout_execution/application/command/motion_spec_commands_test.go
+++ b/internal/workout_execution/application/command/motion_spec_commands_test.go
@@ -122,6 +122,32 @@ func TestUpdateMotionSpecificationHandler(t *testing.T) {
 			t.Error("want spec.IsReady = true after update with all URLs")
 		}
 	})
+
+	t.Run("Update existing spec publishes outbox event when txManager is nil", func(t *testing.T) {
+		repo := newMockMotionSpecRepo()
+		outbox := &mockOutboxWriter{}
+		handlerWithOutbox := command.NewUpdateMotionSpecificationHandler(repo, outbox, nil)
+
+		draft := aggregate.NewDraftMotionSpecification("ex-deadlift", "", "")
+		_ = repo.Save(context.Background(), draft)
+
+		cmd := command.UpdateMotionSpecificationCommand{
+			ExerciseID:             "ex-deadlift",
+			OnnxDetectorURL:        "http://cdn/detector.onnx",
+			OnnxSkeletonURL:        "http://cdn/skeleton.onnx",
+			LocalRulesURL:          "http://cdn/deadlift.json",
+			DialogueEngineURL:      "http://cdn/deadlift_dialogue.json",
+			RecommendedCameraAngle: "side",
+		}
+
+		_, err := handlerWithOutbox.Handle(context.Background(), cmd)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if outbox.writtenCount == 0 {
+			t.Error("want outbox events written when txManager is nil, got 0")
+		}
+	})
 }
 
 func TestDeleteMotionSpecificationHandler(t *testing.T) {

--- a/internal/workout_execution/application/command/update_motion_spec.go
+++ b/internal/workout_execution/application/command/update_motion_spec.go
@@ -67,22 +67,24 @@ func (h *UpdateMotionSpecificationHandler) Handle(
 		cmd.RecommendedCameraAngle,
 	)
 
-	var saveErr error
-	if h.txManager != nil {
-		saveErr = h.txManager.WithTransaction(ctx, func(txCtx context.Context) error {
-			if err := h.motionRepo.Save(txCtx, spec); err != nil {
+	saveAndPublish := func(execCtx context.Context) error {
+		if err := h.motionRepo.Save(execCtx, spec); err != nil {
+			return err
+		}
+		events := spec.PopEvents()
+		if len(events) > 0 && h.outbox != nil {
+			if err := h.outbox.WriteEvents(execCtx, "MotionSpecification", spec.ExerciseID(), events); err != nil {
 				return err
 			}
-			events := spec.PopEvents()
-			if len(events) > 0 && h.outbox != nil {
-				if err := h.outbox.WriteEvents(txCtx, "MotionSpecification", spec.ExerciseID(), events); err != nil {
-					return err
-				}
-			}
-			return nil
-		})
+		}
+		return nil
+	}
+
+	var saveErr error
+	if h.txManager != nil {
+		saveErr = h.txManager.WithTransaction(ctx, saveAndPublish)
 	} else {
-		saveErr = h.motionRepo.Save(ctx, spec)
+		saveErr = saveAndPublish(ctx)
 	}
 
 	if saveErr != nil {

--- a/internal/workout_execution/infrastructure/storage/s3_storage_provider.go
+++ b/internal/workout_execution/infrastructure/storage/s3_storage_provider.go
@@ -37,6 +37,8 @@ type S3StorageConfig struct {
 type S3StorageProvider struct {
 	config S3StorageConfig
 
+	client *s3.Client
+
 	presignClient *s3.PresignClient
 }
 
@@ -118,6 +120,8 @@ func NewS3StorageProvider(cfg S3StorageConfig) *S3StorageProvider {
 
 		config: cfg,
 
+		client: client,
+
 		presignClient: presignClient,
 	}
 
@@ -190,24 +194,7 @@ func (p *S3StorageProvider) GetObject(ctx context.Context, objectKey string) ([]
 
 	}
 
-	opts := s3.Options{
-
-		Region: p.config.Region,
-
-		Credentials: credentials.NewStaticCredentialsProvider(p.config.AccessKey, p.config.SecretKey, ""),
-
-		UsePathStyle: true,
-	}
-
-	if p.config.Endpoint != "" {
-
-		opts.BaseEndpoint = aws.String(p.config.Endpoint)
-
-	}
-
-	client := s3.New(opts)
-
-	out, err := client.GetObject(ctx, &s3.GetObjectInput{
+	out, err := p.client.GetObject(ctx, &s3.GetObjectInput{
 
 		Bucket: aws.String(p.config.BucketName),
 
@@ -252,24 +239,7 @@ func (p *S3StorageProvider) PutObject(ctx context.Context, objectKey string, dat
 
 	}
 
-	opts := s3.Options{
-
-		Region: p.config.Region,
-
-		Credentials: credentials.NewStaticCredentialsProvider(p.config.AccessKey, p.config.SecretKey, ""),
-
-		UsePathStyle: true,
-	}
-
-	if p.config.Endpoint != "" {
-
-		opts.BaseEndpoint = aws.String(p.config.Endpoint)
-
-	}
-
-	client := s3.New(opts)
-
-	_, err := client.PutObject(ctx, &s3.PutObjectInput{
+	_, err := p.client.PutObject(ctx, &s3.PutObjectInput{
 
 		Bucket: aws.String(p.config.BucketName),
 

--- a/internal/workout_execution/infrastructure/storage/s3_storage_provider_test.go
+++ b/internal/workout_execution/infrastructure/storage/s3_storage_provider_test.go
@@ -83,4 +83,18 @@ func TestS3StorageProvider_GeneratePresignedUploadURL(t *testing.T) {
 			t.Errorf("got fileURL = %s, want %s", fileURL, expectedFileURL)
 		}
 	})
+
+	t.Run("GetObject empty objectKey returns error", func(t *testing.T) {
+		_, err := provider.GetObject(context.Background(), "")
+		if err == nil {
+			t.Error("want error on empty object key, got nil")
+		}
+	})
+
+	t.Run("PutObject empty objectKey returns error", func(t *testing.T) {
+		_, err := provider.PutObject(context.Background(), "", []byte("test"), "application/json")
+		if err == nil {
+			t.Error("want error on empty object key, got nil")
+		}
+	})
 }

--- a/internal/workout_execution/infrastructure/worker/pr_event_consumer.go
+++ b/internal/workout_execution/infrastructure/worker/pr_event_consumer.go
@@ -2,10 +2,19 @@ package worker
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"log"
+	"strings"
 
 	"github.com/viethung213/gym-companion/internal/workout_execution/application/command"
 )
+
+// workoutSessionCompletedPayload maps the inner payload for WorkoutSessionCompleted event.
+type workoutSessionCompletedPayload struct {
+	SessionID string `json:"sessionId"`
+	UserID    string `json:"userId"`
+}
 
 // PREventConsumer listens for completed sessions and triggers asynchronous 1RM Personal Record calculation.
 type PREventConsumer struct {
@@ -17,6 +26,30 @@ func NewPREventConsumer(prHandler *command.ProcessCompletedSessionForPRHandler) 
 	return &PREventConsumer{
 		prHandler: prHandler,
 	}
+}
+
+// HandleMessage parses a CloudEvents JSON message from Kafka and triggers OnWorkoutSessionCompleted.
+func (c *PREventConsumer) HandleMessage(ctx context.Context, rawPayload []byte) error {
+	var env cloudEventEnvelope
+	if err := json.Unmarshal(rawPayload, &env); err != nil {
+		return fmt.Errorf("pr event consumer: unmarshal cloudevent: %w", err)
+	}
+
+	// Filter out non-WorkoutSessionCompleted events
+	if !strings.HasSuffix(env.Type, "workoutSessionCompleted") && env.Type != "contracts.core.workout_execution.v1.workoutSessionCompleted" {
+		return nil
+	}
+
+	var data workoutSessionCompletedPayload
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		return fmt.Errorf("pr event consumer: unmarshal data payload: %w", err)
+	}
+
+	if data.SessionID == "" || data.UserID == "" {
+		return fmt.Errorf("pr event consumer: empty sessionId or userId in event payload")
+	}
+
+	return c.OnWorkoutSessionCompleted(ctx, data.SessionID, data.UserID)
 }
 
 // OnWorkoutSessionCompleted processes session completion event to calculate 1RM.

--- a/internal/workout_execution/infrastructure/worker/pr_event_consumer_test.go
+++ b/internal/workout_execution/infrastructure/worker/pr_event_consumer_test.go
@@ -151,4 +151,71 @@ func TestPREventConsumer(t *testing.T) {
 			t.Fatalf("got err = %v, want nil", err)
 		}
 	})
+
+	t.Run("HandleMessage valid CloudEvent", func(t *testing.T) {
+		session, err := aggregate.NewWorkoutSession("sess-100", "user-100", "plan-1")
+		if err != nil {
+			t.Fatalf("failed to create session: %v", err)
+		}
+
+		handler := command.NewProcessCompletedSessionForPRHandler(
+			&mockSessionRepo{session: session},
+			&mockPRRepo{},
+			&mockOutboxWriter{},
+			&mockTxManager{},
+		)
+		consumer := worker.NewPREventConsumer(handler)
+
+		rawJSON := []byte(`{
+			"id": "evt-123",
+			"type": "contracts.core.workout_execution.v1.workoutSessionCompleted",
+			"data": {
+				"sessionId": "sess-100",
+				"userId": "user-100"
+			}
+		}`)
+
+		if err := consumer.HandleMessage(context.Background(), rawJSON); err != nil {
+			t.Fatalf("HandleMessage got err = %v, want nil", err)
+		}
+	})
+
+	t.Run("HandleMessage non-matching event type ignored", func(t *testing.T) {
+		handler := command.NewProcessCompletedSessionForPRHandler(&mockSessionRepo{}, &mockPRRepo{}, &mockOutboxWriter{}, &mockTxManager{})
+		consumer := worker.NewPREventConsumer(handler)
+
+		rawJSON := []byte(`{
+			"id": "evt-124",
+			"type": "contracts.core.workout_execution.v1.workoutSessionStarted",
+			"data": {"sessionId": "sess-100", "userId": "user-100"}
+		}`)
+
+		if err := consumer.HandleMessage(context.Background(), rawJSON); err != nil {
+			t.Fatalf("HandleMessage non-matching type got err = %v, want nil", err)
+		}
+	})
+
+	t.Run("HandleMessage invalid JSON payload", func(t *testing.T) {
+		handler := command.NewProcessCompletedSessionForPRHandler(&mockSessionRepo{}, &mockPRRepo{}, &mockOutboxWriter{}, &mockTxManager{})
+		consumer := worker.NewPREventConsumer(handler)
+
+		if err := consumer.HandleMessage(context.Background(), []byte(`invalid-json`)); err == nil {
+			t.Fatal("HandleMessage invalid json got nil error, want error")
+		}
+	})
+
+	t.Run("HandleMessage missing fields returns error", func(t *testing.T) {
+		handler := command.NewProcessCompletedSessionForPRHandler(&mockSessionRepo{}, &mockPRRepo{}, &mockOutboxWriter{}, &mockTxManager{})
+		consumer := worker.NewPREventConsumer(handler)
+
+		rawJSON := []byte(`{
+			"id": "evt-125",
+			"type": "contracts.core.workout_execution.v1.workoutSessionCompleted",
+			"data": {"sessionId": "", "userId": ""}
+		}`)
+
+		if err := consumer.HandleMessage(context.Background(), rawJSON); err == nil {
+			t.Fatal("HandleMessage missing fields got nil error, want error")
+		}
+	})
 }

--- a/internal/workout_execution/module.go
+++ b/internal/workout_execution/module.go
@@ -118,7 +118,7 @@ func Initialize(ctx context.Context, deps ModuleDeps) (func(), error) {
 	criticalWorker := worker.NewCriticalInactivityWorker(sessionRepo, outboxWriter, txManager, 1*time.Minute, 5*time.Minute)
 	exerciseCreatedConsumer := worker.NewExerciseCreatedConsumer(motionRepo, outboxLogRepo)
 
-	_ = worker.NewPREventConsumer(prProcessHandler)
+	prConsumer := worker.NewPREventConsumer(prProcessHandler)
 
 	workerCtx, cancelWorkers := context.WithCancel(ctx)
 	var wg sync.WaitGroup
@@ -185,6 +185,41 @@ func Initialize(ctx context.Context, deps ModuleDeps) (func(), error) {
 
 						if err := exerciseCreatedConsumer.HandleMessage(workerCtx, msg.Value); err != nil {
 							log.Printf("WorkoutExecution failed to process ExerciseCreated event: %v", err)
+						}
+					}
+				}
+			}()
+		}
+
+		// Start WorkoutSessionCompleted event consumer worker (listening to topic 'workout_execution.events')
+		sessionCompletedReader, err := deps.KafkaRegistry.GetReader("workout_execution_pr_consumer", "workout_execution.events", kafkaBrokers)
+		if err == nil && sessionCompletedReader != nil {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						log.Printf("PANIC RECOVERED in WorkoutExecution PREventConsumer worker: %v", r)
+					}
+					_ = sessionCompletedReader.Close()
+				}()
+
+				for {
+					select {
+					case <-workerCtx.Done():
+						return
+					default:
+						msg, err := sessionCompletedReader.ReadMessage(workerCtx)
+						if err != nil {
+							if errors.Is(err, context.Canceled) {
+								return
+							}
+							time.Sleep(1 * time.Second)
+							continue
+						}
+
+						if err := prConsumer.HandleMessage(workerCtx, msg.Value); err != nil {
+							log.Printf("WorkoutExecution failed to process WorkoutSessionCompleted event for PR: %v", err)
 						}
 					}
 				}


### PR DESCRIPTION
### 1. Vấn đề cần giải quyết (Problem to Solve)
Khắc phục 3 lỗi critical/high trong module \workout_execution\:
- **Lỗi 8 [CRITICAL]**: Mất domain event khi \	xManager\ null trong \update_motion_spec.go\ (nhánh fallback chỉ gọi repo \Save\ mà quên \PopEvents\ và \outbox.WriteEvents\).
- **Lỗi 9 [HIGH]**: Worker \PREventConsumer\ khởi tạo nhưng bị gán biến bỏ đi (\_ =\), dẫn đến không có Kafka reader tiêu thụ event \WorkoutSessionCompleted\ để tính Kỷ Lục Cá Nhân (1RM Personal Record).
- **Lỗi 10 [HIGH]**: Khởi tạo mới \s3.Client\ liên tục ở mỗi lần gọi \GetObject\ hoặc \PutObject\ trong \s3_storage_provider.go\, gây hao phí RAM/CPU cực cao khi có tải.

### 2. Giải pháp kỹ thuật (Proposed Solution)
- **Lỗi 8**: Gói logic save repository và write outbox events vào hàm closure chung \saveAndPublish(execCtx)\. Cả nhánh \	xManager != nil\ (trong DB transaction) và \	xManager == nil\ đều thực thi hàm này, đảm bảo nguyên tố (Atomicity) và không mất event.
- **Lỗi 9**: Bổ sung method \HandleMessage\ cho \PREventConsumer\ để unmarshal CloudEvent \WorkoutSessionCompleted\ từ Kafka raw bytes. Đăng ký \sessionCompletedReader\ trên topic \workout_execution.events\ (group ID \workout_execution_pr_consumer\) trong \module.go\.
- **Lỗi 10**: Thêm field \client *s3.Client\ làm struct field của \S3StorageProvider\, khởi tạo 1 lần duy nhất trong constructor và tái sử dụng connection pool cho \GetObject\ và \PutObject\.

### 3. Chi tiết thay đổi (Changes & Impact)
- \[internal/workout_execution/application/command/update_motion_spec.go](internal/workout_execution/application/command/update_motion_spec.go)\: Refactor logic lưu spec và publish event qua \saveAndPublish\.
- \[internal/workout_execution/application/command/motion_spec_commands_test.go](internal/workout_execution/application/command/motion_spec_commands_test.go)\ & \[mocks_test.go](internal/workout_execution/application/command/mocks_test.go)\: Bổ sung unit test xác minh outbox event khi \	xManager\ null.
- \[internal/workout_execution/infrastructure/worker/pr_event_consumer.go](internal/workout_execution/infrastructure/worker/pr_event_consumer.go)\ & \[pr_event_consumer_test.go](internal/workout_execution/infrastructure/worker/pr_event_consumer_test.go)\: Thêm \HandleMessage\ unmarshal CloudEvent và bộ unit test kiểm thử 4 kịch bản.
- \[internal/workout_execution/module.go](internal/workout_execution/module.go)\: Lưu \prConsumer\ và khởi chạy worker đọc topic \workout_execution.events\.
- \[internal/workout_execution/infrastructure/storage/s3_storage_provider.go](internal/workout_execution/infrastructure/storage/s3_storage_provider.go)\ & \[s3_storage_provider_test.go](internal/workout_execution/infrastructure/storage/s3_storage_provider_test.go)\: Lưu \client\ làm struct field và bổ sung test validation.

### 4. Kiểm thử & Xác minh (Testing & Verification)
- **Automated Tests**: Chạy toàn bộ bộ kiểm thử unit test:
  \\\powershell
  go test -v ./internal/workout_execution/...
  \\\
  Tất cả các package (\command\, \storage\, \worker\, \ggregate\, \query\, \persistence\) đều đạt **PASS 100%**.
- **Static Analysis & Formatting**: Đã chạy \gofmt\ và \go vet ./internal/workout_execution/...\ đạt **0 lỗi**.