### PR TITLE
✨ refactor(outbox): tái cấu trúc Outbox Pattern 2-Pha giải quyết triệt để nghẽn DB Tx trên cả 5 modules

### DIFF
--- a/internal/auth/application/port/outbox_repository.go
+++ b/internal/auth/application/port/outbox_repository.go
@@ -1,6 +1,9 @@
 package port
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // OutboxRecord is a plain data transfer object representing a database outbox log entry.
 type OutboxRecord struct {
@@ -15,6 +18,7 @@ type OutboxRecord struct {
 type OutboxRepository interface {
 	SaveEvent(ctx context.Context, eventID string, eventType string, payload []byte, partitionKey string) error
 	FetchUnpublished(ctx context.Context, limit int) ([]*OutboxRecord, error)
+	ClaimBatch(ctx context.Context, limit int, lockDuration time.Duration) ([]*OutboxRecord, error)
 	MarkPublished(ctx context.Context, ids []string) error
 	ProcessBatch(ctx context.Context, limit int, publishFn func(ctx context.Context, records []*OutboxRecord) error) error
 }

--- a/internal/auth/infrastructure/persistence/postgres/models.go
+++ b/internal/auth/infrastructure/persistence/postgres/models.go
@@ -133,6 +133,8 @@ type OutboxModel struct {
 	CreatedAt    time.Time    `gorm:"column:created_at;index:idx_outbox_published_created,priority:2"`
 	Published    bool         `gorm:"column:published;default:false;index:idx_outbox_published_created,priority:1"`
 	PublishedAt  sql.NullTime `gorm:"column:published_at"`
+	Status       string       `gorm:"column:status;default:PENDING"`
+	LockedUntil  sql.NullTime `gorm:"column:locked_until"`
 }
 
 func (OutboxModel) TableName() string {

--- a/internal/auth/infrastructure/persistence/postgres/outbox_repository.go
+++ b/internal/auth/infrastructure/persistence/postgres/outbox_repository.go
@@ -81,6 +81,7 @@ func (r *OutboxRepository) MarkPublished(ctx context.Context, ids []string) erro
 		Updates(map[string]interface{}{
 			"published":    true,
 			"published_at": time.Now(),
+			"status":       "PUBLISHED",
 		}).
 		Error
 
@@ -90,25 +91,33 @@ func (r *OutboxRepository) MarkPublished(ctx context.Context, ids []string) erro
 	return nil
 }
 
-// ProcessBatch fetches unpublished outbox events using FOR UPDATE SKIP LOCKED,
-// publishes them via publishFn, and marks them as published in a single transaction.
-func (r *OutboxRepository) ProcessBatch(
+// ClaimBatch claims unpublished outbox events using FOR UPDATE SKIP LOCKED,
+// updates status='PROCESSING' and locked_until=NOW()+lockDuration in a short transaction,
+// and returns the claimed records.
+func (r *OutboxRepository) ClaimBatch(
 	ctx context.Context,
 	limit int,
-	publishFn func(ctx context.Context, records []*port.OutboxRecord) error,
-) error {
+	lockDuration time.Duration,
+) ([]*port.OutboxRecord, error) {
 	if limit <= 0 {
 		limit = 100
 	}
+	if lockDuration <= 0 {
+		lockDuration = 30 * time.Second
+	}
 
-	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	var records []*port.OutboxRecord
+	now := time.Now()
+	lockedUntil := now.Add(lockDuration)
+
+	err := r.getDB(ctx).Transaction(func(tx *gorm.DB) error {
 		var dbOutboxes []OutboxModel
 		err := tx.
 			Clauses(clause.Locking{
 				Strength: "UPDATE",
 				Options:  "SKIP LOCKED",
 			}).
-			Where("published = ?", false).
+			Where("published = ? AND (status = ? OR locked_until IS NULL OR locked_until < ?)", false, "PENDING", now).
 			Order("created_at ASC").
 			Limit(limit).
 			Find(&dbOutboxes).
@@ -122,31 +131,58 @@ func (r *OutboxRepository) ProcessBatch(
 			return nil
 		}
 
-		records := make([]*port.OutboxRecord, len(dbOutboxes))
 		ids := make([]string, len(dbOutboxes))
+		records = make([]*port.OutboxRecord, len(dbOutboxes))
 		for i, o := range dbOutboxes {
 			records[i] = o.ToRepositoryRecord()
 			ids[i] = o.ID
 		}
 
-		txCtx := WithTx(ctx, tx)
-		if pubErr := publishFn(txCtx, records); pubErr != nil {
-			return fmt.Errorf("publish outbox batch: %w", pubErr)
-		}
-
-		now := time.Now()
 		err = tx.Model(&OutboxModel{}).
 			Where("id IN ?", ids).
 			Updates(map[string]interface{}{
-				"published":    true,
-				"published_at": now,
+				"status":       "PROCESSING",
+				"locked_until": lockedUntil,
 			}).
 			Error
 
 		if err != nil {
-			return fmt.Errorf("gorm mark outbox events published: %w", err)
+			return fmt.Errorf("gorm claim outbox events: %w", err)
 		}
 
 		return nil
 	})
+
+	if err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+// ProcessBatch claims unpublished outbox events in a short transaction,
+// publishes them via publishFn OUTSIDE the database transaction,
+// and marks them as published upon success.
+func (r *OutboxRepository) ProcessBatch(
+	ctx context.Context,
+	limit int,
+	publishFn func(ctx context.Context, records []*port.OutboxRecord) error,
+) error {
+	records, err := r.ClaimBatch(ctx, limit, 30*time.Second)
+	if err != nil {
+		return err
+	}
+	if len(records) == 0 {
+		return nil
+	}
+
+	if pubErr := publishFn(ctx, records); pubErr != nil {
+		return fmt.Errorf("publish outbox batch: %w", pubErr)
+	}
+
+	ids := make([]string, len(records))
+	for i, rec := range records {
+		ids[i] = rec.ID
+	}
+
+	return r.MarkPublished(ctx, ids)
 }

--- a/internal/auth/infrastructure/worker/worker_test.go
+++ b/internal/auth/infrastructure/worker/worker_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/viethung213/gym-companion/internal/auth/application/port"
 )
@@ -38,6 +39,10 @@ func (m *mockOutboxRepository) FetchUnpublished(ctx context.Context, limit int) 
 		}
 	}
 	return unpublished, nil
+}
+
+func (m *mockOutboxRepository) ClaimBatch(ctx context.Context, limit int, _ time.Duration) ([]*port.OutboxRecord, error) {
+	return m.FetchUnpublished(ctx, limit)
 }
 
 func (m *mockOutboxRepository) MarkPublished(ctx context.Context, ids []string) error {

--- a/internal/auth/tests/integration/repository_test.go
+++ b/internal/auth/tests/integration/repository_test.go
@@ -35,6 +35,9 @@ func getTestDB(t *testing.T) *gorm.DB {
 		t.Fatalf("Failed to wrap database in gorm: %v", err)
 	}
 
+	db.Exec("ALTER TABLE auth.outbox ADD COLUMN IF NOT EXISTS status VARCHAR(50) DEFAULT 'PENDING' NOT NULL;")
+	db.Exec("ALTER TABLE auth.outbox ADD COLUMN IF NOT EXISTS locked_until TIMESTAMP WITH TIME ZONE;")
+
 	return db
 }
 
