### PR TITLE
🔧 chore(ci): include build tags unit, integration, e2e in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,10 @@ run:
   issues-exit-code: 1
   tests: true
   go: '1.26'
+  build-tags:
+    - unit
+    - integration
+    - e2e
 
 
 linters:

--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,8 @@ test-env-down:
 
 # Chạy golangci-lint tĩnh cục bộ để kiểm tra chất lượng mã nguồn (sử dụng go run để biên dịch tự động bằng phiên bản Go của máy host, hỗ trợ Go 1.25+ và đồng bộ với CI)
 lint:
-	@echo "Linting Go source files..."
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5 run -v
+	@echo "Linting Go source files (including unit, integration, and e2e tagged files)..."
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5 run --build-tags "unit,integration,e2e" -v
 
 # --- Lệnh Chạy Toàn Bộ Dự Án ---
 

--- a/internal/auth/application/command/oauth_login_test.go
+++ b/internal/auth/application/command/oauth_login_test.go
@@ -266,4 +266,3 @@ func TestOAuthLoginHandler_FindBySocialID_DBError(t *testing.T) {
 		t.Errorf("got error %v, want error containing 'find user by social id'", err)
 	}
 }
-

--- a/internal/auth/infrastructure/jwt/signer_test.go
+++ b/internal/auth/infrastructure/jwt/signer_test.go
@@ -1,3 +1,4 @@
+
 //go:build unit
 
 package jwt
@@ -107,7 +108,10 @@ func validateTokenHelper(t *testing.T, tokenStr string, key *port.JWKRecord) (st
 		return "", "", fmt.Errorf("invalid claims")
 	}
 
-	userID := claims["sub"].(string)
+	userID, ok := claims["sub"].(string)
+	if !ok {
+		return "", "", fmt.Errorf("invalid sub claim")
+	}
 	role, _ := claims["role"].(string)
 	return userID, role, nil
 }

--- a/internal/auth/infrastructure/jwt/signer_test.go
+++ b/internal/auth/infrastructure/jwt/signer_test.go
@@ -1,4 +1,3 @@
-
 //go:build unit
 
 package jwt

--- a/internal/auth/tests/e2e/testutil.go
+++ b/internal/auth/tests/e2e/testutil.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -14,14 +15,13 @@ import (
 	"testing"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/viethung213/gym-companion/internal/auth"
+	"github.com/viethung213/gym-companion/internal/shared/database"
+	sharedKafka "github.com/viethung213/gym-companion/internal/shared/kafka"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
-
-	"github.com/viethung213/gym-companion/internal/auth"
-	"github.com/viethung213/gym-companion/internal/shared/database"
-	sharedKafka "github.com/viethung213/gym-companion/internal/shared/kafka"
 )
 
 // getTestDB creates a connection to the test database for E2E verification.
@@ -108,7 +108,7 @@ func startE2ETestServer(t *testing.T) (string, *gorm.DB, func()) {
 
 	// Run gRPC server in background
 	go func() {
-		if err := grpcServer.Serve(grpcListener); err != nil && err != grpc.ErrServerStopped {
+		if err := grpcServer.Serve(grpcListener); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
 			log.Printf("gRPC server run error: %v", err)
 		}
 	}()

--- a/internal/auth/tests/integration/repository_test.go
+++ b/internal/auth/tests/integration/repository_test.go
@@ -8,15 +8,14 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"gorm.io/driver/postgres"
-	"gorm.io/gorm"
-
 	"github.com/viethung213/gym-companion/internal/auth/application/port"
 	"github.com/viethung213/gym-companion/internal/auth/domain/aggregate"
 	"github.com/viethung213/gym-companion/internal/auth/domain/derror"
 	"github.com/viethung213/gym-companion/internal/auth/domain/vo"
 	infraPostgres "github.com/viethung213/gym-companion/internal/auth/infrastructure/persistence/postgres"
 	"github.com/viethung213/gym-companion/internal/shared/database"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
 )
 
 func getTestDB(t *testing.T) *gorm.DB {

--- a/internal/coaching/tests/e2e/testutil.go
+++ b/internal/coaching/tests/e2e/testutil.go
@@ -28,7 +28,6 @@ type TestSuite struct {
 	StopServer func()
 }
 
-
 type fakeClock struct{ t time.Time }
 
 func (c *fakeClock) Now() time.Time { return c.t }


### PR DESCRIPTION
### 1. Problem to Solve
Các file test được đánh build tags (`unit`, `integration`, `e2e`) trước đây bị `golangci-lint` bỏ qua do linter chưa được cấu hình nhận diện các build tags này.

### 2. Proposed Solution
- Bổ sung `build-tags: [unit, integration, e2e]` vào `.golangci.yml` và `Makefile`.
- Tái sinh proto stubs (`buf generate proto`) phục vụ typechecking đầy đủ cho module coaching.
- Khắc phục các lỗi linter phát hiện trên file test (`errorlint`, `forcetypeassert`, `gci`).

### 3. Changes & Impact
- `.golangci.yml`: Khai báo build-tags `unit, integration, e2e`.
- `Makefile`: Cập nhật flag `--build-tags` cho lệnh `make lint`.
- `internal/auth/tests/e2e/testutil.go`: Sử dụng `errors.Is` kiểm tra `grpc.ErrServerStopped`.
- `internal/auth/infrastructure/jwt/signer_test.go`: Kiểm tra an toàn cho type assertion `claims["sub"].(string)`.

### 4. Testing & Verification
- **Automated Tests**: Chạy `make lint` thành công 100% với `0 issues`.
