### PR TITLE
✅ test(profile): add e2e and integration test suite

### DIFF
--- a/internal/profile/application/command/command_handlers_test.go
+++ b/internal/profile/application/command/command_handlers_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package command_test
 
 import (

--- a/internal/profile/application/command/save_health_profile_test.go
+++ b/internal/profile/application/command/save_health_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package command_test
 
 import (

--- a/internal/profile/application/command/update_profile_test.go
+++ b/internal/profile/application/command/update_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package command_test
 
 import (

--- a/internal/profile/application/query/query_handlers_test.go
+++ b/internal/profile/application/query/query_handlers_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package query_test
 
 import (

--- a/internal/profile/domain/aggregate/user_profile_test.go
+++ b/internal/profile/domain/aggregate/user_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package aggregate_test
 
 import (

--- a/internal/profile/domain/entity/injury_test.go
+++ b/internal/profile/domain/entity/injury_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package entity_test
 
 import (

--- a/internal/profile/domain/service/completion_calculator_test.go
+++ b/internal/profile/domain/service/completion_calculator_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package service_test
 
 import (

--- a/internal/profile/domain/vo/vo_test.go
+++ b/internal/profile/domain/vo/vo_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package vo_test
 
 import (

--- a/internal/profile/infrastructure/event/outbox_writer_test.go
+++ b/internal/profile/infrastructure/event/outbox_writer_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package event_test
 
 import (

--- a/internal/profile/infrastructure/persistence/postgres_repository_test.go
+++ b/internal/profile/infrastructure/persistence/postgres_repository_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package persistence_test
 
 import (

--- a/internal/profile/infrastructure/transport/grpc/grpc_handler_test.go
+++ b/internal/profile/infrastructure/transport/grpc/grpc_handler_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package grpc_test
 
 import (

--- a/internal/profile/infrastructure/worker/outbox_worker_test.go
+++ b/internal/profile/infrastructure/worker/outbox_worker_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package worker_test
 
 import (

--- a/internal/profile/infrastructure/worker/user_registered_consumer_test.go
+++ b/internal/profile/infrastructure/worker/user_registered_consumer_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package worker_test
 
 import (

--- a/internal/profile/tests/e2e/profile_e2e_test.go
+++ b/internal/profile/tests/e2e/profile_e2e_test.go
@@ -1,0 +1,202 @@
+//go:build e2e || integration
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	profilev1message "github.com/viethung213/gym-companion/internal/gen/go/contracts/supporting/profile/v1/message"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestProfile_FullLifecycle_E2E(t *testing.T) {
+	suite := SetupE2ESuite(t)
+	defer suite.StopServer()
+
+	userID := uuid.NewString()
+	userCtx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("x-user-id", userID, "x-user-role", "User"))
+
+	// 1. Initial SaveHealthProfile
+	dob := time.Date(1995, 5, 20, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	saveResp, err := suite.Client.SaveHealthProfile(userCtx, &profilev1message.SaveHealthProfileRequest{
+		WeightKg:              75.5,
+		HeightCm:              178.0,
+		BodyFatPercent:        18.5,
+		DateOfBirth:           dob,
+		Gender:                "MALE",
+		Goals:                 []string{"BUILD_MUSCLE", "LOSE_FAT"},
+		ExperienceLevel:       "INTERMEDIATE",
+		PreferredWorkoutTimes: []string{"MORNING", "EVENING"},
+		AvailableEquipment:    []string{"BARBELL", "DUMBBELL"},
+		PreferredMuscleGroups: []string{"CHEST", "BACK"},
+		Injuries: []*profilev1message.InjuryInput{
+			{
+				MuscleGroup: "LOWER_BACK",
+				Severity:    "MILD",
+				Notes:       "Slight strain during deadlifts",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SaveHealthProfile failed: %v", err)
+	}
+	if saveResp.GetUserId() != userID {
+		t.Errorf("Expected UserID %s, got %s", userID, saveResp.GetUserId())
+	}
+	if saveResp.GetCompletionRate() <= 0 {
+		t.Errorf("Expected CompletionRate > 0, got %v", saveResp.GetCompletionRate())
+	}
+
+	// 2. Query GetProfile
+	getResp, err := suite.Client.GetProfile(userCtx, &profilev1message.GetProfileRequest{})
+	if err != nil {
+		t.Fatalf("GetProfile failed: %v", err)
+	}
+	if getResp.GetUserId() != userID {
+		t.Errorf("Expected UserID %s, got %s", userID, getResp.GetUserId())
+	}
+	if getResp.GetWeightKg() != 75.5 {
+		t.Errorf("Expected Weight 75.5, got %v", getResp.GetWeightKg())
+	}
+	if getResp.GetCompletionRate() <= 0 {
+		t.Errorf("Expected CompletionRate > 0, got %v", getResp.GetCompletionRate())
+	}
+
+	// 3. UpdateProfile Preferences
+	updateResp, err := suite.Client.UpdateProfile(userCtx, &profilev1message.UpdateProfileRequest{
+		Goals:                 []string{"STRENGTH_BUILDING"},
+		PreferredWorkoutTimes: []string{"MORNING"},
+		AvailableEquipment:    []string{"BARBELL", "DUMBBELL", "CABLE"},
+		PreferredMuscleGroups: []string{"CHEST", "LEGS"},
+		CoachStyle:            "MOTIVATIONAL",
+		TargetWeightKg:        80.0,
+		TargetBodyFatPercent:  15.0,
+	})
+	if err != nil {
+		t.Fatalf("UpdateProfile failed: %v", err)
+	}
+	if !updateResp.GetSuccess() {
+		t.Errorf("Expected UpdateProfile success = true")
+	}
+
+	// Verify updated profile via GetProfile
+	updatedGetResp, err := suite.Client.GetProfile(userCtx, &profilev1message.GetProfileRequest{})
+	if err != nil {
+		t.Fatalf("GetProfile after update failed: %v", err)
+	}
+	if len(updatedGetResp.GetGoals()) != 1 || updatedGetResp.GetGoals()[0] != "STRENGTH_BUILDING" {
+		t.Errorf("Unexpected goals after update: %v", updatedGetResp.GetGoals())
+	}
+
+	// 4. LogPeriodicMetrics
+	logMetricsResp, err := suite.Client.LogPeriodicMetrics(userCtx, &profilev1message.LogPeriodicMetricsRequest{
+		WeightKg:         76.0,
+		HeightCm:         178.0,
+		BodyFatPercent:   18.0,
+		ProgressPhotoUrl: "https://storage.fitai.com/photos/progress1.jpg",
+	})
+	if err != nil {
+		t.Fatalf("LogPeriodicMetrics failed: %v", err)
+	}
+	if logMetricsResp.GetWeightKg() != 76.0 {
+		t.Errorf("Expected weight 76.0, got %v", logMetricsResp.GetWeightKg())
+	}
+
+	// 5. GetBodyMetricsHistory
+	metricsHistResp, err := suite.Client.GetBodyMetricsHistory(userCtx, &profilev1message.GetBodyMetricsHistoryRequest{
+		UserId: userID,
+	})
+	if err != nil {
+		t.Fatalf("GetBodyMetricsHistory failed: %v", err)
+	}
+	if len(metricsHistResp.GetMetrics()) < 2 {
+		t.Errorf("Expected at least 2 metrics in history (initial + periodic), got %d", len(metricsHistResp.GetMetrics()))
+	}
+
+	// 6. ReportInjury & GetInjuryHistory
+	reportInjResp, err := suite.Client.ReportInjury(userCtx, &profilev1message.ReportInjuryRequest{
+		MuscleGroup: "SHOULDER",
+		Severity:    "MODERATE",
+		Notes:       "Right rotator cuff discomfort",
+	})
+	if err != nil {
+		t.Fatalf("ReportInjury failed: %v", err)
+	}
+	newInjuryID := reportInjResp.GetInjuryId()
+	if newInjuryID == "" {
+		t.Fatalf("ReportInjury returned empty injury ID")
+	}
+
+	injHistResp, err := suite.Client.GetInjuryHistory(userCtx, &profilev1message.GetInjuryHistoryRequest{
+		UserId: userID,
+	})
+	if err != nil {
+		t.Fatalf("GetInjuryHistory failed: %v", err)
+	}
+	if len(injHistResp.GetInjuries()) < 2 {
+		t.Errorf("Expected at least 2 injuries in history, got %d", len(injHistResp.GetInjuries()))
+	}
+
+	// 7. RecoverInjury
+	recoverResp, err := suite.Client.RecoverInjury(userCtx, &profilev1message.RecoverInjuryRequest{
+		InjuryId: newInjuryID,
+	})
+	if err != nil {
+		t.Fatalf("RecoverInjury failed: %v", err)
+	}
+	if !recoverResp.GetSuccess() {
+		t.Errorf("Expected RecoverInjury success = true")
+	}
+
+	// 8. Verify Outbox Records Created
+	var outboxCount int64
+	if err := suite.DB.Table("profile.outbox").Count(&outboxCount).Error; err != nil {
+		t.Fatalf("Failed to count profile outbox records: %v", err)
+	}
+	if outboxCount == 0 {
+		t.Errorf("Expected outbox events to be created in profile.outbox, got 0")
+	}
+}
+
+func TestProfile_AccessControl_E2E(t *testing.T) {
+	suite := SetupE2ESuite(t)
+	defer suite.StopServer()
+
+	user1ID := uuid.NewString()
+	user2ID := uuid.NewString()
+
+	user1Ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("x-user-id", user1ID, "x-user-role", "User"))
+	user2Ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("x-user-id", user2ID, "x-user-role", "User"))
+	adminCtx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("x-user-id", "admin-id", "x-user-role", "Admin"))
+
+	// User 1 creates profile
+	_, err := suite.Client.SaveHealthProfile(user1Ctx, &profilev1message.SaveHealthProfileRequest{
+		WeightKg: 70.0,
+		HeightCm: 170.0,
+	})
+	if err != nil {
+		t.Fatalf("SaveHealthProfile for User 1 failed: %v", err)
+	}
+
+	// User 2 attempts to fetch User 1's profile -> Should be denied
+	_, err = suite.Client.GetProfile(user2Ctx, &profilev1message.GetProfileRequest{
+		UserId: user1ID,
+	})
+	if err == nil {
+		t.Errorf("Expected PermissionDenied when User 2 accesses User 1's profile, got nil error")
+	}
+
+	// Admin fetches User 1's profile -> Should succeed
+	adminGetResp, err := suite.Client.GetProfile(adminCtx, &profilev1message.GetProfileRequest{
+		UserId: user1ID,
+	})
+	if err != nil {
+		t.Fatalf("Admin GetProfile for User 1 failed: %v", err)
+	}
+	if adminGetResp.GetUserId() != user1ID {
+		t.Errorf("Admin got profile UserID = %s, want %s", adminGetResp.GetUserId(), user1ID)
+	}
+}

--- a/internal/profile/tests/e2e/testutil.go
+++ b/internal/profile/tests/e2e/testutil.go
@@ -1,0 +1,186 @@
+//go:build e2e || integration
+
+package e2e
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	profilev1service "github.com/viethung213/gym-companion/internal/gen/go/contracts/supporting/profile/v1/service"
+	"github.com/viethung213/gym-companion/internal/profile"
+	"github.com/viethung213/gym-companion/internal/shared/database"
+	sharedKafka "github.com/viethung213/gym-companion/internal/shared/kafka"
+	"github.com/viethung213/gym-companion/internal/shared/middleware"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+type TestSuite struct {
+	DB         *gorm.DB
+	GRPCConn   *grpc.ClientConn
+	Client     profilev1service.ProfileServiceClient
+	StopServer func()
+}
+
+func ensureTablesExist(db *gorm.DB) {
+	db.Exec(`CREATE SCHEMA IF NOT EXISTS profile;`)
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS profile.users (
+		user_id VARCHAR(255) PRIMARY KEY,
+		date_of_birth TIMESTAMP WITH TIME ZONE,
+		gender VARCHAR(50),
+		experience_level VARCHAR(50),
+		goals JSONB,
+		preferred_workout_times JSONB,
+		available_equipment JSONB,
+		preferred_muscle_groups JSONB,
+		coach_style VARCHAR(50),
+		target_weight_kg NUMERIC(10, 2),
+		target_body_fat_percent NUMERIC(5, 2),
+		completion_rate NUMERIC(5, 2),
+		ai_coach_activated BOOLEAN DEFAULT FALSE,
+		created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+	);`)
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS profile.body_metrics (
+		id VARCHAR(255) PRIMARY KEY,
+		user_id VARCHAR(255) NOT NULL REFERENCES profile.users(user_id) ON DELETE CASCADE,
+		weight_kg NUMERIC(10, 2),
+		height_cm NUMERIC(10, 2),
+		body_fat_percent NUMERIC(5, 2),
+		progress_photo_url VARCHAR(1024),
+		logged_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+	);`)
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS profile.injuries (
+		id VARCHAR(255) PRIMARY KEY,
+		user_id VARCHAR(255) NOT NULL REFERENCES profile.users(user_id) ON DELETE CASCADE,
+		muscle_group VARCHAR(100) NOT NULL,
+		severity VARCHAR(50) NOT NULL,
+		notes TEXT,
+		reported_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+		recovered_at TIMESTAMP WITH TIME ZONE
+	);`)
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS profile.outbox (
+		id VARCHAR(255) PRIMARY KEY,
+		event_id VARCHAR(255),
+		aggregate_type VARCHAR(255),
+		aggregate_id VARCHAR(255),
+		event_type VARCHAR(255) NOT NULL,
+		payload JSONB NOT NULL,
+		partition_key VARCHAR(255),
+		published BOOLEAN DEFAULT FALSE,
+		published_at TIMESTAMP WITH TIME ZONE,
+		created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+	);`)
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS profile.outbox_log (
+		id UUID PRIMARY KEY,
+		event_id UUID NOT NULL,
+		event_type VARCHAR(255) NOT NULL,
+		payload JSONB NOT NULL,
+		partition_key VARCHAR(255) NOT NULL,
+		processed_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+		status VARCHAR(50) NOT NULL,
+		error_message TEXT
+	);`)
+}
+
+func truncateTables(db *gorm.DB) {
+	db.Exec("TRUNCATE TABLE profile.injuries CASCADE")
+	db.Exec("TRUNCATE TABLE profile.body_metrics CASCADE")
+	db.Exec("TRUNCATE TABLE profile.users CASCADE")
+	db.Exec("TRUNCATE TABLE profile.outbox CASCADE")
+	db.Exec("TRUNCATE TABLE profile.outbox_log CASCADE")
+}
+
+func SetupE2ESuite(t *testing.T) *TestSuite {
+	t.Helper()
+
+	sqlDB, err := database.GetRegistry().GetPool("profile")
+	if err != nil {
+		t.Fatalf("Failed to initialize profile DB pool from monolith registry: %v", err)
+	}
+
+	db, err := gorm.Open(postgres.New(postgres.Config{
+		Conn: sqlDB,
+	}), &gorm.Config{
+		SkipDefaultTransaction: true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to wrap database in gorm: %v", err)
+	}
+
+	ensureTablesExist(db)
+	truncateTables(db)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Failed to listen on random port for gRPC: %v", err)
+	}
+
+	testAuthInterceptor := func(
+		ctx context.Context,
+		req any,
+		_ *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (any, error) {
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			if vals := md.Get("x-user-id"); len(vals) > 0 && vals[0] != "" {
+				ctx = context.WithValue(ctx, middleware.UserIDKey, vals[0])
+			}
+			if vals := md.Get("x-user-role"); len(vals) > 0 && vals[0] != "" {
+				ctx = context.WithValue(ctx, middleware.UserRoleKey, vals[0])
+			}
+		}
+		return handler(ctx, req)
+	}
+
+	grpcServer := grpc.NewServer(grpc.UnaryInterceptor(testAuthInterceptor))
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cleanup, err := profile.Initialize(ctx, profile.ModuleDeps{
+		DB:            sqlDB,
+		GRPCServer:    grpcServer,
+		KafkaRegistry: sharedKafka.GetRegistry(),
+	})
+	if err != nil {
+		cancel()
+		t.Fatalf("Failed to initialize profile module: %v", err)
+	}
+
+	go func() {
+		_ = grpcServer.Serve(lis)
+	}()
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		grpcServer.Stop()
+		cleanup()
+		cancel()
+		t.Fatalf("Failed to connect to gRPC test server: %v", err)
+	}
+
+	client := profilev1service.NewProfileServiceClient(conn)
+
+	stopServer := func() {
+		truncateTables(db)
+		_ = conn.Close()
+		grpcServer.GracefulStop()
+		cleanup()
+		cancel()
+	}
+
+	return &TestSuite{
+		DB:         db,
+		GRPCConn:   conn,
+		Client:     client,
+		StopServer: stopServer,
+	}
+}

--- a/internal/profile/tests/integration/repository_test.go
+++ b/internal/profile/tests/integration/repository_test.go
@@ -1,0 +1,258 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/viethung213/gym-companion/internal/profile/application/port"
+	"github.com/viethung213/gym-companion/internal/profile/domain/aggregate"
+	"github.com/viethung213/gym-companion/internal/profile/domain/entity"
+	"github.com/viethung213/gym-companion/internal/profile/domain/vo"
+	infraPostgres "github.com/viethung213/gym-companion/internal/profile/infrastructure/persistence"
+	"github.com/viethung213/gym-companion/internal/shared/database"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func getTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	sqlDB, err := database.GetRegistry().GetPool("profile")
+	if err != nil {
+		t.Fatalf("Integration test failed to get profile database pool: %v", err)
+	}
+
+	db, err := gorm.Open(postgres.New(postgres.Config{
+		Conn: sqlDB,
+	}), &gorm.Config{
+		SkipDefaultTransaction: true,
+	})
+	if err != nil {
+		t.Fatalf("Integration test failed to wrap database in gorm: %v", err)
+	}
+
+	ensureTablesExist(db)
+	return db
+}
+
+func ensureTablesExist(db *gorm.DB) {
+	db.Exec(`CREATE SCHEMA IF NOT EXISTS profile;`)
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS profile.users (
+		user_id VARCHAR(255) PRIMARY KEY,
+		date_of_birth TIMESTAMP WITH TIME ZONE,
+		gender VARCHAR(50),
+		experience_level VARCHAR(50),
+		goals JSONB,
+		preferred_workout_times JSONB,
+		available_equipment JSONB,
+		preferred_muscle_groups JSONB,
+		coach_style VARCHAR(50),
+		target_weight_kg NUMERIC(10, 2),
+		target_body_fat_percent NUMERIC(5, 2),
+		completion_rate NUMERIC(5, 2),
+		ai_coach_activated BOOLEAN DEFAULT FALSE,
+		created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+	);`)
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS profile.body_metrics (
+		id VARCHAR(255) PRIMARY KEY,
+		user_id VARCHAR(255) NOT NULL REFERENCES profile.users(user_id) ON DELETE CASCADE,
+		weight_kg NUMERIC(10, 2),
+		height_cm NUMERIC(10, 2),
+		body_fat_percent NUMERIC(5, 2),
+		progress_photo_url VARCHAR(1024),
+		logged_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+	);`)
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS profile.injuries (
+		id VARCHAR(255) PRIMARY KEY,
+		user_id VARCHAR(255) NOT NULL REFERENCES profile.users(user_id) ON DELETE CASCADE,
+		muscle_group VARCHAR(100) NOT NULL,
+		severity VARCHAR(50) NOT NULL,
+		notes TEXT,
+		reported_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+		recovered_at TIMESTAMP WITH TIME ZONE
+	);`)
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS profile.outbox (
+		id VARCHAR(255) PRIMARY KEY,
+		event_id VARCHAR(255),
+		aggregate_type VARCHAR(255),
+		aggregate_id VARCHAR(255),
+		event_type VARCHAR(255) NOT NULL,
+		payload JSONB NOT NULL,
+		partition_key VARCHAR(255),
+		published BOOLEAN DEFAULT FALSE,
+		published_at TIMESTAMP WITH TIME ZONE,
+		created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+	);`)
+
+	db.Exec(`CREATE TABLE IF NOT EXISTS profile.outbox_log (
+		id UUID PRIMARY KEY,
+		event_id UUID NOT NULL,
+		event_type VARCHAR(255) NOT NULL,
+		payload JSONB NOT NULL,
+		partition_key VARCHAR(255) NOT NULL,
+		processed_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+		status VARCHAR(50) NOT NULL,
+		error_message TEXT
+	);`)
+}
+
+func truncateTables(db *gorm.DB) {
+	db.Exec("TRUNCATE TABLE profile.injuries CASCADE")
+	db.Exec("TRUNCATE TABLE profile.body_metrics CASCADE")
+	db.Exec("TRUNCATE TABLE profile.users CASCADE")
+	db.Exec("TRUNCATE TABLE profile.outbox CASCADE")
+	db.Exec("TRUNCATE TABLE profile.outbox_log CASCADE")
+}
+
+func TestPostgresUserProfileRepository_SaveAndFindByUserID(t *testing.T) {
+	db := getTestDB(t)
+	truncateTables(db)
+	defer truncateTables(db)
+
+	repo := infraPostgres.NewPostgresUserProfileRepository(db)
+	ctx := context.Background()
+
+	userID := uuid.NewString()
+	dob := time.Date(1996, 8, 15, 0, 0, 0, 0, time.UTC)
+	bioMetrics, err := vo.NewBiologicalMetricsWithDOB(75.5, 178.0, dob, "MALE")
+	if err != nil {
+		t.Fatalf("NewBiologicalMetricsWithDOB failed: %v", err)
+	}
+
+	userProfile, err := aggregate.NewUserProfile(
+		userID,
+		bioMetrics,
+		"INTERMEDIATE",
+		[]string{"BUILD_MUSCLE"},
+		[]string{"MORNING"},
+		[]string{"BARBELL"},
+		[]string{"CHEST"},
+		"FRIENDLY",
+		80.0,
+		15.0,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewUserProfile failed: %v", err)
+	}
+
+	// Update Preferences & Target Metrics
+	userProfile.UpdateProfile(
+		bioMetrics,
+		"ADVANCED",
+		[]string{"BUILD_MUSCLE"},
+		[]string{"MORNING"},
+		[]string{"BARBELL", "DUMBBELL"},
+		[]string{"CHEST", "ARMS"},
+		"MOTIVATIONAL",
+		82.0,
+		14.0,
+	)
+
+	// Add Injury
+	inj, err := entity.NewInjury(uuid.NewString(), "SHOULDER", "MODERATE", "Overuse strain", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("NewInjury failed: %v", err)
+	}
+	if err := userProfile.AddInjury(inj); err != nil {
+		t.Fatalf("AddInjury failed: %v", err)
+	}
+
+	// Save profile to database
+	if err := repo.Save(ctx, userProfile); err != nil {
+		t.Fatalf("Save profile failed: %v", err)
+	}
+
+	// Find profile from database
+	fetched, err := repo.FindByUserID(ctx, userID)
+	if err != nil {
+		t.Fatalf("FindByUserID failed: %v", err)
+	}
+
+	if fetched.UserID() != userID {
+		t.Errorf("got UserID %s, want %s", fetched.UserID(), userID)
+	}
+	if fetched.ExperienceLevel() != "ADVANCED" {
+		t.Errorf("got ExperienceLevel %s, want ADVANCED", fetched.ExperienceLevel())
+	}
+	if fetched.CoachStyle() != "MOTIVATIONAL" {
+		t.Errorf("got CoachStyle %s, want MOTIVATIONAL", fetched.CoachStyle())
+	}
+	if len(fetched.Injuries()) != 1 {
+		t.Errorf("got %d injuries, want 1", len(fetched.Injuries()))
+	}
+	if fetched.Injuries()[0].MuscleGroup() != "SHOULDER" {
+		t.Errorf("got injury muscle group %s, want SHOULDER", fetched.Injuries()[0].MuscleGroup())
+	}
+}
+
+func TestPostgresUserProfileRepository_TransactionManager(t *testing.T) {
+	db := getTestDB(t)
+	truncateTables(db)
+	defer truncateTables(db)
+
+	repo := infraPostgres.NewPostgresUserProfileRepository(db)
+	outboxRepo := infraPostgres.NewGormOutboxRepository(db)
+	txManager := infraPostgres.NewSQLTransactionManager(db)
+
+	userID := uuid.NewString()
+	dob := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+	bioMetrics, _ := vo.NewBiologicalMetricsWithDOB(60.0, 165.0, dob, "FEMALE")
+	userProfile, _ := aggregate.NewUserProfile(
+		userID,
+		bioMetrics,
+		"BEGINNER",
+		[]string{"LOSE_WEIGHT"},
+		[]string{"EVENING"},
+		[]string{"DUMBBELL"},
+		[]string{"LEGS"},
+		"FRIENDLY",
+		55.0,
+		20.0,
+		nil,
+	)
+
+	ctx := context.Background()
+
+	// Perform atomic transaction writing both profile and outbox event
+	err := txManager.WithTransaction(ctx, func(txCtx context.Context) error {
+		if err := repo.Save(txCtx, userProfile); err != nil {
+			return err
+		}
+		outboxRecord := &port.OutboxRecord{
+			ID:           uuid.NewString(),
+			EventID:      uuid.NewString(),
+			EventType:    "contracts.supporting.profile.v1.userProfileCreated",
+			Payload:      []byte(`{"userId":"` + userID + `"}`),
+			PartitionKey: userID,
+		}
+		return outboxRepo.Save(txCtx, outboxRecord)
+	})
+	if err != nil {
+		t.Fatalf("WithTransaction failed: %v", err)
+	}
+
+	// Verify profile exists in DB
+	fetched, err := repo.FindByUserID(ctx, userID)
+	if err != nil || fetched == nil {
+		t.Fatalf("Failed to fetch profile committed in transaction: %v", err)
+	}
+
+	// Verify outbox record exists in DB
+	records, err := outboxRepo.FetchUnpublished(ctx, 10)
+	if err != nil {
+		t.Fatalf("FetchUnpublished failed: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("got %d unpublished outbox records, want 1", len(records))
+	}
+}


### PR DESCRIPTION
### 1. Problem to Solve
Module \profile\ lacked E2E test coverage (\	ests/e2e/\), repository integration test coverage (\	ests/integration/\), and explicit build tags for unit tests.

### 2. Proposed Solution
- Created \internal/profile/tests/e2e/testutil.go\ and \profile_e2e_test.go\ covering full profile lifecycle (SaveHealthProfile, GetProfile, UpdateProfile, LogPeriodicMetrics, ReportInjury, RecoverInjury, Outbox events) and access control.
- Created \internal/profile/tests/integration/repository_test.go\ for \PostgresUserProfileRepository\ & \SQLTransactionManager\ testing with PostgreSQL.
- Added \//go:build unit\ tag to all existing unit test files in \internal/profile/...\.

### 3. Changes & Impact
- [internal/profile/tests/e2e/testutil.go](internal/profile/tests/e2e/testutil.go): E2E test suite setup with gRPC server, metadata auth interceptor, and PostgreSQL schema setup/truncation.
- [internal/profile/tests/e2e/profile_e2e_test.go](internal/profile/tests/e2e/profile_e2e_test.go): E2E test scenarios for profile lifecycle and RBAC access control.
- [internal/profile/tests/integration/repository_test.go](internal/profile/tests/integration/repository_test.go): Integration tests for repository and transaction manager.
- [internal/profile/...](internal/profile/): Standardized build tags (\//go:build unit\).

### 4. Testing & Verification
- **Automated Tests**:
  - \go test -tags=unit ./internal/profile/...\: **PASS**
  - \go test -tags=integration ./internal/profile/tests/integration/...\: **PASS**
  - \go test -tags=e2e ./internal/profile/tests/e2e/...\: **PASS**