@@ -367,6 +370,139 @@ func TestOutboxRepository_ConcurrentWorkers_Integration(t *testing.T) {
 		if count > 1 {
 			t.Errorf("Record %s was processed %d times (expected exactly 1)", id, count)
 		}
+	}
+}
+
+func TestOutboxRepository_3ConcurrentNodes_Integration(t *testing.T) {
+	db := getTestDB(t)
+	truncateTables(db)
+	defer truncateTables(db)
+
+	repo := infraPostgres.NewOutboxRepository(db)
+	ctx := context.Background()
+
+	const totalRecords = 30
+	const batchLimit = 10
+
+	for i := 0; i < totalRecords; i++ {
+		eventID := uuid.New().String()
+		if err := repo.SaveEvent(ctx, eventID, "test.3nodes", []byte(`{}`), fmt.Sprintf("key-%d", i)); err != nil {
+			t.Fatalf("Failed to seed outbox record %d: %v", i, err)
+		}
+	}
+
+	var mu sync.Mutex
+	processedIDs := make(map[string]int)
+
+	var wg sync.WaitGroup
+	const nodeCount = 3
+	wg.Add(nodeCount)
+
+	for nodeIdx := 1; nodeIdx <= nodeCount; nodeIdx++ {
+		go func(id int) {
+			defer wg.Done()
+			for {
+				records, err := repo.ClaimBatch(ctx, batchLimit, 5*time.Second)
+				if err != nil || len(records) == 0 {
+					break
+				}
+
+				mu.Lock()
+				recIDs := make([]string, len(records))
+				for i, r := range records {
+					processedIDs[r.ID]++
+					recIDs[i] = r.ID
+				}
+				mu.Unlock()
+
+				// Simulate brief Kafka network push
+				time.Sleep(10 * time.Millisecond)
+
+				_ = repo.MarkPublished(ctx, recIDs)
+			}
+		}(nodeIdx)
+	}
+
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(processedIDs) != totalRecords {
+		t.Errorf("Expected %d total unique records processed across 3 nodes, got %d", totalRecords, len(processedIDs))
+	}
+
+	for id, count := range processedIDs {
+		if count > 1 {
+			t.Errorf("Record %s was processed %d times (expected exactly 1)", id, count)
+		}
+	}
+}
+
+func TestOutboxRepository_NodeCrashFailover_Integration(t *testing.T) {
+	db := getTestDB(t)
+	truncateTables(db)
+	defer truncateTables(db)
+
+	repo := infraPostgres.NewOutboxRepository(db)
+	ctx := context.Background()
+
+	// Seed 5 records
+	for i := 0; i < 5; i++ {
+		eventID := uuid.New().String()
+		if err := repo.SaveEvent(ctx, eventID, "test.failover", []byte(`{}`), fmt.Sprintf("key-%d", i)); err != nil {
+			t.Fatalf("Failed to seed record %d: %v", i, err)
+		}
+	}
+
+	// Step 1: Node 1 claims batch with a VERY SHORT lock duration of 100ms
+	node1Claimed, err := repo.ClaimBatch(ctx, 5, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Node 1 ClaimBatch failed: %v", err)
+	}
+	if len(node1Claimed) != 5 {
+		t.Fatalf("Node 1 expected 5 claimed records, got %d", len(node1Claimed))
+	}
+
+	// NODE 1 CRASHES HERE (does NOT call MarkPublished)
+
+	// Step 2: Immediate claim attempt by Node 2 (lock still active) -> Node 2 should get 0 records
+	node2Immediate, err := repo.ClaimBatch(ctx, 5, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Node 2 immediate ClaimBatch failed: %v", err)
+	}
+	if len(node2Immediate) != 0 {
+		t.Errorf("Node 2 expected 0 records while Node 1 lock is active, got %d", len(node2Immediate))
+	}
+
+	// Step 3: Wait 150ms for Node 1's lock to expire
+	time.Sleep(150 * time.Millisecond)
+
+	// Step 4: Node 2 attempts claim AFTER Node 1 lock expired -> Node 2 successfully takes over orphaned records!
+	node2Recovered, err := repo.ClaimBatch(ctx, 5, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Node 2 failover ClaimBatch failed: %v", err)
+	}
+	if len(node2Recovered) != 5 {
+		t.Errorf("Node 2 expected 5 recovered records after Node 1 crash, got %d", len(node2Recovered))
+	}
+
+	// Step 5: Node 2 publishes and marks published
+	recIDs := make([]string, len(node2Recovered))
+	for i, r := range node2Recovered {
+		recIDs[i] = r.ID
+	}
+	if err := repo.MarkPublished(ctx, recIDs); err != nil {
+		t.Fatalf("Node 2 MarkPublished failed: %v", err)
+	}
+
+	// Verify no unpublished records remain
+	leftover, err := repo.FetchUnpublished(ctx, 10)
+	if err != nil {
+		t.Fatalf("FetchUnpublished failed: %v", err)
+	}
+	if len(leftover) != 0 {
+		t.Errorf("Expected 0 leftover unpublished records, got %d", len(leftover))
 	}
 }
 

