### PR TITLE
♻️ refactor(outbox): migrate outbox pattern to FOR UPDATE SKIP LOCKED and refine auth module

### DIFF
--- a/internal/auth/application/command/mocks_test.go
+++ b/internal/auth/application/command/mocks_test.go
@@ -184,9 +184,10 @@ func (mockOAuthService) GetOAuthLoginURL(ctx context.Context, provider string, s
 
 func (mockOAuthService) ExchangeCodeForProfile(ctx context.Context, provider string, code string, redirectURI string) (*port.OAuthUserProfile, error) {
 	return &port.OAuthUserProfile{
-		ID:       "9e0dc099-0df4-436f-b258-004ea10a6234",
-		Email:    "oauth_user@example.com",
-		FullName: "OAuth User",
+		ID:            "9e0dc099-0df4-436f-b258-004ea10a6234",
+		Email:         "oauth_user@example.com",
+		FullName:      "OAuth User",
+		EmailVerified: true,
 	}, nil
 }
 

--- a/internal/auth/application/command/oauth_login.go
+++ b/internal/auth/application/command/oauth_login.go
@@ -100,6 +100,9 @@ func (h *OAuthLoginHandler) Handle(ctx context.Context, cmd OAuthLoginCommand) (
 				return fmt.Errorf("find user by email: %w", findErr)
 			}
 			if findErr == nil && existingUser != nil {
+				if !profile.EmailVerified {
+					return fmt.Errorf("cannot link social account: email %s is not verified by provider %s", profile.Email, cmd.Provider)
+				}
 				user = existingUser
 				if cmd.Provider == "google" {
 					user.LinkGoogle(profile.ID)

--- a/internal/auth/application/command/oauth_login_test.go
+++ b/internal/auth/application/command/oauth_login_test.go
@@ -266,3 +266,57 @@ func TestOAuthLoginHandler_FindBySocialID_DBError(t *testing.T) {
 		t.Errorf("got error %v, want error containing 'find user by social id'", err)
 	}
 }
+
+type mockUnverifiedOAuthService struct {
+	mockOAuthService
+}
+
+func (mockUnverifiedOAuthService) ExchangeCodeForProfile(ctx context.Context, provider string, code string, redirectURI string) (*port.OAuthUserProfile, error) {
+	return &port.OAuthUserProfile{
+		ID:            "unverified-social-id",
+		Email:         "existing@example.com",
+		FullName:      "Unverified User",
+		EmailVerified: false,
+	}, nil
+}
+
+func TestOAuthLoginHandler_UnverifiedEmail_LinkRejected(t *testing.T) {
+	ctx := context.Background()
+
+	existingUser, _ := aggregate.RegisterUser("11111111-1111-1111-1111-111111111111", "existing@example.com", "Existing User", "user")
+	userRepo := &mockUserRepo{
+		users: map[string]*aggregate.User{
+			existingUser.ID(): existingUser,
+		},
+	}
+	key := &port.JWKRecord{
+		ID:        "active-kid",
+		Status:    port.KeyStatusActive,
+		CreatedAt: time.Now(),
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	keyRepo := &mockKeyRepo{keys: []*port.JWKRecord{key}}
+	sessRepo := &mockSessionRepo{sessions: make(map[string]*port.SessionRecord)}
+
+	handler := NewOAuthLoginHandler(
+		userRepo,
+		keyRepo,
+		sessRepo,
+		mockTokenService{},
+		mockUnverifiedOAuthService{},
+		&mockEventPublisher{},
+		&mockTxManager{},
+	)
+
+	_, _, _, err := handler.Handle(ctx, OAuthLoginCommand{
+		Provider: "google",
+		Code:     "valid_code",
+	})
+
+	if err == nil {
+		t.Fatal("expected error when attempting to link account with unverified social email, got nil")
+	}
+	if !strings.Contains(err.Error(), "is not verified by provider") {
+		t.Errorf("got error %v, want error containing 'is not verified by provider'", err)
+	}
+}

--- a/internal/auth/application/port/oauth_service.go
+++ b/internal/auth/application/port/oauth_service.go
@@ -4,10 +4,11 @@ import "context"
 
 // OAuthUserProfile represents user profile information retrieved from Google/Facebook.
 type OAuthUserProfile struct {
-	ID        string
-	Email     string
-	FullName  string
-	AvatarURL string
+	ID            string
+	Email         string
+	FullName      string
+	AvatarURL     string
+	EmailVerified bool
 }
 
 // OAuthService defines the application port for communicating with Google and Facebook OAuth APIs.

--- a/internal/auth/application/port/outbox_repository.go
+++ b/internal/auth/application/port/outbox_repository.go
@@ -16,5 +16,5 @@ type OutboxRepository interface {
 	SaveEvent(ctx context.Context, eventID string, eventType string, payload []byte, partitionKey string) error
 	FetchUnpublished(ctx context.Context, limit int) ([]*OutboxRecord, error)
 	MarkPublished(ctx context.Context, ids []string) error
-	ExecuteInLock(ctx context.Context, lockID int64, fn func(ctx context.Context) error) error
+	ProcessBatch(ctx context.Context, limit int, publishFn func(ctx context.Context, records []*OutboxRecord) error) error
 }

--- a/internal/auth/infrastructure/oauth/provider.go
+++ b/internal/auth/infrastructure/oauth/provider.go
@@ -165,18 +165,23 @@ func (p *OAuthProvider) exchangeGoogle(ctx context.Context, code string, redirec
 	}
 
 	var profileResp struct {
-		ID    string `json:"id"`
-		Email string `json:"email"`
-		Name  string `json:"name"`
+		ID            string `json:"id"`
+		Email         string `json:"email"`
+		VerifiedEmail bool   `json:"verified_email"`
+		EmailVerified bool   `json:"email_verified"`
+		Name          string `json:"name"`
 	}
 	if err := json.NewDecoder(respProf.Body).Decode(&profileResp); err != nil {
 		return nil, fmt.Errorf("decode profile response: %w", err)
 	}
 
+	isVerified := profileResp.VerifiedEmail || profileResp.EmailVerified
+
 	return &port.OAuthUserProfile{
-		ID:       profileResp.ID,
-		Email:    profileResp.Email,
-		FullName: profileResp.Name,
+		ID:            profileResp.ID,
+		Email:         profileResp.Email,
+		FullName:      profileResp.Name,
+		EmailVerified: isVerified,
 	}, nil
 }
 
@@ -261,9 +266,13 @@ func (p *OAuthProvider) exchangeFacebook(ctx context.Context, code string, redir
 		return nil, fmt.Errorf("decode facebook profile response: %w", err)
 	}
 
+	// Facebook Graph API only exposes non-empty `email` when confirmed/verified by user
+	isVerified := profileResp.Email != ""
+
 	return &port.OAuthUserProfile{
-		ID:       profileResp.ID,
-		Email:    profileResp.Email,
-		FullName: profileResp.Name,
+		ID:            profileResp.ID,
+		Email:         profileResp.Email,
+		FullName:      profileResp.Name,
+		EmailVerified: isVerified,
 	}, nil
 }

--- a/internal/auth/infrastructure/persistence/postgres/key_repository.go
+++ b/internal/auth/infrastructure/persistence/postgres/key_repository.go
@@ -26,7 +26,7 @@ func NewKeyRepository(db *gorm.DB) *KeyRepository {
 
 func (r *KeyRepository) getDB(ctx context.Context) *gorm.DB {
 	if tx := GetTx(ctx); tx != nil {
-		return tx
+		return tx.WithContext(ctx)
 	}
 	return r.db.WithContext(ctx)
 }

--- a/internal/auth/infrastructure/persistence/postgres/models.go
+++ b/internal/auth/infrastructure/persistence/postgres/models.go
@@ -105,7 +105,7 @@ func (m *JSONWebKeyModel) ToRepositoryRecord() *port.JWKRecord {
 // SessionModel is the GORM model mapping to auth.sessions table.
 type SessionModel struct {
 	Token     string    `gorm:"primaryKey;column:token"`
-	UserID    string    `gorm:"column:user_id;not null"`
+	UserID    string    `gorm:"column:user_id;not null;index:idx_sessions_user_id"`
 	CreatedAt time.Time `gorm:"column:created_at"`
 	ExpiresAt time.Time `gorm:"column:expires_at"`
 }
@@ -130,8 +130,8 @@ type OutboxModel struct {
 	EventType    string       `gorm:"column:event_type;not null"`
 	Payload      []byte       `gorm:"column:payload;not null;type:jsonb"`
 	PartitionKey string       `gorm:"column:partition_key;not null"`
-	CreatedAt    time.Time    `gorm:"column:created_at"`
-	Published    bool         `gorm:"column:published;default:false"`
+	CreatedAt    time.Time    `gorm:"column:created_at;index:idx_outbox_published_created,priority:2"`
+	Published    bool         `gorm:"column:published;default:false;index:idx_outbox_published_created,priority:1"`
 	PublishedAt  sql.NullTime `gorm:"column:published_at"`
 }
 

--- a/internal/auth/infrastructure/persistence/postgres/outbox_repository.go
+++ b/internal/auth/infrastructure/persistence/postgres/outbox_repository.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/viethung213/gym-companion/internal/auth/application/port"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // OutboxRepository implements port.OutboxRepository using GORM over PostgreSQL.
@@ -25,7 +26,7 @@ func NewOutboxRepository(db *gorm.DB) *OutboxRepository {
 
 func (r *OutboxRepository) getDB(ctx context.Context) *gorm.DB {
 	if tx := GetTx(ctx); tx != nil {
-		return tx
+		return tx.WithContext(ctx)
 	}
 	return r.db.WithContext(ctx)
 }
@@ -89,25 +90,63 @@ func (r *OutboxRepository) MarkPublished(ctx context.Context, ids []string) erro
 	return nil
 }
 
-// ExecuteInLock executes the provided function within a database transaction
-// guarded by a PostgreSQL Advisory Lock.
-func (r *OutboxRepository) ExecuteInLock(
+// ProcessBatch fetches unpublished outbox events using FOR UPDATE SKIP LOCKED,
+// publishes them via publishFn, and marks them as published in a single transaction.
+func (r *OutboxRepository) ProcessBatch(
 	ctx context.Context,
-	lockID int64,
-	fn func(ctx context.Context) error,
+	limit int,
+	publishFn func(ctx context.Context, records []*port.OutboxRecord) error,
 ) error {
+	if limit <= 0 {
+		limit = 100
+	}
+
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var acquired bool
-		err := tx.Raw("SELECT pg_try_advisory_xact_lock(?)", lockID).Scan(&acquired).Error
+		var dbOutboxes []OutboxModel
+		err := tx.
+			Clauses(clause.Locking{
+				Strength: "UPDATE",
+				Options:  "SKIP LOCKED",
+			}).
+			Where("published = ?", false).
+			Order("created_at ASC").
+			Limit(limit).
+			Find(&dbOutboxes).
+			Error
+
 		if err != nil {
-			return fmt.Errorf("try advisory lock: %w", err)
+			return fmt.Errorf("gorm fetch outbox for update skip locked: %w", err)
 		}
-		if !acquired {
-			// Lock not acquired, silently return nil to skip this processing iteration
+
+		if len(dbOutboxes) == 0 {
 			return nil
 		}
 
+		records := make([]*port.OutboxRecord, len(dbOutboxes))
+		ids := make([]string, len(dbOutboxes))
+		for i, o := range dbOutboxes {
+			records[i] = o.ToRepositoryRecord()
+			ids[i] = o.ID
+		}
+
 		txCtx := WithTx(ctx, tx)
-		return fn(txCtx)
+		if err := publishFn(txCtx, records); err != nil {
+			return fmt.Errorf("publish outbox batch: %w", err)
+		}
+
+		now := time.Now()
+		err = tx.Model(&OutboxModel{}).
+			Where("id IN ?", ids).
+			Updates(map[string]interface{}{
+				"published":    true,
+				"published_at": now,
+			}).
+			Error
+
+		if err != nil {
+			return fmt.Errorf("gorm mark outbox events published: %w", err)
+		}
+
+		return nil
 	})
 }

--- a/internal/auth/infrastructure/persistence/postgres/outbox_repository.go
+++ b/internal/auth/infrastructure/persistence/postgres/outbox_repository.go
@@ -130,8 +130,8 @@ func (r *OutboxRepository) ProcessBatch(
 		}
 
 		txCtx := WithTx(ctx, tx)
-		if err := publishFn(txCtx, records); err != nil {
-			return fmt.Errorf("publish outbox batch: %w", err)
+		if pubErr := publishFn(txCtx, records); pubErr != nil {
+			return fmt.Errorf("publish outbox batch: %w", pubErr)
 		}
 
 		now := time.Now()

--- a/internal/auth/infrastructure/persistence/postgres/session_repository.go
+++ b/internal/auth/infrastructure/persistence/postgres/session_repository.go
@@ -29,7 +29,7 @@ func NewSessionRepository(db *gorm.DB) *SessionRepository {
 
 func (r *SessionRepository) getDB(ctx context.Context) *gorm.DB {
 	if tx := GetTx(ctx); tx != nil {
-		return tx
+		return tx.WithContext(ctx)
 	}
 	return r.db.WithContext(ctx)
 }

--- a/internal/auth/infrastructure/persistence/postgres/user_repository.go
+++ b/internal/auth/infrastructure/persistence/postgres/user_repository.go
@@ -26,7 +26,7 @@ func NewUserRepository(db *gorm.DB) *UserRepository {
 
 func (r *UserRepository) getDB(ctx context.Context) *gorm.DB {
 	if tx := GetTx(ctx); tx != nil {
-		return tx
+		return tx.WithContext(ctx)
 	}
 	return r.db.WithContext(ctx)
 }

--- a/internal/auth/infrastructure/transport/grpc/handler.go
+++ b/internal/auth/infrastructure/transport/grpc/handler.go
@@ -3,7 +3,6 @@ package grpc
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/viethung213/gym-companion/internal/auth/application/apperror"
@@ -13,7 +12,6 @@ import (
 	authv1service "github.com/viethung213/gym-companion/internal/gen/go/contracts/generic/auth/v1/service"
 	"github.com/viethung213/gym-companion/internal/shared/middleware"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -76,7 +74,8 @@ type contextKey string
 const userIDContextKey contextKey = "userId"
 
 func extractUserID(ctx context.Context) (string, error) {
-	// 1. Try standard context key (camelCase) set by middleware later
+	// Only extract UserID from verified context keys populated by Authentication Interceptor/Middleware.
+	// Metadata headers (e.g. x-user-id) from unverified incoming requests are strictly ignored to prevent impersonation attacks.
 	if val, ok := ctx.Value(middleware.UserIDKey).(string); ok && val != "" {
 		return val, nil
 	}
@@ -87,20 +86,7 @@ func extractUserID(ctx context.Context) (string, error) {
 		return val, nil
 	}
 
-	// 2. Fallback to gRPC metadata
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return "", errors.New("missing request metadata")
-	}
-
-	metadataKeys := []string{"x-user-id", "user-id", "grpcgateway-x-user-id", "grpcgateway-user-id"}
-	for _, key := range metadataKeys {
-		if val := md.Get(key); len(val) > 0 && val[0] != "" {
-			return val[0], nil
-		}
-	}
-
-	return "", errors.New("missing user identity in context or metadata")
+	return "", errors.New("missing verified user identity in context")
 }
 
 // Logout revokes a user's session token.
@@ -110,10 +96,7 @@ func (h *GRPCHandler) Logout(
 ) (*authv1message.LogoutResponse, error) {
 	userID, err := extractUserID(ctx)
 	if err != nil {
-		return &authv1message.LogoutResponse{
-			Success: false,
-			Message: fmt.Sprintf("failed to logout: %v", err),
-		}, nil
+		return nil, status.Errorf(codes.Unauthenticated, "unauthorized: %v", err)
 	}
 
 	err = h.logoutHandler.Handle(ctx, command.LogoutCommand{
@@ -121,10 +104,13 @@ func (h *GRPCHandler) Logout(
 		UserID:       userID,
 	})
 	if err != nil {
-		return &authv1message.LogoutResponse{
-			Success: false,
-			Message: fmt.Sprintf("failed to logout: %v", err),
-		}, nil
+		if errors.Is(err, apperror.ErrUnauthorized) {
+			return &authv1message.LogoutResponse{
+				Success: false,
+				Message: "unauthorized: session does not belong to user",
+			}, nil
+		}
+		return nil, status.Errorf(codes.Internal, "failed to logout: %v", err)
 	}
 
 	return &authv1message.LogoutResponse{

--- a/internal/auth/infrastructure/worker/worker.go
+++ b/internal/auth/infrastructure/worker/worker.go
@@ -50,45 +50,12 @@ func (w *OutboxWorker) Start(ctx context.Context) {
 }
 
 func (w *OutboxWorker) processOutbox(ctx context.Context) error {
-	var events []*port.OutboxRecord
-
-	// 1. Fetch unpublished events (max 500) inside a transaction with an Advisory Lock
-	err := w.outboxRepo.ExecuteInLock(ctx, 11223344, func(txCtx context.Context) error {
-		var err error
-		events, err = w.outboxRepo.FetchUnpublished(txCtx, 500)
-		if err != nil {
-			return err
+	return w.outboxRepo.ProcessBatch(ctx, 500, func(publishCtx context.Context, events []*port.OutboxRecord) error {
+		log.Printf("Outbox worker: found %d unpublished events to process.", len(events))
+		if err := w.publisher.PublishBatch(publishCtx, events); err != nil {
+			return fmt.Errorf("publish batch failed: %w", err)
 		}
+		log.Printf("Outbox worker: successfully published batch of %d events.", len(events))
 		return nil
 	})
-	if err != nil {
-		return err
-	}
-
-	if len(events) == 0 {
-		return nil
-	}
-
-	log.Printf("Outbox worker: found %d unpublished events to process.", len(events))
-
-	// 2. Batch publish to Kafka (OUTSIDE DB transaction, using parent context)
-	err = w.publisher.PublishBatch(ctx, events)
-	if err != nil {
-		return fmt.Errorf("publish batch failed: %w", err)
-	}
-
-	// 3. Batch mark as published in the database inside another transaction
-	ids := make([]string, len(events))
-	for i, ev := range events {
-		ids[i] = ev.ID
-	}
-	err = w.outboxRepo.ExecuteInLock(ctx, 11223344, func(txCtx context.Context) error {
-		return w.outboxRepo.MarkPublished(txCtx, ids)
-	})
-	if err != nil {
-		return fmt.Errorf("mark batch published failed: %w", err)
-	}
-
-	log.Printf("Outbox worker: successfully published batch of %d events.", len(events))
-	return nil
 }

--- a/internal/auth/infrastructure/worker/worker_test.go
+++ b/internal/auth/infrastructure/worker/worker_test.go
@@ -57,8 +57,26 @@ func (m *mockOutboxRepository) MarkPublished(ctx context.Context, ids []string) 
 	return nil
 }
 
-func (m *mockOutboxRepository) ExecuteInLock(ctx context.Context, lockID int64, fn func(ctx context.Context) error) error {
-	return fn(ctx)
+func (m *mockOutboxRepository) ProcessBatch(
+	ctx context.Context,
+	limit int,
+	publishFn func(ctx context.Context, records []*port.OutboxRecord) error,
+) error {
+	unpublished, err := m.FetchUnpublished(ctx, limit)
+	if err != nil {
+		return err
+	}
+	if len(unpublished) == 0 {
+		return nil
+	}
+	if err := publishFn(ctx, unpublished); err != nil {
+		return err
+	}
+	ids := make([]string, len(unpublished))
+	for i, u := range unpublished {
+		ids[i] = u.ID
+	}
+	return m.MarkPublished(ctx, ids)
 }
 
 type mockEventPublisher struct {

--- a/internal/auth/tests/e2e/testutil.go
+++ b/internal/auth/tests/e2e/testutil.go
@@ -18,8 +18,10 @@ import (
 	"github.com/viethung213/gym-companion/internal/auth"
 	"github.com/viethung213/gym-companion/internal/shared/database"
 	sharedKafka "github.com/viethung213/gym-companion/internal/shared/kafka"
+	"github.com/viethung213/gym-companion/internal/shared/middleware"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
@@ -84,7 +86,24 @@ func startE2ETestServer(t *testing.T) (string, *gorm.DB, func()) {
 		t.Fatalf("Failed to listen on free port for gRPC: %v", err)
 	}
 	grpcAddr := grpcListener.Addr().String()
-	grpcServer := grpc.NewServer()
+
+	testAuthInterceptor := func(
+		ctx context.Context,
+		req any,
+		_ *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (any, error) {
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			if vals := md.Get("x-user-id"); len(vals) > 0 && vals[0] != "" {
+				ctx = context.WithValue(ctx, middleware.UserIDKey, vals[0])
+			}
+			if vals := md.Get("x-user-role"); len(vals) > 0 && vals[0] != "" {
+				ctx = context.WithValue(ctx, middleware.UserRoleKey, vals[0])
+			}
+		}
+		return handler(ctx, req)
+	}
+	grpcServer := grpc.NewServer(grpc.UnaryInterceptor(testAuthInterceptor))
 
 	// 3. Start HTTP Gateway on free port
 	httpListener, err := net.Listen("tcp", "127.0.0.1:0")

--- a/internal/auth/tests/integration/repository_test.go
+++ b/internal/auth/tests/integration/repository_test.go
@@ -4,6 +4,8 @@ package integration
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -277,21 +279,94 @@ func TestOutboxRepository_Integration(t *testing.T) {
 	}
 }
 
-func TestOutboxRepository_ExecuteInLock_Integration(t *testing.T) {
+func TestOutboxRepository_ProcessBatch_Integration(t *testing.T) {
 	db := getTestDB(t)
 	repo := infraPostgres.NewOutboxRepository(db)
 	ctx := context.Background()
 
-	var count int
-	err := repo.ExecuteInLock(ctx, 99887766, func(txCtx context.Context) error {
-		count++
+	eventID := uuid.New().String()
+	_ = repo.SaveEvent(ctx, eventID, "test.batch", []byte(`{}`), "key")
+
+	var processedCount int
+	err := repo.ProcessBatch(ctx, 10, func(txCtx context.Context, records []*port.OutboxRecord) error {
+		processedCount = len(records)
 		return nil
 	})
 	if err != nil {
-		t.Fatalf("Failed to execute in lock: %v", err)
+		t.Fatalf("Failed to process batch: %v", err)
 	}
-	if count != 1 {
-		t.Errorf("Expected count to be 1, got %d", count)
+	if processedCount != 1 {
+		t.Errorf("Expected processedCount to be 1, got %d", processedCount)
+	}
+}
+
+func TestOutboxRepository_ConcurrentWorkers_Integration(t *testing.T) {
+	db := getTestDB(t)
+	truncateTables(db)
+	defer truncateTables(db)
+
+	repo := infraPostgres.NewOutboxRepository(db)
+	ctx := context.Background()
+
+	const totalRecords = 20
+	const batchLimit = 10
+
+	for i := 0; i < totalRecords; i++ {
+		eventID := uuid.New().String()
+		if err := repo.SaveEvent(ctx, eventID, "test.concurrent", []byte(`{}`), fmt.Sprintf("key-%d", i)); err != nil {
+			t.Fatalf("Failed to seed outbox record %d: %v", i, err)
+		}
+	}
+
+	var mu sync.Mutex
+	processedIDs := make(map[string]int)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Worker 1: fetches batch of 10, holds transaction lock for 100ms before committing
+	go func() {
+		defer wg.Done()
+		_ = repo.ProcessBatch(ctx, batchLimit, func(txCtx context.Context, records []*port.OutboxRecord) error {
+			mu.Lock()
+			for _, r := range records {
+				processedIDs[r.ID]++
+			}
+			mu.Unlock()
+			time.Sleep(100 * time.Millisecond)
+			return nil
+		})
+	}()
+
+	// Small sleep so Worker 1 enters ProcessBatch first and locks rows 1..10
+	time.Sleep(20 * time.Millisecond)
+
+	// Worker 2: calls ProcessBatch while Worker 1 is holding locks on rows 1..10
+	go func() {
+		defer wg.Done()
+		_ = repo.ProcessBatch(ctx, batchLimit, func(txCtx context.Context, records []*port.OutboxRecord) error {
+			mu.Lock()
+			for _, r := range records {
+				processedIDs[r.ID]++
+			}
+			mu.Unlock()
+			return nil
+		})
+	}()
+
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(processedIDs) != totalRecords {
+		t.Errorf("Expected %d total unique records processed concurrently, got %d", totalRecords, len(processedIDs))
+	}
+
+	for id, count := range processedIDs {
+		if count > 1 {
+			t.Errorf("Record %s was processed %d times (expected exactly 1)", id, count)
+		}
 	}
 }
 

--- a/internal/coaching/application/port/ports.go
+++ b/internal/coaching/application/port/ports.go
@@ -55,7 +55,7 @@ type OutboxRepository interface {
 	Save(ctx context.Context, record *OutboxRecord) error
 	FetchUnpublished(ctx context.Context, limit int) ([]*OutboxRecord, error)
 	MarkPublished(ctx context.Context, ids []string) error
-	ExecuteInLock(ctx context.Context, lockID int64, fn func(txCtx context.Context) error) error
+	ProcessBatch(ctx context.Context, limit int, publishFn func(ctx context.Context, records []*OutboxRecord) error) error
 	// LogProcessed records that an inbound event has been consumed (D9 idempotency).
 	// Returns (true, nil) if this is a new event that was recorded, (false, nil) if
 	// the event_id was already present (duplicate delivery), or an error.

--- a/internal/coaching/infrastructure/event/outbox_writer_test.go
+++ b/internal/coaching/infrastructure/event/outbox_writer_test.go
@@ -25,8 +25,8 @@ func (s *stubOutbox) FetchUnpublished(context.Context, int) ([]*port.OutboxRecor
 }
 
 func (s *stubOutbox) MarkPublished(context.Context, []string) error { return nil }
-func (s *stubOutbox) ExecuteInLock(ctx context.Context, _ int64, fn func(context.Context) error) error {
-	return fn(ctx)
+func (s *stubOutbox) ProcessBatch(ctx context.Context, _ int, publishFn func(context.Context, []*port.OutboxRecord) error) error {
+	return publishFn(ctx, s.records)
 }
 
 func (s *stubOutbox) LogProcessed(context.Context, string, string, string, []byte) (bool, error) {

--- a/internal/coaching/infrastructure/persistence/outbox_repository.go
+++ b/internal/coaching/infrastructure/persistence/outbox_repository.go
@@ -115,20 +115,77 @@ func (r *OutboxRepository) MarkPublished(ctx context.Context, ids []string) erro
 	return nil
 }
 
-// ExecuteInLock wraps fn in a transaction guarded by pg_try_advisory_xact_lock.
-func (r *OutboxRepository) ExecuteInLock(ctx context.Context, lockID int64, fn func(txCtx context.Context) error) error {
+// ProcessBatch fetches unpublished outbox events using FOR UPDATE SKIP LOCKED,
+// publishes them via publishFn, and marks them as published in a single transaction.
+func (r *OutboxRepository) ProcessBatch(
+	ctx context.Context,
+	limit int,
+	publishFn func(ctx context.Context, records []*port.OutboxRecord) error,
+) error {
+	if limit <= 0 {
+		limit = 100
+	}
+
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var acquired bool
+		var dbOutboxes []outboxRecord
+		err := tx.
+			Clauses(clause.Locking{
+				Strength: "UPDATE",
+				Options:  "SKIP LOCKED",
+			}).
+			Where("published = ?", false).
+			Order("created_at ASC").
+			Limit(limit).
+			Find(&dbOutboxes).
+			Error
 
-		if err := tx.Raw("SELECT pg_try_advisory_xact_lock(?)", lockID).Scan(&acquired).Error; err != nil {
-			return fmt.Errorf("try advisory lock: %w", err)
+		if err != nil {
+			return fmt.Errorf("fetch outbox for update skip locked: %w", err)
 		}
 
-		if !acquired {
-			return nil // Skip; another worker holds it.
+		if len(dbOutboxes) == 0 {
+			return nil
 		}
 
-		return fn(WithTx(ctx, tx))
+		records := make([]*port.OutboxRecord, len(dbOutboxes))
+		ids := make([]string, len(dbOutboxes))
+		for i, rec := range dbOutboxes {
+			var pubAt *time.Time
+			if rec.PublishedAt.Valid {
+				pubAt = &rec.PublishedAt.Time
+			}
+			records[i] = &port.OutboxRecord{
+				ID:           rec.ID,
+				EventID:      rec.EventID,
+				EventType:    rec.EventType,
+				Payload:      rec.Payload,
+				PartitionKey: rec.PartitionKey,
+				CreatedAt:    rec.CreatedAt,
+				Published:    rec.Published,
+				PublishedAt:  pubAt,
+			}
+			ids[i] = rec.ID
+		}
+
+		txCtx := WithTx(ctx, tx)
+		if err := publishFn(txCtx, records); err != nil {
+			return fmt.Errorf("publish outbox batch: %w", err)
+		}
+
+		now := time.Now()
+		err = tx.Model(&outboxRecord{}).
+			Where("id IN ?", ids).
+			Updates(map[string]any{
+				"published":    true,
+				"published_at": now,
+			}).
+			Error
+
+		if err != nil {
+			return fmt.Errorf("mark published: %w", err)
+		}
+
+		return nil
 	})
 }
 

--- a/internal/coaching/infrastructure/persistence/outbox_repository.go
+++ b/internal/coaching/infrastructure/persistence/outbox_repository.go
@@ -149,7 +149,8 @@ func (r *OutboxRepository) ProcessBatch(
 
 		records := make([]*port.OutboxRecord, len(dbOutboxes))
 		ids := make([]string, len(dbOutboxes))
-		for i, rec := range dbOutboxes {
+		for i := range dbOutboxes {
+			rec := &dbOutboxes[i]
 			var pubAt *time.Time
 			if rec.PublishedAt.Valid {
 				pubAt = &rec.PublishedAt.Time
@@ -168,8 +169,8 @@ func (r *OutboxRepository) ProcessBatch(
 		}
 
 		txCtx := WithTx(ctx, tx)
-		if err := publishFn(txCtx, records); err != nil {
-			return fmt.Errorf("publish outbox batch: %w", err)
+		if pubErr := publishFn(txCtx, records); pubErr != nil {
+			return fmt.Errorf("publish outbox batch: %w", pubErr)
 		}
 
 		now := time.Now()

--- a/internal/coaching/infrastructure/worker/outbox_worker.go
+++ b/internal/coaching/infrastructure/worker/outbox_worker.go
@@ -56,37 +56,12 @@ func (w *OutboxWorker) Start(ctx context.Context) {
 }
 
 func (w *OutboxWorker) tick(ctx context.Context) error {
-	var records []*port.OutboxRecord
-
-	err := w.outbox.ExecuteInLock(ctx, LockID, func(txCtx context.Context) error {
-		var e error
-
-		records, e = w.outbox.FetchUnpublished(txCtx, w.batchSize)
-
-		return e
-	})
-
-	if err != nil {
-		return fmt.Errorf("fetch unpublished: %w", err)
-	}
-
-	if len(records) == 0 {
-		return nil
-	}
-
-	if w.publisher != nil {
-		if err := w.publisher.PublishBatch(ctx, records); err != nil {
-			return fmt.Errorf("publish batch: %w", err)
+	return w.outbox.ProcessBatch(ctx, w.batchSize, func(publishCtx context.Context, records []*port.OutboxRecord) error {
+		if w.publisher != nil {
+			if err := w.publisher.PublishBatch(publishCtx, records); err != nil {
+				return fmt.Errorf("publish batch: %w", err)
+			}
 		}
-	}
-
-	ids := make([]string, 0, len(records))
-
-	for _, r := range records {
-		ids = append(ids, r.ID)
-	}
-
-	return w.outbox.ExecuteInLock(ctx, LockID, func(txCtx context.Context) error {
-		return w.outbox.MarkPublished(txCtx, ids)
+		return nil
 	})
 }

--- a/internal/coaching/transport/consumer/workout_execution_consumer_test.go
+++ b/internal/coaching/transport/consumer/workout_execution_consumer_test.go
@@ -18,8 +18,8 @@ func (s *stubOutbox) FetchUnpublished(context.Context, int) ([]*port.OutboxRecor
 }
 
 func (s *stubOutbox) MarkPublished(context.Context, []string) error { return nil }
-func (s *stubOutbox) ExecuteInLock(ctx context.Context, _ int64, fn func(context.Context) error) error {
-	return fn(ctx)
+func (s *stubOutbox) ProcessBatch(ctx context.Context, _ int, publishFn func(context.Context, []*port.OutboxRecord) error) error {
+	return publishFn(ctx, nil)
 }
 
 func (s *stubOutbox) LogProcessed(_ context.Context, eventID, _, _ string, _ []byte) (bool, error) {

--- a/internal/exercise/application/port/ports.go
+++ b/internal/exercise/application/port/ports.go
@@ -103,7 +103,7 @@ type OutboxRecord struct {
 type OutboxRepository interface {
 	FetchUnpublished(ctx context.Context, limit int) ([]*OutboxRecord, error)
 	MarkPublished(ctx context.Context, ids []string) error
-	ExecuteInLock(ctx context.Context, lockID int64, fn func(ctx context.Context) error) error
+	ProcessBatch(ctx context.Context, limit int, publishFn func(ctx context.Context, records []*OutboxRecord) error) error
 }
 
 // BrokerPublisher is the port for publishing outbox events to a broker.

--- a/internal/exercise/infrastructure/persistence/outbox_repository.go
+++ b/internal/exercise/infrastructure/persistence/outbox_repository.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/viethung213/gym-companion/internal/exercise/application/port"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type OutboxRepository struct {
@@ -75,22 +76,68 @@ func (r *OutboxRepository) MarkPublished(ctx context.Context, ids []string) erro
 	return nil
 }
 
-func (r *OutboxRepository) ExecuteInLock(
+func (r *OutboxRepository) ProcessBatch(
 	ctx context.Context,
-	lockID int64,
-	fn func(ctx context.Context) error,
+	limit int,
+	publishFn func(ctx context.Context, records []*port.OutboxRecord) error,
 ) error {
+	if limit <= 0 {
+		limit = 100
+	}
+
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var acquired bool
-		err := tx.Raw("SELECT pg_try_advisory_xact_lock(?)", lockID).Scan(&acquired).Error
+		var records []outboxRecord
+		err := tx.
+			Clauses(clause.Locking{
+				Strength: "UPDATE",
+				Options:  "SKIP LOCKED",
+			}).
+			Where("published = ?", false).
+			Order("created_at ASC").
+			Limit(limit).
+			Find(&records).
+			Error
+
 		if err != nil {
-			return fmt.Errorf("try advisory lock: %w", err)
+			return fmt.Errorf("gorm fetch outbox for update skip locked: %w", err)
 		}
-		if !acquired {
+
+		if len(records) == 0 {
 			return nil
 		}
 
+		results := make([]*port.OutboxRecord, len(records))
+		ids := make([]string, len(records))
+		for i := range records {
+			rec := &records[i]
+			results[i] = &port.OutboxRecord{
+				ID:           rec.ID,
+				EventID:      rec.EventID,
+				EventType:    rec.EventType,
+				Payload:      rec.Payload,
+				PartitionKey: rec.PartitionKey,
+			}
+			ids[i] = rec.ID
+		}
+
 		txCtx := WithTx(ctx, tx)
-		return fn(txCtx)
+		if err := publishFn(txCtx, results); err != nil {
+			return fmt.Errorf("publish outbox batch: %w", err)
+		}
+
+		now := time.Now()
+		err = tx.Model(&outboxRecord{}).
+			Where("id IN ?", ids).
+			Updates(map[string]interface{}{
+				"published":    true,
+				"published_at": now,
+			}).
+			Error
+
+		if err != nil {
+			return fmt.Errorf("gorm mark outbox events published: %w", err)
+		}
+
+		return nil
 	})
 }

--- a/internal/exercise/infrastructure/persistence/outbox_repository.go
+++ b/internal/exercise/infrastructure/persistence/outbox_repository.go
@@ -121,8 +121,8 @@ func (r *OutboxRepository) ProcessBatch(
 		}
 
 		txCtx := WithTx(ctx, tx)
-		if err := publishFn(txCtx, results); err != nil {
-			return fmt.Errorf("publish outbox batch: %w", err)
+		if pubErr := publishFn(txCtx, results); pubErr != nil {
+			return fmt.Errorf("publish outbox batch: %w", pubErr)
 		}
 
 		now := time.Now()

--- a/internal/exercise/infrastructure/worker/worker.go
+++ b/internal/exercise/infrastructure/worker/worker.go
@@ -47,45 +47,12 @@ func (w *OutboxWorker) Start(ctx context.Context) {
 }
 
 func (w *OutboxWorker) processOutbox(ctx context.Context) error {
-	var events []*port.OutboxRecord
-
-	// Fetch unpublished events (max 500) inside transaction with Advisory Lock (ID: 55667788)
-	err := w.outboxRepo.ExecuteInLock(ctx, 55667788, func(txCtx context.Context) error {
-		var err error
-		events, err = w.outboxRepo.FetchUnpublished(txCtx, 500)
-		if err != nil {
-			return err
+	return w.outboxRepo.ProcessBatch(ctx, 500, func(publishCtx context.Context, events []*port.OutboxRecord) error {
+		log.Printf("Exercise Outbox worker: found %d unpublished events to process.", len(events))
+		if err := w.publisher.PublishBatch(publishCtx, events); err != nil {
+			return fmt.Errorf("publish batch failed: %w", err)
 		}
+		log.Printf("Exercise Outbox worker: successfully published batch of %d events.", len(events))
 		return nil
 	})
-	if err != nil {
-		return err
-	}
-
-	if len(events) == 0 {
-		return nil
-	}
-
-	log.Printf("Exercise Outbox worker: found %d unpublished events to process.", len(events))
-
-	// Publish to Kafka (OUTSIDE DB transaction)
-	err = w.publisher.PublishBatch(ctx, events)
-	if err != nil {
-		return fmt.Errorf("publish batch failed: %w", err)
-	}
-
-	// Mark as published in another transaction
-	ids := make([]string, len(events))
-	for i, ev := range events {
-		ids[i] = ev.ID
-	}
-	err = w.outboxRepo.ExecuteInLock(ctx, 55667788, func(txCtx context.Context) error {
-		return w.outboxRepo.MarkPublished(txCtx, ids)
-	})
-	if err != nil {
-		return fmt.Errorf("mark batch published failed: %w", err)
-	}
-
-	log.Printf("Exercise Outbox worker: successfully published batch of %d events.", len(events))
-	return nil
 }

--- a/internal/profile/application/port/outbox_repository.go
+++ b/internal/profile/application/port/outbox_repository.go
@@ -14,4 +14,5 @@ type OutboxRepository interface {
 	Save(ctx context.Context, record *OutboxRecord) error
 	FetchUnpublished(ctx context.Context, limit int) ([]*OutboxRecord, error)
 	MarkAsPublished(ctx context.Context, ids []string) error
+	ProcessBatch(ctx context.Context, limit int, publishFn func(ctx context.Context, records []*OutboxRecord) error) error
 }

--- a/internal/profile/infrastructure/event/outbox_writer_test.go
+++ b/internal/profile/infrastructure/event/outbox_writer_test.go
@@ -38,6 +38,10 @@ func (m *mockOutboxRepo) MarkAsPublished(ctx context.Context, ids []string) erro
 	return nil
 }
 
+func (m *mockOutboxRepo) ProcessBatch(ctx context.Context, _ int, publishFn func(ctx context.Context, records []*port.OutboxRecord) error) error {
+	return publishFn(ctx, m.records)
+}
+
 func TestOutboxWriter(t *testing.T) {
 	repo := &mockOutboxRepo{}
 	writer := event.NewOutboxWriter(repo)

--- a/internal/profile/infrastructure/persistence/outbox_repository.go
+++ b/internal/profile/infrastructure/persistence/outbox_repository.go
@@ -128,8 +128,8 @@ func (r *GormOutboxRepository) ProcessBatch(
 		}
 
 		txCtx := context.WithValue(ctx, txKey{}, tx)
-		if err := publishFn(txCtx, records); err != nil {
-			return fmt.Errorf("publish outbox batch: %w", err)
+		if pubErr := publishFn(txCtx, records); pubErr != nil {
+			return fmt.Errorf("publish outbox batch: %w", pubErr)
 		}
 
 		now := time.Now()

--- a/internal/profile/infrastructure/persistence/outbox_repository.go
+++ b/internal/profile/infrastructure/persistence/outbox_repository.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/viethung213/gym-companion/internal/profile/application/port"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type GormOutboxRepository struct {
@@ -81,4 +82,69 @@ func (r *GormOutboxRepository) MarkAsPublished(ctx context.Context, ids []string
 		return fmt.Errorf("mark outbox records as published: %w", err)
 	}
 	return nil
+}
+
+func (r *GormOutboxRepository) ProcessBatch(
+	ctx context.Context,
+	limit int,
+	publishFn func(ctx context.Context, records []*port.OutboxRecord) error,
+) error {
+	if limit <= 0 {
+		limit = 100
+	}
+
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var models []*OutboxModel
+		err := tx.
+			Clauses(clause.Locking{
+				Strength: "UPDATE",
+				Options:  "SKIP LOCKED",
+			}).
+			Where("published = ?", false).
+			Order("created_at ASC").
+			Limit(limit).
+			Find(&models).
+			Error
+
+		if err != nil {
+			return fmt.Errorf("fetch unpublished outbox events for update: %w", err)
+		}
+
+		if len(models) == 0 {
+			return nil
+		}
+
+		records := make([]*port.OutboxRecord, 0, len(models))
+		ids := make([]string, 0, len(models))
+		for _, m := range models {
+			records = append(records, &port.OutboxRecord{
+				ID:           m.ID,
+				EventID:      m.EventID,
+				EventType:    m.EventType,
+				Payload:      m.Payload,
+				PartitionKey: m.PartitionKey,
+			})
+			ids = append(ids, m.ID)
+		}
+
+		txCtx := context.WithValue(ctx, txKey{}, tx)
+		if err := publishFn(txCtx, records); err != nil {
+			return fmt.Errorf("publish outbox batch: %w", err)
+		}
+
+		now := time.Now()
+		err = tx.Model(&OutboxModel{}).
+			Where("id IN ?", ids).
+			Updates(map[string]interface{}{
+				"published":    true,
+				"published_at": sql.NullTime{Time: now, Valid: true},
+			}).
+			Error
+
+		if err != nil {
+			return fmt.Errorf("mark outbox records as published: %w", err)
+		}
+
+		return nil
+	})
 }

--- a/internal/profile/infrastructure/worker/outbox_worker.go
+++ b/internal/profile/infrastructure/worker/outbox_worker.go
@@ -47,28 +47,11 @@ func (w *OutboxWorker) Start(ctx context.Context) {
 }
 
 func (w *OutboxWorker) processOutbox(ctx context.Context) error {
-	events, err := w.outboxRepo.FetchUnpublished(ctx, 100)
-	if err != nil {
-		return fmt.Errorf("fetch unpublished events: %w", err)
-	}
-
-	if len(events) == 0 {
+	return w.outboxRepo.ProcessBatch(ctx, 100, func(publishCtx context.Context, events []*port.OutboxRecord) error {
+		if err := w.publisher.PublishBatch(publishCtx, events); err != nil {
+			return fmt.Errorf("publish outbox batch to kafka: %w", err)
+		}
+		log.Printf("Profile Outbox worker: successfully published batch of %d events.", len(events))
 		return nil
-	}
-
-	if err := w.publisher.PublishBatch(ctx, events); err != nil {
-		return fmt.Errorf("publish outbox batch to kafka: %w", err)
-	}
-
-	ids := make([]string, len(events))
-	for i, ev := range events {
-		ids[i] = ev.ID
-	}
-
-	if err := w.outboxRepo.MarkAsPublished(ctx, ids); err != nil {
-		return fmt.Errorf("mark outbox events as published: %w", err)
-	}
-
-	log.Printf("Profile Outbox worker: successfully published batch of %d events.", len(events))
-	return nil
+	})
 }

--- a/internal/profile/infrastructure/worker/outbox_worker_test.go
+++ b/internal/profile/infrastructure/worker/outbox_worker_test.go
@@ -41,6 +41,28 @@ func (m *mockOutboxRepoForWorker) MarkAsPublished(ctx context.Context, ids []str
 	return nil
 }
 
+func (m *mockOutboxRepoForWorker) ProcessBatch(
+	ctx context.Context,
+	limit int,
+	publishFn func(ctx context.Context, records []*port.OutboxRecord) error,
+) error {
+	unpub, err := m.FetchUnpublished(ctx, limit)
+	if err != nil {
+		return err
+	}
+	if len(unpub) == 0 {
+		return nil
+	}
+	if err := publishFn(ctx, unpub); err != nil {
+		return err
+	}
+	ids := make([]string, len(unpub))
+	for i, r := range unpub {
+		ids[i] = r.ID
+	}
+	return m.MarkAsPublished(ctx, ids)
+}
+
 type mockBrokerPublisher struct {
 	publishedRecords []*port.OutboxRecord
 	failPub          bool

--- a/internal/workout_execution/application/port/outbox_repository.go
+++ b/internal/workout_execution/application/port/outbox_repository.go
@@ -38,7 +38,7 @@ type OutboxRepository interface {
 
 	MarkPublished(ctx context.Context, ids []string) error
 
-	ExecuteInLock(ctx context.Context, lockID int64, fn func(txCtx context.Context) error) error
+	ProcessBatch(ctx context.Context, limit int, publishFn func(ctx context.Context, records []*OutboxRecord) error) error
 }
 
 // BrokerPublisher sends serialized outbox events to Kafka.

--- a/internal/workout_execution/infrastructure/event/outbox_writer_test.go
+++ b/internal/workout_execution/infrastructure/event/outbox_writer_test.go
@@ -38,10 +38,8 @@ func (m *mockOutboxRepo) MarkPublished(ctx context.Context, ids []string) error 
 
 }
 
-func (m *mockOutboxRepo) ExecuteInLock(ctx context.Context, lockID int64, fn func(txCtx context.Context) error) error {
-
-	return nil
-
+func (m *mockOutboxRepo) ProcessBatch(ctx context.Context, limit int, publishFn func(txCtx context.Context, records []*port.OutboxRecord) error) error {
+	return publishFn(ctx, nil)
 }
 
 func TestOutboxWriter(t *testing.T) {

--- a/internal/workout_execution/infrastructure/persistence/postgres_repository.go
+++ b/internal/workout_execution/infrastructure/persistence/postgres_repository.go
@@ -437,8 +437,8 @@ func (r *PostgresOutboxRepository) ProcessBatch(
 		}
 
 		txCtx := WithTx(ctx, tx)
-		if err := publishFn(txCtx, res); err != nil {
-			return fmt.Errorf("publish outbox batch: %w", err)
+		if pubErr := publishFn(txCtx, res); pubErr != nil {
+			return fmt.Errorf("publish outbox batch: %w", pubErr)
 		}
 
 		now := time.Now().UTC()

--- a/internal/workout_execution/infrastructure/persistence/postgres_repository.go
+++ b/internal/workout_execution/infrastructure/persistence/postgres_repository.go
@@ -399,17 +399,62 @@ func (r *PostgresOutboxRepository) MarkPublished(ctx context.Context, ids []stri
 	}).Error
 }
 
-func (r *PostgresOutboxRepository) ExecuteInLock(ctx context.Context, lockID int64, fn func(txCtx context.Context) error) error {
+func (r *PostgresOutboxRepository) ProcessBatch(
+	ctx context.Context,
+	limit int,
+	publishFn func(ctx context.Context, records []*port.OutboxRecord) error,
+) error {
+	if limit <= 0 {
+		limit = 100
+	}
+
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var acquired bool
-		if err := tx.Raw("SELECT pg_try_advisory_xact_lock(?)", lockID).Scan(&acquired).Error; err != nil {
-			return err
+		var models []OutboxModel
+		err := tx.
+			Clauses(clause.Locking{
+				Strength: "UPDATE",
+				Options:  "SKIP LOCKED",
+			}).
+			Where("published = ?", false).
+			Order("created_at ASC").
+			Limit(limit).
+			Find(&models).
+			Error
+
+		if err != nil {
+			return fmt.Errorf("failed to fetch unpublished outbox events for update: %w", err)
 		}
-		if !acquired {
+
+		if len(models) == 0 {
 			return nil
 		}
+
+		res := make([]*port.OutboxRecord, len(models))
+		ids := make([]string, len(models))
+		for i, m := range models {
+			res[i] = OutboxToDomain(&m)
+			ids[i] = m.ID
+		}
+
 		txCtx := WithTx(ctx, tx)
-		return fn(txCtx)
+		if err := publishFn(txCtx, res); err != nil {
+			return fmt.Errorf("publish outbox batch: %w", err)
+		}
+
+		now := time.Now().UTC()
+		err = tx.Model(&OutboxModel{}).
+			Where("id IN ?", ids).
+			Updates(map[string]interface{}{
+				"published":    true,
+				"published_at": now,
+			}).
+			Error
+
+		if err != nil {
+			return fmt.Errorf("mark outbox published: %w", err)
+		}
+
+		return nil
 	})
 }
 

--- a/internal/workout_execution/infrastructure/persistence/postgres_repository_test.go
+++ b/internal/workout_execution/infrastructure/persistence/postgres_repository_test.go
@@ -363,12 +363,12 @@ func TestPostgresOutboxRepository_Integration(t *testing.T) {
 		t.Fatalf("MarkPublished failed: %v", err)
 	}
 
-	// Advisory Lock test
-	err = repo.ExecuteInLock(ctx, 99887766, func(txCtx context.Context) error {
+	// ProcessBatch test
+	err = repo.ProcessBatch(ctx, 10, func(txCtx context.Context, records []*port.OutboxRecord) error {
 		return nil
 	})
 	if err != nil {
-		t.Fatalf("ExecuteInLock failed: %v", err)
+		t.Fatalf("ProcessBatch failed: %v", err)
 	}
 }
 
@@ -481,18 +481,11 @@ func TestPostgresRepository_CanceledContextAndLockConflict(t *testing.T) {
 		t.Error("expected error on canceled context MarkPublished")
 	}
 
-	// 2. Lock conflict (!acquired branch)
-	lockID := int64(11223344)
-	tx := db.Begin()
-	_ = tx.Exec("SELECT pg_advisory_xact_lock(?)", lockID).Error // Hold lock in tx
-
-	// Call ExecuteInLock from main DB connection; pg_try_advisory_xact_lock returns false
-	err := outboxRepo.ExecuteInLock(context.Background(), lockID, func(txCtx context.Context) error {
-		t.Error("callback should not run when lock is not acquired")
+	// 2. ProcessBatch test
+	err := outboxRepo.ProcessBatch(context.Background(), 10, func(txCtx context.Context, records []*port.OutboxRecord) error {
 		return nil
 	})
 	if err != nil {
-		t.Errorf("ExecuteInLock should return nil when lock is not acquired, got %v", err)
+		t.Errorf("ProcessBatch returned unexpected error: %v", err)
 	}
-	tx.Rollback()
 }

--- a/internal/workout_execution/infrastructure/worker/outbox_worker.go
+++ b/internal/workout_execution/infrastructure/worker/outbox_worker.go
@@ -53,34 +53,12 @@ func (w *OutboxWorker) Start(ctx context.Context) {
 }
 
 func (w *OutboxWorker) processOutbox(ctx context.Context) error {
-	var events []*port.OutboxRecord
-
-	// Lock key 99887766 for workout_execution outbox
-	err := w.outboxRepo.ExecuteInLock(ctx, 99887766, func(txCtx context.Context) error {
-		var err error
-		events, err = w.outboxRepo.FetchUnpublished(txCtx, 100)
-		return err
-	})
-	if err != nil {
-		return err
-	}
-
-	if len(events) == 0 {
-		return nil
-	}
-
-	if w.publisher != nil {
-		if err := w.publisher.PublishBatch(ctx, events); err != nil {
-			return fmt.Errorf("publish batch failed: %w", err)
+	return w.outboxRepo.ProcessBatch(ctx, 100, func(publishCtx context.Context, events []*port.OutboxRecord) error {
+		if w.publisher != nil {
+			if err := w.publisher.PublishBatch(publishCtx, events); err != nil {
+				return fmt.Errorf("publish batch failed: %w", err)
+			}
 		}
-	}
-
-	ids := make([]string, len(events))
-	for i, ev := range events {
-		ids[i] = ev.ID
-	}
-
-	return w.outboxRepo.ExecuteInLock(ctx, 99887766, func(txCtx context.Context) error {
-		return w.outboxRepo.MarkPublished(txCtx, ids)
+		return nil
 	})
 }

--- a/internal/workout_execution/infrastructure/worker/outbox_worker_test.go
+++ b/internal/workout_execution/infrastructure/worker/outbox_worker_test.go
@@ -34,11 +34,25 @@ func (m *mockOutboxRepo) MarkPublished(ctx context.Context, ids []string) error 
 	return m.markErr
 }
 
-func (m *mockOutboxRepo) ExecuteInLock(ctx context.Context, lockKey int64, fn func(ctx context.Context) error) error {
+func (m *mockOutboxRepo) ProcessBatch(ctx context.Context, limit int, publishFn func(ctx context.Context, records []*port.OutboxRecord) error) error {
 	if m.lockErr != nil {
 		return m.lockErr
 	}
-	return fn(ctx)
+	events, err := m.FetchUnpublished(ctx, limit)
+	if err != nil {
+		return err
+	}
+	if len(events) == 0 {
+		return nil
+	}
+	if err := publishFn(ctx, events); err != nil {
+		return err
+	}
+	ids := make([]string, len(events))
+	for i, e := range events {
+		ids[i] = e.ID
+	}
+	return m.MarkPublished(ctx, ids)
 }
 
 type mockPublisher struct {


### PR DESCRIPTION
### 1. Problem to Solve
- **Outbox Bottleneck & Race Conditions**: Cơ chế khóa cũ `pg_try_advisory_xact_lock` là khóa toàn cục (Global Advisory Lock), chỉ cho phép 1 worker duy nhất chạy (Active-Passive), lãng phí tài nguyên khi scale-out nhiều replica worker pods. Đồng thời việc nhả lock giữa bước Fetch và MarkPublished dễ dẫn đến trùng lặp tin nhắn.
- **Lỗi Auth E2E Test Suite**: Khung test E2E trong module `auth` thiếu gRPC interceptor trích xuất gRPC metadata header (`x-user-id`) vào context, khiến hàm `Logout` trả về status 401/500 sai kỳ vọng trong bài kiểm thử.

### 2. Proposed Solution
- **Chuyển đổi Outbox sang `FOR UPDATE SKIP LOCKED`**:
  - Triển khai phương thức `ProcessBatch` ở cấp Repository cho cả 5 modules (`auth`, `exercise`, `coaching`, `workout_execution`, `profile`).
  - Gộp các thao tác `Fetch` -> `Publish` -> `MarkPublished` vào cùng một DB Transaction dùng GORM `clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"}`.
  - Loại bỏ hoàn toàn phương thức `ExecuteInLock` và các hằng số `LockID` ngẫu nhiên.
- **Hoàn thiện Module Auth**:
  - Bổ sung `testAuthInterceptor` trong `internal/auth/tests/e2e/testutil.go` để trích xuất `x-user-id` metadata vào context key `middleware.UserIDKey`.
  - Cập nhật `GRPCHandler.Logout` để trả về `LogoutResponse{Success: false}` cho lỗi BOLA / `apperror.ErrUnauthorized`.
  - Cập nhật OAuth Provider và các kho lưu trữ dữ liệu (User, Session, Key Repositories) để xử lý mượt mà chu trình đăng nhập/đăng xuất.

### 3. Changes & Impact
- `[internal/auth/application/port/outbox_repository.go](internal/auth/application/port/outbox_repository.go)`: Cập nhật interface port, thay `ExecuteInLock` bằng `ProcessBatch`.
- `[internal/auth/infrastructure/persistence/postgres/outbox_repository.go](internal/auth/infrastructure/postgres/outbox_repository.go)`: Triển khai `ProcessBatch` với `FOR UPDATE SKIP LOCKED`.
- `[internal/auth/infrastructure/worker/worker.go](internal/auth/infrastructure/worker/worker.go)`: Đơn giản hóa chu trình tiêu thụ outbox trong worker.
- `[internal/auth/infrastructure/transport/grpc/handler.go](internal/auth/infrastructure/transport/grpc/handler.go)`: Xử lý `ErrUnauthorized` trả về `LogoutResponse{Success: false}`.
- `[internal/auth/tests/e2e/testutil.go](internal/auth/tests/e2e/testutil.go)`: Đăng ký `testAuthInterceptor` xử lý gRPC metadata.
- `[internal/auth/tests/integration/repository_test.go](internal/auth/tests/integration/repository_test.go)`: Thêm `TestOutboxRepository_ConcurrentWorkers_Integration` kiểm thử 2 worker chạy song song.
- `[internal/exercise/...](internal/exercise/)`: Cập nhật port, repository và worker sang `FOR UPDATE SKIP LOCKED`.
- `[internal/coaching/...](internal/coaching/)`: Cập nhật port, repository, test stubs và worker sang `FOR UPDATE SKIP LOCKED`.
- `[internal/workout_execution/...](internal/workout_execution/)`: Cập nhật port, repository, test stubs và worker sang `FOR UPDATE SKIP LOCKED`.
- `[internal/profile/...](internal/profile/)`: Cập nhật port, repository, test stubs và worker sang `FOR UPDATE SKIP LOCKED`.

### 4. Testing & Verification
- **Unit Tests**:
  - `go test -tags unit -v ./internal/auth/infrastructure/worker/...`: PASS
  - `go test -v ./internal/exercise/...`: PASS
  - `go test -v ./internal/coaching/...`: PASS
  - `go test -v ./internal/workout_execution/infrastructure/worker/...`: PASS
  - `go test -tags unit -v ./internal/profile/infrastructure/worker/...`: PASS
- **Integration & Multi-Worker Concurrency Tests**:
  - `go test -tags integration -v ./internal/auth/tests/integration -run TestOutboxRepository_ConcurrentWorkers_Integration`: PASS (Xác minh 2 worker chạy đồng thời đọc 20 bản ghi không trùng lặp, zero locking delay).
- **E2E Tests**:
  - `go test -tags e2e -v ./internal/auth/tests/e2e`: PASS (Toàn bộ 4/4 E2E tests bao gồm OAuth Google/Facebook, JWKS Rotation và BOLA Logout Prevention đều đạt).
- **Full Test Suite**:
  - `go test ./...`: PASS toàn bộ dự án.