--- a/internal/coaching/application/port/ports.go
+++ b/internal/coaching/application/port/ports.go
@@ -54,6 +54,7 @@ type OutboxRecord struct {
 type OutboxRepository interface {
 	Save(ctx context.Context, record *OutboxRecord) error
 	FetchUnpublished(ctx context.Context, limit int) ([]*OutboxRecord, error)
+	ClaimBatch(ctx context.Context, limit int, lockDuration time.Duration) ([]*OutboxRecord, error)
 	MarkPublished(ctx context.Context, ids []string) error
 	ProcessBatch(ctx context.Context, limit int, publishFn func(ctx context.Context, records []*OutboxRecord) error) error
 	// LogProcessed records that an inbound event has been consumed (D9 idempotency).

--- a/internal/coaching/infrastructure/event/outbox_writer_test.go
+++ b/internal/coaching/infrastructure/event/outbox_writer_test.go
@@ -24,6 +24,9 @@ func (s *stubOutbox) FetchUnpublished(context.Context, int) ([]*port.OutboxRecor
 	return s.records, nil
 }
 
+func (s *stubOutbox) ClaimBatch(ctx context.Context, _ int, _ time.Duration) ([]*port.OutboxRecord, error) {
+	return s.records, nil
+}
 func (s *stubOutbox) MarkPublished(context.Context, []string) error { return nil }
 func (s *stubOutbox) ProcessBatch(ctx context.Context, _ int, publishFn func(context.Context, []*port.OutboxRecord) error) error {
 	return publishFn(ctx, s.records)

--- a/internal/coaching/infrastructure/persistence/models.go
+++ b/internal/coaching/infrastructure/persistence/models.go
@@ -79,6 +79,8 @@ type outboxRecord struct {
 	CreatedAt    time.Time    `gorm:"column:created_at"`
 	Published    bool         `gorm:"column:published;default:false"`
 	PublishedAt  sql.NullTime `gorm:"column:published_at"`
+	Status       string       `gorm:"column:status;default:PENDING"`
+	LockedUntil  sql.NullTime `gorm:"column:locked_until"`
 }
 
 func (outboxRecord) TableName() string { return "coaching.outbox" }

--- a/internal/coaching/infrastructure/persistence/outbox_repository.go
+++ b/internal/coaching/infrastructure/persistence/outbox_repository.go
@@ -103,9 +103,9 @@ func (r *OutboxRepository) MarkPublished(ctx context.Context, ids []string) erro
 		Model(&outboxRecord{}).
 		Where("id IN ?", ids).
 		Updates(map[string]any{
-			"published": true,
-
+			"published":    true,
 			"published_at": time.Now(),
+			"status":       "PUBLISHED",
 		}).Error
 
 	if err != nil {
@@ -115,25 +115,33 @@ func (r *OutboxRepository) MarkPublished(ctx context.Context, ids []string) erro
 	return nil
 }
 
-// ProcessBatch fetches unpublished outbox events using FOR UPDATE SKIP LOCKED,
-// publishes them via publishFn, and marks them as published in a single transaction.
-func (r *OutboxRepository) ProcessBatch(
+// ClaimBatch claims unpublished outbox events using FOR UPDATE SKIP LOCKED,
+// updates status='PROCESSING' and locked_until=NOW()+lockDuration in a short transaction,
+// and returns the claimed records.
+func (r *OutboxRepository) ClaimBatch(
 	ctx context.Context,
 	limit int,
-	publishFn func(ctx context.Context, records []*port.OutboxRecord) error,
-) error {
+	lockDuration time.Duration,
+) ([]*port.OutboxRecord, error) {
 	if limit <= 0 {
 		limit = 100
 	}
+	if lockDuration <= 0 {
+		lockDuration = 30 * time.Second
+	}
 
-	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	var records []*port.OutboxRecord
+	now := time.Now()
+	lockedUntil := now.Add(lockDuration)
+
+	err := r.getDB(ctx).Transaction(func(tx *gorm.DB) error {
 		var dbOutboxes []outboxRecord
 		err := tx.
 			Clauses(clause.Locking{
 				Strength: "UPDATE",
 				Options:  "SKIP LOCKED",
 			}).
-			Where("published = ?", false).
+			Where("published = ? AND (status = ? OR locked_until IS NULL OR locked_until < ?)", false, "PENDING", now).
 			Order("created_at ASC").
 			Limit(limit).
 			Find(&dbOutboxes).
@@ -147,7 +155,7 @@ func (r *OutboxRepository) ProcessBatch(
 			return nil
 		}
 
-		records := make([]*port.OutboxRecord, len(dbOutboxes))
+		records = make([]*port.OutboxRecord, len(dbOutboxes))
 		ids := make([]string, len(dbOutboxes))
 		for i := range dbOutboxes {
 			rec := &dbOutboxes[i]
@@ -168,26 +176,53 @@ func (r *OutboxRepository) ProcessBatch(
 			ids[i] = rec.ID
 		}
 
-		txCtx := WithTx(ctx, tx)
-		if pubErr := publishFn(txCtx, records); pubErr != nil {
-			return fmt.Errorf("publish outbox batch: %w", pubErr)
-		}
-
-		now := time.Now()
 		err = tx.Model(&outboxRecord{}).
 			Where("id IN ?", ids).
 			Updates(map[string]any{
-				"published":    true,
-				"published_at": now,
+				"status":       "PROCESSING",
+				"locked_until": lockedUntil,
 			}).
 			Error
 
 		if err != nil {
-			return fmt.Errorf("mark published: %w", err)
+			return fmt.Errorf("claim outbox events: %w", err)
 		}
 
 		return nil
 	})
+
+	if err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+// ProcessBatch claims unpublished outbox events in a short transaction,
+// publishes them via publishFn OUTSIDE the database transaction,
+// and marks them as published upon success.
+func (r *OutboxRepository) ProcessBatch(
+	ctx context.Context,
+	limit int,
+	publishFn func(ctx context.Context, records []*port.OutboxRecord) error,
+) error {
+	records, err := r.ClaimBatch(ctx, limit, 30*time.Second)
+	if err != nil {
+		return err
+	}
+	if len(records) == 0 {
+		return nil
+	}
+
+	if pubErr := publishFn(ctx, records); pubErr != nil {
+		return fmt.Errorf("publish outbox batch: %w", pubErr)
+	}
+
+	ids := make([]string, len(records))
+	for i, rec := range records {
+		ids[i] = rec.ID
+	}
+
+	return r.MarkPublished(ctx, ids)
 }
 
 // LogProcessed records an inbound event in coaching.outbox_log. Returns

--- a/internal/coaching/infrastructure/persistence/outbox_repository_integration_test.go
+++ b/internal/coaching/infrastructure/persistence/outbox_repository_integration_test.go
@@ -1,0 +1,180 @@
+//go:build integration
+
+package persistence_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	"github.com/viethung213/gym-companion/internal/coaching/infrastructure/persistence"
+	"github.com/viethung213/gym-companion/internal/shared/database"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func getCoachingTestDB(t *testing.T) *gorm.DB {
+	sqlDB, err := database.GetRegistry().GetPool("coaching")
+	if err != nil {
+		t.Fatalf("Failed to initialize coaching test database: %v", err)
+	}
+
+	db, err := gorm.Open(postgres.New(postgres.Config{
+		Conn: sqlDB,
+	}), &gorm.Config{
+		SkipDefaultTransaction: true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to wrap database in gorm: %v", err)
+	}
+
+	db.Exec("CREATE SCHEMA IF NOT EXISTS coaching;")
+	db.Exec(`
+		CREATE TABLE IF NOT EXISTS coaching.outbox (
+			id VARCHAR(255) PRIMARY KEY,
+			event_id VARCHAR(255) UNIQUE NOT NULL,
+			event_type VARCHAR(255) NOT NULL,
+			payload JSONB NOT NULL,
+			partition_key VARCHAR(255) NOT NULL,
+			created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+			published BOOLEAN DEFAULT FALSE,
+			published_at TIMESTAMP WITH TIME ZONE,
+			status VARCHAR(50) DEFAULT 'PENDING' NOT NULL,
+			locked_until TIMESTAMP WITH TIME ZONE
+		);
+	`)
+	db.Exec("ALTER TABLE coaching.outbox ADD COLUMN IF NOT EXISTS status VARCHAR(50) DEFAULT 'PENDING' NOT NULL;")
+	db.Exec("ALTER TABLE coaching.outbox ADD COLUMN IF NOT EXISTS locked_until TIMESTAMP WITH TIME ZONE;")
+
+	return db
+}
+
+func truncateCoachingOutbox(db *gorm.DB) {
+	db.Exec("TRUNCATE TABLE coaching.outbox CASCADE;")
+}
+
+func TestCoachingOutboxRepository_3ConcurrentNodes_Integration(t *testing.T) {
+	db := getCoachingTestDB(t)
+	truncateCoachingOutbox(db)
+	defer truncateCoachingOutbox(db)
+
+	repo := persistence.NewOutboxRepository(db)
+	ctx := context.Background()
+
+	const totalRecords = 30
+	const batchLimit = 10
+
+	for i := 0; i < totalRecords; i++ {
+		id := uuid.New().String()
+		rec := &port.OutboxRecord{
+			ID:           id,
+			EventID:      id,
+			EventType:    "coaching.test",
+			Payload:      []byte(`{}`),
+			PartitionKey: fmt.Sprintf("key-%d", i),
+			CreatedAt:    time.Now(),
+		}
+		err := repo.Save(ctx, rec)
+		require.NoError(t, err)
+	}
+
+	var mu sync.Mutex
+	processedIDs := make(map[string]int)
+
+	var wg sync.WaitGroup
+	const nodeCount = 3
+	wg.Add(nodeCount)
+
+	for nodeIdx := 1; nodeIdx <= nodeCount; nodeIdx++ {
+		go func(id int) {
+			defer wg.Done()
+			for {
+				records, err := repo.ClaimBatch(ctx, batchLimit, 5*time.Second)
+				if err != nil || len(records) == 0 {
+					break
+				}
+
+				mu.Lock()
+				recIDs := make([]string, len(records))
+				for i, r := range records {
+					processedIDs[r.ID]++
+					recIDs[i] = r.ID
+				}
+				mu.Unlock()
+
+				time.Sleep(10 * time.Millisecond)
+				_ = repo.MarkPublished(ctx, recIDs)
+			}
+		}(nodeIdx)
+	}
+
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	assert.Len(t, processedIDs, totalRecords)
+	for id, count := range processedIDs {
+		assert.Equal(t, 1, count, "Record %s processed more than once", id)
+	}
+}
+
+func TestCoachingOutboxRepository_NodeCrashFailover_Integration(t *testing.T) {
+	db := getCoachingTestDB(t)
+	truncateCoachingOutbox(db)
+	defer truncateCoachingOutbox(db)
+
+	repo := persistence.NewOutboxRepository(db)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		id := uuid.New().String()
+		rec := &port.OutboxRecord{
+			ID:           id,
+			EventID:      id,
+			EventType:    "coaching.test.failover",
+			Payload:      []byte(`{}`),
+			PartitionKey: fmt.Sprintf("key-%d", i),
+			CreatedAt:    time.Now(),
+		}
+		err := repo.Save(ctx, rec)
+		require.NoError(t, err)
+	}
+
+	// Node 1 claims with 100ms short lock
+	node1Claimed, err := repo.ClaimBatch(ctx, 5, 100*time.Millisecond)
+	require.NoError(t, err)
+	assert.Len(t, node1Claimed, 5)
+
+	// Node 1 CRASHES (no MarkPublished called)
+
+	// Node 2 tries immediately -> 0 records
+	node2Immediate, err := repo.ClaimBatch(ctx, 5, 5*time.Second)
+	require.NoError(t, err)
+	assert.Len(t, node2Immediate, 0)
+
+	// Wait 150ms for lock expiration
+	time.Sleep(150 * time.Millisecond)
+
+	// Node 2 tries after lock expired -> claims all 5
+	node2Recovered, err := repo.ClaimBatch(ctx, 5, 5*time.Second)
+	require.NoError(t, err)
+	assert.Len(t, node2Recovered, 5)
+
+	recIDs := make([]string, len(node2Recovered))
+	for i, r := range node2Recovered {
+		recIDs[i] = r.ID
+	}
+	err = repo.MarkPublished(ctx, recIDs)
+	require.NoError(t, err)
+
+	unpub, err := repo.FetchUnpublished(ctx, 10)
+	require.NoError(t, err)
+	assert.Len(t, unpub, 0)
+}

--- a/internal/coaching/transport/consumer/workout_execution_consumer_test.go
+++ b/internal/coaching/transport/consumer/workout_execution_consumer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/viethung213/gym-companion/internal/coaching/application/port"
 )
@@ -17,6 +18,9 @@ func (s *stubOutbox) FetchUnpublished(context.Context, int) ([]*port.OutboxRecor
 	return nil, nil
 }
 
+func (s *stubOutbox) ClaimBatch(context.Context, int, time.Duration) ([]*port.OutboxRecord, error) {
+	return nil, nil
+}
 func (s *stubOutbox) MarkPublished(context.Context, []string) error { return nil }
 func (s *stubOutbox) ProcessBatch(ctx context.Context, _ int, publishFn func(context.Context, []*port.OutboxRecord) error) error {
 	return publishFn(ctx, nil)

--- a/internal/exercise/application/port/ports.go
+++ b/internal/exercise/application/port/ports.go
@@ -102,6 +102,7 @@ type OutboxRecord struct {
 // OutboxRepository defines the persistence port for the outbox pattern.
 type OutboxRepository interface {
 	FetchUnpublished(ctx context.Context, limit int) ([]*OutboxRecord, error)
+	ClaimBatch(ctx context.Context, limit int, lockDuration time.Duration) ([]*OutboxRecord, error)
 	MarkPublished(ctx context.Context, ids []string) error
 	ProcessBatch(ctx context.Context, limit int, publishFn func(ctx context.Context, records []*OutboxRecord) error) error
 }

--- a/internal/exercise/infrastructure/persistence/models.go
+++ b/internal/exercise/infrastructure/persistence/models.go
@@ -91,6 +91,8 @@ type outboxRecord struct {
 	CreatedAt    time.Time    `gorm:"column:created_at"`
 	Published    bool         `gorm:"column:published;default:false"`
 	PublishedAt  sql.NullTime `gorm:"column:published_at"`
+	Status       string       `gorm:"column:status;default:PENDING"`
+	LockedUntil  sql.NullTime `gorm:"column:locked_until"`
 }
 
 func (outboxRecord) TableName() string {

--- a/internal/exercise/infrastructure/persistence/outbox_repository.go
+++ b/internal/exercise/infrastructure/persistence/outbox_repository.go
@@ -27,6 +27,19 @@ func (r *OutboxRepository) getDB(ctx context.Context) *gorm.DB {
 	return r.db.WithContext(ctx)
 }
 
+func (r *OutboxRepository) Save(ctx context.Context, rec *port.OutboxRecord) error {
+	obr := outboxRecord{
+		ID:           rec.ID,
+		EventID:      rec.EventID,
+		EventType:    rec.EventType,
+		Payload:      rec.Payload,
+		PartitionKey: rec.PartitionKey,
+		CreatedAt:    time.Now(),
+		Published:    false,
+	}
+	return r.getDB(ctx).Create(&obr).Error
+}
+
 func (r *OutboxRepository) FetchUnpublished(
 	ctx context.Context,
 	limit int,
@@ -67,6 +80,7 @@ func (r *OutboxRepository) MarkPublished(ctx context.Context, ids []string) erro
 		Updates(map[string]interface{}{
 			"published":    true,
 			"published_at": time.Now(),
+			"status":       "PUBLISHED",
 		}).
 		Error
 
@@ -76,23 +90,30 @@ func (r *OutboxRepository) MarkPublished(ctx context.Context, ids []string) erro
 	return nil
 }
 
-func (r *OutboxRepository) ProcessBatch(
+func (r *OutboxRepository) ClaimBatch(
 	ctx context.Context,
 	limit int,
-	publishFn func(ctx context.Context, records []*port.OutboxRecord) error,
-) error {
+	lockDuration time.Duration,
+) ([]*port.OutboxRecord, error) {
 	if limit <= 0 {
 		limit = 100
 	}
+	if lockDuration <= 0 {
+		lockDuration = 30 * time.Second
+	}
 
-	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	var results []*port.OutboxRecord
+	now := time.Now()
+	lockedUntil := now.Add(lockDuration)
+
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var records []outboxRecord
 		err := tx.
 			Clauses(clause.Locking{
 				Strength: "UPDATE",
 				Options:  "SKIP LOCKED",
 			}).
-			Where("published = ?", false).
+			Where("published = ? AND (status = ? OR locked_until IS NULL OR locked_until < ?)", false, "PENDING", now).
 			Order("created_at ASC").
 			Limit(limit).
 			Find(&records).
@@ -106,7 +127,7 @@ func (r *OutboxRepository) ProcessBatch(
 			return nil
 		}
 
-		results := make([]*port.OutboxRecord, len(records))
+		results = make([]*port.OutboxRecord, len(records))
 		ids := make([]string, len(records))
 		for i := range records {
 			rec := &records[i]
@@ -120,24 +141,48 @@ func (r *OutboxRepository) ProcessBatch(
 			ids[i] = rec.ID
 		}
 
-		txCtx := WithTx(ctx, tx)
-		if pubErr := publishFn(txCtx, results); pubErr != nil {
-			return fmt.Errorf("publish outbox batch: %w", pubErr)
-		}
-
-		now := time.Now()
 		err = tx.Model(&outboxRecord{}).
 			Where("id IN ?", ids).
 			Updates(map[string]interface{}{
-				"published":    true,
-				"published_at": now,
+				"status":       "PROCESSING",
+				"locked_until": lockedUntil,
 			}).
 			Error
 
 		if err != nil {
-			return fmt.Errorf("gorm mark outbox events published: %w", err)
+			return fmt.Errorf("gorm claim outbox events: %w", err)
 		}
 
 		return nil
 	})
+
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (r *OutboxRepository) ProcessBatch(
+	ctx context.Context,
+	limit int,
+	publishFn func(ctx context.Context, records []*port.OutboxRecord) error,
+) error {
+	records, err := r.ClaimBatch(ctx, limit, 30*time.Second)
+	if err != nil {
+		return err
+	}
+	if len(records) == 0 {
+		return nil
+	}
+
+	if pubErr := publishFn(ctx, records); pubErr != nil {
+		return fmt.Errorf("publish outbox batch: %w", pubErr)
+	}
+
+	ids := make([]string, len(records))
+	for i, rec := range records {
+		ids[i] = rec.ID
+	}
+
+	return r.MarkPublished(ctx, ids)
 }

--- a/internal/exercise/infrastructure/persistence/postgres_repository_integration_test.go
+++ b/internal/exercise/infrastructure/persistence/postgres_repository_integration_test.go
@@ -7,11 +7,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/viethung213/gym-companion/internal/exercise/application/port"
 	"github.com/viethung213/gym-companion/internal/exercise/domain"
+	"github.com/viethung213/gym-companion/internal/shared/database"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
@@ -169,8 +172,12 @@ func prepareExerciseSchema(ctx context.Context, db *gorm.DB) error {
 			partition_key VARCHAR(255) NOT NULL,
 			created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
 			published BOOLEAN DEFAULT FALSE,
-			published_at TIMESTAMP WITH TIME ZONE
+			published_at TIMESTAMP WITH TIME ZONE,
+			status VARCHAR(50) DEFAULT 'PENDING' NOT NULL,
+			locked_until TIMESTAMP WITH TIME ZONE
 		)`,
+		`ALTER TABLE exercise.outbox ADD COLUMN IF NOT EXISTS status VARCHAR(50) DEFAULT 'PENDING' NOT NULL;`,
+		`ALTER TABLE exercise.outbox ADD COLUMN IF NOT EXISTS locked_until TIMESTAMP WITH TIME ZONE;`,
 		`INSERT INTO exercise.body_parts (id, name) VALUES ('legs', 'Legs')`,
 		`INSERT INTO exercise.equipments (id, name) VALUES ('barbell', 'Barbell')`,
 		`INSERT INTO exercise.muscles (id, name, body_part_id) VALUES ('quads', 'Quads', 'legs')`,
@@ -232,5 +239,185 @@ func TestPostgresRepository_FindByIDNotFound(t *testing.T) {
 	_, err = repo.FindByID(ctx, "non-existent-uuid")
 	if !errors.Is(err, domain.ErrExerciseNotFound) {
 		t.Fatalf("got error %v, want %v", err, domain.ErrExerciseNotFound)
+	}
+}
+
+func getExerciseTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	databaseURL := os.Getenv("TEST_DATABASE_URL")
+	if databaseURL != "" {
+		db, err := InitDB(databaseURL)
+		if err != nil {
+			t.Fatalf("open database: %v", err)
+		}
+		_ = prepareExerciseSchema(context.Background(), db)
+		return db
+	}
+
+	sqlDB, err := database.GetRegistry().GetPool("exercise")
+	if err != nil {
+		t.Fatalf("Failed to initialize exercise test database: %v", err)
+	}
+
+	db, err := gorm.Open(postgres.New(postgres.Config{
+		Conn: sqlDB,
+	}), &gorm.Config{
+		SkipDefaultTransaction: true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to wrap database in gorm: %v", err)
+	}
+
+	_ = prepareExerciseSchema(context.Background(), db)
+	db.Exec("ALTER TABLE exercise.outbox ADD COLUMN IF NOT EXISTS status VARCHAR(50) DEFAULT 'PENDING' NOT NULL;")
+	db.Exec("ALTER TABLE exercise.outbox ADD COLUMN IF NOT EXISTS locked_until TIMESTAMP WITH TIME ZONE;")
+	return db
+}
+
+func truncateExerciseOutbox(db *gorm.DB) {
+	db.Exec("TRUNCATE TABLE exercise.outbox CASCADE;")
+}
+
+func TestExerciseOutboxRepository_3ConcurrentNodes_Integration(t *testing.T) {
+	db := getExerciseTestDB(t)
+	truncateExerciseOutbox(db)
+	defer truncateExerciseOutbox(db)
+
+	repo := NewOutboxRepository(db)
+	ctx := context.Background()
+
+	const totalRecords = 30
+	const batchLimit = 10
+
+	for i := 0; i < totalRecords; i++ {
+		id := uuid.New().String()
+		rec := &port.OutboxRecord{
+			ID:           id,
+			EventID:      id,
+			EventType:    "ExerciseCreated",
+			Payload:      []byte(`{}`),
+			PartitionKey: fmt.Sprintf("key-%d", i),
+		}
+		err := repo.Save(ctx, rec)
+		if err != nil {
+			t.Fatalf("Failed to seed record %d: %v", i, err)
+		}
+	}
+
+	var mu sync.Mutex
+	processedIDs := make(map[string]int)
+
+	var wg sync.WaitGroup
+	const nodeCount = 3
+	wg.Add(nodeCount)
+
+	for nodeIdx := 1; nodeIdx <= nodeCount; nodeIdx++ {
+		go func(id int) {
+			defer wg.Done()
+			for {
+				records, err := repo.ClaimBatch(ctx, batchLimit, 5*time.Second)
+				if err != nil || len(records) == 0 {
+					break
+				}
+
+				mu.Lock()
+				recIDs := make([]string, len(records))
+				for i, r := range records {
+					processedIDs[r.ID]++
+					recIDs[i] = r.ID
+				}
+				mu.Unlock()
+
+				time.Sleep(10 * time.Millisecond)
+				_ = repo.MarkPublished(ctx, recIDs)
+			}
+		}(nodeIdx)
+	}
+
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(processedIDs) != totalRecords {
+		t.Errorf("Expected %d total unique records processed across 3 nodes, got %d", totalRecords, len(processedIDs))
+	}
+
+	for id, count := range processedIDs {
+		if count > 1 {
+			t.Errorf("Record %s was processed %d times (expected exactly 1)", id, count)
+		}
+	}
+}
+
+func TestExerciseOutboxRepository_NodeCrashFailover_Integration(t *testing.T) {
+	db := getExerciseTestDB(t)
+	truncateExerciseOutbox(db)
+	defer truncateExerciseOutbox(db)
+
+	repo := NewOutboxRepository(db)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		id := uuid.New().String()
+		rec := &port.OutboxRecord{
+			ID:           id,
+			EventID:      id,
+			EventType:    "ExerciseCreated",
+			Payload:      []byte(`{}`),
+			PartitionKey: fmt.Sprintf("key-%d", i),
+		}
+		err := repo.Save(ctx, rec)
+		if err != nil {
+			t.Fatalf("Failed to seed record %d: %v", i, err)
+		}
+	}
+
+	// Node 1 claims with 100ms lock
+	node1Claimed, err := repo.ClaimBatch(ctx, 5, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Node 1 ClaimBatch failed: %v", err)
+	}
+	if len(node1Claimed) != 5 {
+		t.Fatalf("Node 1 expected 5 claimed records, got %d", len(node1Claimed))
+	}
+
+	// Node 1 CRASHES (no MarkPublished)
+
+	// Node 2 tries immediately -> 0 records
+	node2Immediate, err := repo.ClaimBatch(ctx, 5, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Node 2 immediate ClaimBatch failed: %v", err)
+	}
+	if len(node2Immediate) != 0 {
+		t.Errorf("Node 2 expected 0 records while Node 1 lock active, got %d", len(node2Immediate))
+	}
+
+	// Wait 150ms for lock expiration
+	time.Sleep(150 * time.Millisecond)
+
+	// Node 2 tries after lock expired -> claims all 5
+	node2Recovered, err := repo.ClaimBatch(ctx, 5, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Node 2 failover ClaimBatch failed: %v", err)
+	}
+	if len(node2Recovered) != 5 {
+		t.Errorf("Node 2 expected 5 recovered records after Node 1 crash, got %d", len(node2Recovered))
+	}
+
+	recIDs := make([]string, len(node2Recovered))
+	for i, r := range node2Recovered {
+		recIDs[i] = r.ID
+	}
+	if err := repo.MarkPublished(ctx, recIDs); err != nil {
+		t.Fatalf("Node 2 MarkPublished failed: %v", err)
+	}
+
+	unpub, err := repo.FetchUnpublished(ctx, 10)
+	if err != nil {
+		t.Fatalf("FetchUnpublished failed: %v", err)
+	}
+	if len(unpub) != 0 {
+		t.Errorf("Expected 0 leftover unpublished records, got %d", len(unpub))
 	}
 }

--- a/internal/profile/application/port/outbox_repository.go
+++ b/internal/profile/application/port/outbox_repository.go
@@ -1,6 +1,9 @@
 package port
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 type OutboxRecord struct {
 	ID           string
@@ -13,6 +16,7 @@ type OutboxRecord struct {
 type OutboxRepository interface {
 	Save(ctx context.Context, record *OutboxRecord) error
 	FetchUnpublished(ctx context.Context, limit int) ([]*OutboxRecord, error)
+	ClaimBatch(ctx context.Context, limit int, lockDuration time.Duration) ([]*OutboxRecord, error)
 	MarkAsPublished(ctx context.Context, ids []string) error
 	ProcessBatch(ctx context.Context, limit int, publishFn func(ctx context.Context, records []*OutboxRecord) error) error
 }

--- a/internal/profile/infrastructure/event/outbox_writer_test.go
+++ b/internal/profile/infrastructure/event/outbox_writer_test.go
@@ -34,6 +34,9 @@ func (m *mockOutboxRepo) FetchUnpublished(ctx context.Context, limit int) ([]*po
 	return m.records, nil
 }
 
+func (m *mockOutboxRepo) ClaimBatch(ctx context.Context, _ int, _ time.Duration) ([]*port.OutboxRecord, error) {
+	return m.records, nil
+}
 func (m *mockOutboxRepo) MarkAsPublished(ctx context.Context, ids []string) error {
 	return nil
 }

--- a/internal/profile/infrastructure/persistence/models.go
+++ b/internal/profile/infrastructure/persistence/models.go
@@ -1,6 +1,7 @@
 package persistence
 
 import (
+	"database/sql"
 	"time"
 )
 
@@ -58,14 +59,16 @@ func (InjuryModel) TableName() string {
 }
 
 type OutboxModel struct {
-	ID           string     `gorm:"primaryKey;column:id"`
-	EventID      string     `gorm:"column:event_id;uniqueIndex;not null"`
-	EventType    string     `gorm:"column:event_type;not null"`
-	Payload      []byte     `gorm:"column:payload;not null;type:jsonb"`
-	PartitionKey string     `gorm:"column:partition_key;not null"`
-	CreatedAt    time.Time  `gorm:"column:created_at"`
-	Published    bool       `gorm:"column:published"`
-	PublishedAt  *time.Time `gorm:"column:published_at"`
+	ID           string       `gorm:"primaryKey;column:id"`
+	EventID      string       `gorm:"column:event_id;uniqueIndex;not null"`
+	EventType    string       `gorm:"column:event_type;not null"`
+	Payload      []byte       `gorm:"column:payload;not null;type:jsonb"`
+	PartitionKey string       `gorm:"column:partition_key;not null"`
+	CreatedAt    time.Time    `gorm:"column:created_at"`
+	Published    bool         `gorm:"column:published"`
+	PublishedAt  *time.Time   `gorm:"column:published_at"`
+	Status       string       `gorm:"column:status;default:PENDING"`
+	LockedUntil  sql.NullTime `gorm:"column:locked_until"`
 }
 
 func (OutboxModel) TableName() string {

--- a/internal/profile/infrastructure/persistence/outbox_repository.go
+++ b/internal/profile/infrastructure/persistence/outbox_repository.go
@@ -77,6 +77,7 @@ func (r *GormOutboxRepository) MarkAsPublished(ctx context.Context, ids []string
 		Updates(map[string]interface{}{
 			"published":    true,
 			"published_at": sql.NullTime{Time: now, Valid: true},
+			"status":       "PUBLISHED",
 		}).Error
 	if err != nil {
 		return fmt.Errorf("mark outbox records as published: %w", err)
@@ -84,23 +85,30 @@ func (r *GormOutboxRepository) MarkAsPublished(ctx context.Context, ids []string
 	return nil
 }
 
-func (r *GormOutboxRepository) ProcessBatch(
+func (r *GormOutboxRepository) ClaimBatch(
 	ctx context.Context,
 	limit int,
-	publishFn func(ctx context.Context, records []*port.OutboxRecord) error,
-) error {
+	lockDuration time.Duration,
+) ([]*port.OutboxRecord, error) {
 	if limit <= 0 {
 		limit = 100
 	}
+	if lockDuration <= 0 {
+		lockDuration = 30 * time.Second
+	}
 
-	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	var records []*port.OutboxRecord
+	now := time.Now()
+	lockedUntil := now.Add(lockDuration)
+
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var models []*OutboxModel
 		err := tx.
 			Clauses(clause.Locking{
 				Strength: "UPDATE",
 				Options:  "SKIP LOCKED",
 			}).
-			Where("published = ?", false).
+			Where("published = ? AND (status = ? OR locked_until IS NULL OR locked_until < ?)", false, "PENDING", now).
 			Order("created_at ASC").
 			Limit(limit).
 			Find(&models).
@@ -114,7 +122,7 @@ func (r *GormOutboxRepository) ProcessBatch(
 			return nil
 		}
 
-		records := make([]*port.OutboxRecord, 0, len(models))
+		records = make([]*port.OutboxRecord, 0, len(models))
 		ids := make([]string, 0, len(models))
 		for _, m := range models {
 			records = append(records, &port.OutboxRecord{
@@ -127,24 +135,48 @@ func (r *GormOutboxRepository) ProcessBatch(
 			ids = append(ids, m.ID)
 		}
 
-		txCtx := context.WithValue(ctx, txKey{}, tx)
-		if pubErr := publishFn(txCtx, records); pubErr != nil {
-			return fmt.Errorf("publish outbox batch: %w", pubErr)
-		}
-
-		now := time.Now()
 		err = tx.Model(&OutboxModel{}).
 			Where("id IN ?", ids).
 			Updates(map[string]interface{}{
-				"published":    true,
-				"published_at": sql.NullTime{Time: now, Valid: true},
+				"status":       "PROCESSING",
+				"locked_until": lockedUntil,
 			}).
 			Error
 
 		if err != nil {
-			return fmt.Errorf("mark outbox records as published: %w", err)
+			return fmt.Errorf("claim outbox records: %w", err)
 		}
 
 		return nil
 	})
+
+	if err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+func (r *GormOutboxRepository) ProcessBatch(
+	ctx context.Context,
+	limit int,
+	publishFn func(ctx context.Context, records []*port.OutboxRecord) error,
+) error {
+	records, err := r.ClaimBatch(ctx, limit, 30*time.Second)
+	if err != nil {
+		return err
+	}
+	if len(records) == 0 {
+		return nil
+	}
+
+	if pubErr := publishFn(ctx, records); pubErr != nil {
+		return fmt.Errorf("publish outbox batch: %w", pubErr)
+	}
+
+	ids := make([]string, 0, len(records))
+	for _, rec := range records {
+		ids = append(ids, rec.ID)
+	}
+
+	return r.MarkAsPublished(ctx, ids)
 }

--- a/internal/profile/infrastructure/persistence/postgres_repository_test.go
+++ b/internal/profile/infrastructure/persistence/postgres_repository_test.go
@@ -74,7 +74,9 @@ func setupTestDB(t *testing.T) *gorm.DB {
 			partition_key TEXT NOT NULL,
 			created_at DATETIME,
 			published INTEGER DEFAULT 0,
-			published_at DATETIME
+			published_at DATETIME,
+			status TEXT DEFAULT 'PENDING',
+			locked_until DATETIME
 		);
 	`).Error
 	require.NoError(t, err)

--- a/internal/profile/infrastructure/worker/outbox_worker_test.go
+++ b/internal/profile/infrastructure/worker/outbox_worker_test.go
@@ -41,6 +41,10 @@ func (m *mockOutboxRepoForWorker) MarkAsPublished(ctx context.Context, ids []str
 	return nil
 }
 
+func (m *mockOutboxRepoForWorker) ClaimBatch(ctx context.Context, limit int, _ time.Duration) ([]*port.OutboxRecord, error) {
+	return m.FetchUnpublished(ctx, limit)
+}
+
 func (m *mockOutboxRepoForWorker) ProcessBatch(
 	ctx context.Context,
 	limit int,

--- a/internal/profile/tests/integration/repository_test.go
+++ b/internal/profile/tests/integration/repository_test.go
@@ -4,6 +4,8 @@ package integration
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -90,8 +92,12 @@ func ensureTablesExist(db *gorm.DB) {
 		partition_key VARCHAR(255),
 		published BOOLEAN DEFAULT FALSE,
 		published_at TIMESTAMP WITH TIME ZONE,
-		created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+		created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+		status VARCHAR(50) DEFAULT 'PENDING' NOT NULL,
+		locked_until TIMESTAMP WITH TIME ZONE
 	);`)
+	db.Exec("ALTER TABLE profile.outbox ADD COLUMN IF NOT EXISTS status VARCHAR(50) DEFAULT 'PENDING' NOT NULL;")
+	db.Exec("ALTER TABLE profile.outbox ADD COLUMN IF NOT EXISTS locked_until TIMESTAMP WITH TIME ZONE;")
 
 	db.Exec(`CREATE TABLE IF NOT EXISTS profile.outbox_log (
 		id UUID PRIMARY KEY,
@@ -254,5 +260,149 @@ func TestPostgresUserProfileRepository_TransactionManager(t *testing.T) {
 	}
 	if len(records) != 1 {
 		t.Fatalf("got %d unpublished outbox records, want 1", len(records))
+	}
+}
+
+func TestProfileOutboxRepository_3ConcurrentNodes_Integration(t *testing.T) {
+	db := getTestDB(t)
+	truncateTables(db)
+	defer truncateTables(db)
+
+	repo := infraPostgres.NewGormOutboxRepository(db)
+	ctx := context.Background()
+
+	const totalRecords = 30
+	const batchLimit = 10
+
+	for i := 0; i < totalRecords; i++ {
+		id := uuid.New().String()
+		rec := &port.OutboxRecord{
+			ID:           id,
+			EventID:      id,
+			EventType:    "ProfileCompleted",
+			Payload:      []byte(`{}`),
+			PartitionKey: fmt.Sprintf("key-%d", i),
+		}
+		err := repo.Save(ctx, rec)
+		if err != nil {
+			t.Fatalf("Failed to seed record %d: %v", i, err)
+		}
+	}
+
+	var mu sync.Mutex
+	processedIDs := make(map[string]int)
+
+	var wg sync.WaitGroup
+	const nodeCount = 3
+	wg.Add(nodeCount)
+
+	for nodeIdx := 1; nodeIdx <= nodeCount; nodeIdx++ {
+		go func(id int) {
+			defer wg.Done()
+			for {
+				records, err := repo.ClaimBatch(ctx, batchLimit, 5*time.Second)
+				if err != nil || len(records) == 0 {
+					break
+				}
+
+				mu.Lock()
+				recIDs := make([]string, len(records))
+				for i, r := range records {
+					processedIDs[r.ID]++
+					recIDs[i] = r.ID
+				}
+				mu.Unlock()
+
+				time.Sleep(10 * time.Millisecond)
+				_ = repo.MarkAsPublished(ctx, recIDs)
+			}
+		}(nodeIdx)
+	}
+
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(processedIDs) != totalRecords {
+		t.Errorf("Expected %d total unique records processed across 3 nodes, got %d", totalRecords, len(processedIDs))
+	}
+
+	for id, count := range processedIDs {
+		if count > 1 {
+			t.Errorf("Record %s was processed %d times (expected exactly 1)", id, count)
+		}
+	}
+}
+
+func TestProfileOutboxRepository_NodeCrashFailover_Integration(t *testing.T) {
+	db := getTestDB(t)
+	truncateTables(db)
+	defer truncateTables(db)
+
+	repo := infraPostgres.NewGormOutboxRepository(db)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		id := uuid.New().String()
+		rec := &port.OutboxRecord{
+			ID:           id,
+			EventID:      id,
+			EventType:    "ProfileCompleted",
+			Payload:      []byte(`{}`),
+			PartitionKey: fmt.Sprintf("key-%d", i),
+		}
+		err := repo.Save(ctx, rec)
+		if err != nil {
+			t.Fatalf("Failed to seed record %d: %v", i, err)
+		}
+	}
+
+	// Node 1 claims with 100ms lock
+	node1Claimed, err := repo.ClaimBatch(ctx, 5, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Node 1 ClaimBatch failed: %v", err)
+	}
+	if len(node1Claimed) != 5 {
+		t.Fatalf("Node 1 expected 5 claimed records, got %d", len(node1Claimed))
+	}
+
+	// Node 1 CRASHES (no MarkAsPublished)
+
+	// Node 2 tries immediately -> 0 records
+	node2Immediate, err := repo.ClaimBatch(ctx, 5, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Node 2 immediate ClaimBatch failed: %v", err)
+	}
+	if len(node2Immediate) != 0 {
+		t.Errorf("Node 2 expected 0 records while Node 1 lock active, got %d", len(node2Immediate))
+	}
+
+	// Wait 150ms for lock expiration
+	time.Sleep(150 * time.Millisecond)
+
+	// Node 2 tries after lock expired -> claims all 5
+	node2Recovered, err := repo.ClaimBatch(ctx, 5, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Node 2 failover ClaimBatch failed: %v", err)
+	}
+	if len(node2Recovered) != 5 {
+		t.Errorf("Node 2 expected 5 recovered records after Node 1 crash, got %d", len(node2Recovered))
+	}
+
+	recIDs := make([]string, len(node2Recovered))
+	for i, r := range node2Recovered {
+		recIDs[i] = r.ID
+	}
+	if err := repo.MarkAsPublished(ctx, recIDs); err != nil {
+		t.Fatalf("Node 2 MarkAsPublished failed: %v", err)
+	}
+
+	unpub, err := repo.FetchUnpublished(ctx, 10)
+	if err != nil {
+		t.Fatalf("FetchUnpublished failed: %v", err)
+	}
+	if len(unpub) != 0 {
+		t.Errorf("Expected 0 leftover unpublished records, got %d", len(unpub))
 	}
 }

--- a/internal/workout_execution/application/port/outbox_repository.go
+++ b/internal/workout_execution/application/port/outbox_repository.go
@@ -36,6 +36,8 @@ type OutboxRepository interface {
 
 	FetchUnpublished(ctx context.Context, limit int) ([]*OutboxRecord, error)
 
+	ClaimBatch(ctx context.Context, limit int, lockDuration time.Duration) ([]*OutboxRecord, error)
+
 	MarkPublished(ctx context.Context, ids []string) error
 
 	ProcessBatch(ctx context.Context, limit int, publishFn func(ctx context.Context, records []*OutboxRecord) error) error

--- a/internal/workout_execution/infrastructure/event/outbox_writer_test.go
+++ b/internal/workout_execution/infrastructure/event/outbox_writer_test.go
@@ -32,6 +32,10 @@ func (m *mockOutboxRepo) FetchUnpublished(ctx context.Context, limit int) ([]*po
 
 }
 
+func (m *mockOutboxRepo) ClaimBatch(ctx context.Context, limit int, lockDuration time.Duration) ([]*port.OutboxRecord, error) {
+	return nil, nil
+}
+
 func (m *mockOutboxRepo) MarkPublished(ctx context.Context, ids []string) error {
 
 	return nil

--- a/internal/workout_execution/infrastructure/persistence/models.go
+++ b/internal/workout_execution/infrastructure/persistence/models.go
@@ -155,6 +155,8 @@ type OutboxModel struct {
 	Published     bool         `gorm:"column:published;default:false"`
 	PublishedAt   sql.NullTime `gorm:"column:published_at"`
 	CreatedAt     time.Time    `gorm:"column:created_at"`
+	Status        string       `gorm:"column:status;default:PENDING"`
+	LockedUntil   sql.NullTime `gorm:"column:locked_until"`
 }
 
 // TableName returns table name for GORM.

--- a/internal/workout_execution/infrastructure/persistence/postgres_repository.go
+++ b/internal/workout_execution/infrastructure/persistence/postgres_repository.go
@@ -396,26 +396,34 @@ func (r *PostgresOutboxRepository) MarkPublished(ctx context.Context, ids []stri
 	return db.Model(&OutboxModel{}).Where("id IN ?", ids).Updates(map[string]interface{}{
 		"published":    true,
 		"published_at": now,
+		"status":       "PUBLISHED",
 	}).Error
 }
 
-func (r *PostgresOutboxRepository) ProcessBatch(
+func (r *PostgresOutboxRepository) ClaimBatch(
 	ctx context.Context,
 	limit int,
-	publishFn func(ctx context.Context, records []*port.OutboxRecord) error,
-) error {
+	lockDuration time.Duration,
+) ([]*port.OutboxRecord, error) {
 	if limit <= 0 {
 		limit = 100
 	}
+	if lockDuration <= 0 {
+		lockDuration = 30 * time.Second
+	}
 
-	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	var res []*port.OutboxRecord
+	now := time.Now().UTC()
+	lockedUntil := now.Add(lockDuration)
+
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var models []OutboxModel
 		err := tx.
 			Clauses(clause.Locking{
 				Strength: "UPDATE",
 				Options:  "SKIP LOCKED",
 			}).
-			Where("published = ?", false).
+			Where("published = ? AND (status = ? OR locked_until IS NULL OR locked_until < ?)", false, "PENDING", now).
 			Order("created_at ASC").
 			Limit(limit).
 			Find(&models).
@@ -429,33 +437,57 @@ func (r *PostgresOutboxRepository) ProcessBatch(
 			return nil
 		}
 
-		res := make([]*port.OutboxRecord, len(models))
+		res = make([]*port.OutboxRecord, len(models))
 		ids := make([]string, len(models))
 		for i, m := range models {
 			res[i] = OutboxToDomain(&m)
 			ids[i] = m.ID
 		}
 
-		txCtx := WithTx(ctx, tx)
-		if pubErr := publishFn(txCtx, res); pubErr != nil {
-			return fmt.Errorf("publish outbox batch: %w", pubErr)
-		}
-
-		now := time.Now().UTC()
 		err = tx.Model(&OutboxModel{}).
 			Where("id IN ?", ids).
 			Updates(map[string]interface{}{
-				"published":    true,
-				"published_at": now,
+				"status":       "PROCESSING",
+				"locked_until": lockedUntil,
 			}).
 			Error
 
 		if err != nil {
-			return fmt.Errorf("mark outbox published: %w", err)
+			return fmt.Errorf("failed to claim outbox events: %w", err)
 		}
 
 		return nil
 	})
+
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (r *PostgresOutboxRepository) ProcessBatch(
+	ctx context.Context,
+	limit int,
+	publishFn func(ctx context.Context, records []*port.OutboxRecord) error,
+) error {
+	records, err := r.ClaimBatch(ctx, limit, 30*time.Second)
+	if err != nil {
+		return err
+	}
+	if len(records) == 0 {
+		return nil
+	}
+
+	if pubErr := publishFn(ctx, records); pubErr != nil {
+		return fmt.Errorf("publish outbox batch: %w", pubErr)
+	}
+
+	ids := make([]string, len(records))
+	for i, rec := range records {
+		ids[i] = rec.ID
+	}
+
+	return r.MarkPublished(ctx, ids)
 }
 
 // PostgresOutboxLogRepository implements port.OutboxLogRepository for consumer idempotency tracking.

--- a/internal/workout_execution/infrastructure/persistence/postgres_repository_test.go
+++ b/internal/workout_execution/infrastructure/persistence/postgres_repository_test.go
@@ -5,6 +5,8 @@ package persistence_test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -112,6 +114,8 @@ func ensureTablesExist(db *gorm.DB) {
 		published_at TIMESTAMP WITH TIME ZONE,
 		created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 	);`)
+	db.Exec("ALTER TABLE workout_execution.outbox ADD COLUMN IF NOT EXISTS status VARCHAR(50) DEFAULT 'PENDING' NOT NULL;")
+	db.Exec("ALTER TABLE workout_execution.outbox ADD COLUMN IF NOT EXISTS locked_until TIMESTAMP WITH TIME ZONE;")
 	db.Exec(`CREATE INDEX IF NOT EXISTS idx_workout_execution_outbox_pub_created ON workout_execution.outbox (published, created_at);`)
 
 	db.Exec(`CREATE TABLE IF NOT EXISTS workout_execution.outbox_log (
@@ -487,5 +491,153 @@ func TestPostgresRepository_CanceledContextAndLockConflict(t *testing.T) {
 	})
 	if err != nil {
 		t.Errorf("ProcessBatch returned unexpected error: %v", err)
+	}
+}
+
+func TestWorkoutExecutionOutboxRepository_3ConcurrentNodes_Integration(t *testing.T) {
+	db := getTestDB(t)
+	ensureTablesExist(db)
+
+	repo := infraPostgres.NewPostgresOutboxRepository(db)
+	ctx := context.Background()
+
+	const totalRecords = 30
+	const batchLimit = 10
+
+	for i := 0; i < totalRecords; i++ {
+		id := uuid.New().String()
+		rec := &port.OutboxRecord{
+			ID:            id,
+			EventID:       id,
+			AggregateType: "WorkoutSession",
+			AggregateID:   fmt.Sprintf("sess-%d", i),
+			EventType:     "WorkoutSessionStarted",
+			Payload:       []byte(`{}`),
+			PartitionKey:  fmt.Sprintf("key-%d", i),
+			CreatedAt:     time.Now(),
+		}
+		err := repo.Save(ctx, rec)
+		if err != nil {
+			t.Fatalf("Failed to seed record %d: %v", i, err)
+		}
+	}
+
+	var mu sync.Mutex
+	processedIDs := make(map[string]int)
+
+	var wg sync.WaitGroup
+	const nodeCount = 3
+	wg.Add(nodeCount)
+
+	for nodeIdx := 1; nodeIdx <= nodeCount; nodeIdx++ {
+		go func(id int) {
+			defer wg.Done()
+			for {
+				records, err := repo.ClaimBatch(ctx, batchLimit, 5*time.Second)
+				if err != nil || len(records) == 0 {
+					break
+				}
+
+				mu.Lock()
+				recIDs := make([]string, len(records))
+				for i, r := range records {
+					processedIDs[r.ID]++
+					recIDs[i] = r.ID
+				}
+				mu.Unlock()
+
+				time.Sleep(10 * time.Millisecond)
+				_ = repo.MarkPublished(ctx, recIDs)
+			}
+		}(nodeIdx)
+	}
+
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(processedIDs) != totalRecords {
+		t.Errorf("Expected %d total unique records processed across 3 nodes, got %d", totalRecords, len(processedIDs))
+	}
+
+	for id, count := range processedIDs {
+		if count > 1 {
+			t.Errorf("Record %s was processed %d times (expected exactly 1)", id, count)
+		}
+	}
+}
+
+func TestWorkoutExecutionOutboxRepository_NodeCrashFailover_Integration(t *testing.T) {
+	db := getTestDB(t)
+	ensureTablesExist(db)
+
+	repo := infraPostgres.NewPostgresOutboxRepository(db)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		id := uuid.New().String()
+		rec := &port.OutboxRecord{
+			ID:            id,
+			EventID:       id,
+			AggregateType: "WorkoutSession",
+			AggregateID:   fmt.Sprintf("sess-%d", i),
+			EventType:     "WorkoutSessionStarted",
+			Payload:       []byte(`{}`),
+			PartitionKey:  fmt.Sprintf("key-%d", i),
+			CreatedAt:     time.Now(),
+		}
+		err := repo.Save(ctx, rec)
+		if err != nil {
+			t.Fatalf("Failed to seed record %d: %v", i, err)
+		}
+	}
+
+	// Node 1 claims with 100ms lock
+	node1Claimed, err := repo.ClaimBatch(ctx, 5, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Node 1 ClaimBatch failed: %v", err)
+	}
+	if len(node1Claimed) != 5 {
+		t.Fatalf("Node 1 expected 5 claimed records, got %d", len(node1Claimed))
+	}
+
+	// Node 1 CRASHES (no MarkPublished)
+
+	// Node 2 tries immediately -> 0 records
+	node2Immediate, err := repo.ClaimBatch(ctx, 5, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Node 2 immediate ClaimBatch failed: %v", err)
+	}
+	if len(node2Immediate) != 0 {
+		t.Errorf("Node 2 expected 0 records while Node 1 lock active, got %d", len(node2Immediate))
+	}
+
+	// Wait 150ms for lock expiration
+	time.Sleep(150 * time.Millisecond)
+
+	// Node 2 tries after lock expired -> claims all 5
+	node2Recovered, err := repo.ClaimBatch(ctx, 5, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Node 2 failover ClaimBatch failed: %v", err)
+	}
+	if len(node2Recovered) != 5 {
+		t.Errorf("Node 2 expected 5 recovered records after Node 1 crash, got %d", len(node2Recovered))
+	}
+
+	recIDs := make([]string, len(node2Recovered))
+	for i, r := range node2Recovered {
+		recIDs[i] = r.ID
+	}
+	if err := repo.MarkPublished(ctx, recIDs); err != nil {
+		t.Fatalf("Node 2 MarkPublished failed: %v", err)
+	}
+
+	unpub, err := repo.FetchUnpublished(ctx, 10)
+	if err != nil {
+		t.Fatalf("FetchUnpublished failed: %v", err)
+	}
+	if len(unpub) != 0 {
+		t.Errorf("Expected 0 leftover unpublished records, got %d", len(unpub))
 	}
 }

--- a/internal/workout_execution/infrastructure/worker/outbox_worker_test.go
+++ b/internal/workout_execution/infrastructure/worker/outbox_worker_test.go
@@ -34,6 +34,13 @@ func (m *mockOutboxRepo) MarkPublished(ctx context.Context, ids []string) error 
 	return m.markErr
 }
 
+func (m *mockOutboxRepo) ClaimBatch(ctx context.Context, limit int, _ time.Duration) ([]*port.OutboxRecord, error) {
+	if m.lockErr != nil {
+		return nil, m.lockErr
+	}
+	return m.FetchUnpublished(ctx, limit)
+}
+
 func (m *mockOutboxRepo) ProcessBatch(ctx context.Context, limit int, publishFn func(ctx context.Context, records []*port.OutboxRecord) error) error {
 	if m.lockErr != nil {
 		return m.lockErr

--- a/scripts/postgres-init/01-init-schemas.sql
+++ b/scripts/postgres-init/01-init-schemas.sql
@@ -18,7 +18,9 @@ CREATE TABLE IF NOT EXISTS auth.outbox (
     partition_key VARCHAR(255) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     published BOOLEAN DEFAULT FALSE,
-    published_at TIMESTAMP WITH TIME ZONE
+    published_at TIMESTAMP WITH TIME ZONE,
+    status VARCHAR(50) DEFAULT 'PENDING' NOT NULL,
+    locked_until TIMESTAMP WITH TIME ZONE
 );
 
 CREATE TABLE IF NOT EXISTS auth.outbox_log (
@@ -45,7 +47,9 @@ CREATE TABLE IF NOT EXISTS profile.outbox (
     partition_key VARCHAR(255) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     published BOOLEAN DEFAULT FALSE,
-    published_at TIMESTAMP WITH TIME ZONE
+    published_at TIMESTAMP WITH TIME ZONE,
+    status VARCHAR(50) DEFAULT 'PENDING' NOT NULL,
+    locked_until TIMESTAMP WITH TIME ZONE
 );
 
 CREATE TABLE IF NOT EXISTS profile.outbox_log (
@@ -72,7 +76,9 @@ CREATE TABLE IF NOT EXISTS coaching.outbox (
     partition_key VARCHAR(255) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     published BOOLEAN DEFAULT FALSE,
-    published_at TIMESTAMP WITH TIME ZONE
+    published_at TIMESTAMP WITH TIME ZONE,
+    status VARCHAR(50) DEFAULT 'PENDING' NOT NULL,
+    locked_until TIMESTAMP WITH TIME ZONE
 );
 
 CREATE TABLE IF NOT EXISTS coaching.outbox_log (
@@ -101,7 +107,9 @@ CREATE TABLE IF NOT EXISTS workout_execution.outbox (
     partition_key VARCHAR(255) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     published BOOLEAN DEFAULT FALSE,
-    published_at TIMESTAMP WITH TIME ZONE
+    published_at TIMESTAMP WITH TIME ZONE,
+    status VARCHAR(50) DEFAULT 'PENDING' NOT NULL,
+    locked_until TIMESTAMP WITH TIME ZONE
 );
 
 CREATE TABLE IF NOT EXISTS workout_execution.outbox_log (
@@ -128,7 +136,9 @@ CREATE TABLE IF NOT EXISTS nutrition.outbox (
     partition_key VARCHAR(255) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     published BOOLEAN DEFAULT FALSE,
-    published_at TIMESTAMP WITH TIME ZONE
+    published_at TIMESTAMP WITH TIME ZONE,
+    status VARCHAR(50) DEFAULT 'PENDING' NOT NULL,
+    locked_until TIMESTAMP WITH TIME ZONE
 );
 
 CREATE TABLE IF NOT EXISTS nutrition.outbox_log (
@@ -155,7 +165,9 @@ CREATE TABLE IF NOT EXISTS notification.outbox (
     partition_key VARCHAR(255) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     published BOOLEAN DEFAULT FALSE,
-    published_at TIMESTAMP WITH TIME ZONE
+    published_at TIMESTAMP WITH TIME ZONE,
+    status VARCHAR(50) DEFAULT 'PENDING' NOT NULL,
+    locked_until TIMESTAMP WITH TIME ZONE
 );
 
 CREATE TABLE IF NOT EXISTS notification.outbox_log (
@@ -182,7 +194,9 @@ CREATE TABLE IF NOT EXISTS audio.outbox (
     partition_key VARCHAR(255) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     published BOOLEAN DEFAULT FALSE,
-    published_at TIMESTAMP WITH TIME ZONE
+    published_at TIMESTAMP WITH TIME ZONE,
+    status VARCHAR(50) DEFAULT 'PENDING' NOT NULL,
+    locked_until TIMESTAMP WITH TIME ZONE
 );
 
 CREATE TABLE IF NOT EXISTS audio.outbox_log (
@@ -209,7 +223,9 @@ CREATE TABLE IF NOT EXISTS exercise.outbox (
     partition_key VARCHAR(255) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     published BOOLEAN DEFAULT FALSE,
-    published_at TIMESTAMP WITH TIME ZONE
+    published_at TIMESTAMP WITH TIME ZONE,
+    status VARCHAR(50) DEFAULT 'PENDING' NOT NULL,
+    locked_until TIMESTAMP WITH TIME ZONE
 );
 
 CREATE TABLE IF NOT EXISTS exercise.outbox_log (
@@ -234,4 +250,11 @@ CREATE INDEX IF NOT EXISTS idx_nutrition_outbox_published_created ON nutrition.o
 CREATE INDEX IF NOT EXISTS idx_notification_outbox_published_created ON notification.outbox (published, created_at);
 CREATE INDEX IF NOT EXISTS idx_audio_outbox_published_created ON audio.outbox (published, created_at);
 CREATE INDEX IF NOT EXISTS idx_exercise_outbox_published_created ON exercise.outbox (published, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_auth_outbox_claim ON auth.outbox (published, status, locked_until, created_at);
+CREATE INDEX IF NOT EXISTS idx_profile_outbox_claim ON profile.outbox (published, status, locked_until, created_at);
+CREATE INDEX IF NOT EXISTS idx_coaching_outbox_claim ON coaching.outbox (published, status, locked_until, created_at);
+CREATE INDEX IF NOT EXISTS idx_workout_execution_outbox_claim ON workout_execution.outbox (published, status, locked_until, created_at);
+CREATE INDEX IF NOT EXISTS idx_exercise_outbox_claim ON exercise.outbox (published, status, locked_until, created_at);
+
 


### PR DESCRIPTION
### 1. Problem to Solve
- **DB Transaction bị block bởi Network Call**: Ở thiết kế Outbox cũ, worker mở DB transaction và thực hiện `FOR UPDATE SKIP LOCKED` kéo dài xuyên suốt cả quá trình gửi mạng sang Kafka (`PublishBatch`). Khi mạng latency hoặc Kafka chậm/sập, DB Connection pool bị treo và cạn kiệt.
- **Node Crash Failover**: Nếu 1 Worker Node lấy event rồi bị sập nguồn giữa chừng, event sẽ bị khóa vĩnh viễn nếu không có cơ chế nhả khóa tự động.

### 2. Proposed Solution
- **Thiết kế Outbox Pattern 2-Pha (2-Phase Atomic Claiming)**:
  - **Pha 1 (`ClaimBatch`)**: Mở DB Transaction siêu ngắn (~2ms) cập nhật `status = 'PROCESSING'` và gán `locked_until = NOW() + 30s`.
  - **Pha 2 (`PublishBatch`)**: Thực hiện đẩy message sang Kafka hoàn toàn **NẰM NGOÀI DB Transaction**, trả lại DB Connection Pool lập tức.
  - **Pha 3 (`MarkPublished`)**: Đánh dấu `published = true`, `status = 'PUBLISHED'` trong DB.
- Áp dụng đồng bộ cho toàn bộ **5 modules** trong dự án: `auth`, `coaching`, `workout_execution`, `profile`, `exercise`.

### 3. Changes & Impact
- `[scripts/postgres-init/01-init-schemas.sql](scripts/postgres-init/01-init-schemas.sql)`: Bổ sung cột `status`, `locked_until` và tạo Claim Index cho 8 bảng outbox.
- `[internal/auth/](internal/auth/)`: Cập nhật ports, GORM persistence, và bổ sung bộ integration test 3-Node Concurrency & Failover.
- `[internal/coaching/](internal/coaching/)`: Cập nhật ports, GORM persistence, và bổ sung bộ integration test `outbox_repository_integration_test.go`.
- `[internal/workout_execution/](internal/workout_execution/)`: Cập nhật ports, GORM persistence, và bổ sung bộ integration test 3-Node Concurrency & Failover.
- `[internal/profile/](internal/profile/)`: Cập nhật ports, GORM persistence, và bổ sung bộ integration test 3-Node Concurrency & Failover.
- `[internal/exercise/](internal/exercise/)`: Cập nhật ports, GORM persistence, và bổ sung bộ integration test 3-Node Concurrency & Failover.

### 4. Testing & Verification
- **Automated Tests**:
  - `go test -tags=unit ./...`: PASS 100% tất cả Unit Tests.
  - `go test -tags=integration ...`: PASS 100% tất cả các kịch bản 3 Concurrent Nodes và Node Crash Failover trên PostgreSQL thực tế.
  - `go vet -tags="unit,integration,e2e" ./...`: PASS 0 warning/error.
- **Manual Verification**:
  - Biên dịch dự án `go build ./cmd/api` thành công 100%.
