### PR TITLE
🐛 fix(auth): wrap key rotation in DB transaction and add atomic key deactivation

### DIFF
--- a/internal/auth/application/command/mocks_test.go
+++ b/internal/auth/application/command/mocks_test.go
@@ -114,6 +114,15 @@ func (m *mockKeyRepo) UpdateStatus(ctx context.Context, id string, status string
 	return apperror.ErrKeyNotFound
 }
 
+func (m *mockKeyRepo) DeactivateAllActiveKeys(ctx context.Context) error {
+	for _, k := range m.keys {
+		if k.Status == port.KeyStatusActive {
+			k.Status = port.KeyStatusInactive
+		}
+	}
+	return nil
+}
+
 func (m *mockKeyRepo) DeleteExpiredKeys(ctx context.Context) error {
 	return nil
 }

--- a/internal/auth/application/command/rotate_keys.go
+++ b/internal/auth/application/command/rotate_keys.go
@@ -18,24 +18,27 @@ type RotateKeysCommand struct {
 
 // RotateKeysHandler generates a new key pair, sets it active, and deactivates old active ones.
 type RotateKeysHandler struct {
-	keyRepo port.KeyRepository
-	keyGen  port.KeyGenerator
+	keyRepo   port.KeyRepository
+	keyGen    port.KeyGenerator
+	txManager port.TransactionManager
 }
 
 // NewRotateKeysHandler constructs a RotateKeysHandler instance.
 func NewRotateKeysHandler(
 	keyRepo port.KeyRepository,
 	keyGen port.KeyGenerator,
+	txManager port.TransactionManager,
 ) *RotateKeysHandler {
 	return &RotateKeysHandler{
-		keyRepo: keyRepo,
-		keyGen:  keyGen,
+		keyRepo:   keyRepo,
+		keyGen:    keyGen,
+		txManager: txManager,
 	}
 }
 
 // Handle executes the key rotation logic.
 func (h *RotateKeysHandler) Handle(ctx context.Context, cmd RotateKeysCommand) (string, error) {
-	// 1. Generate new active key
+	// 1. Generate new active key in memory
 	privPEM, pubPEM, err := h.keyGen.Generate(ctx)
 	if err != nil {
 		return "", fmt.Errorf("generate key pair: %w", err)
@@ -52,26 +55,33 @@ func (h *RotateKeysHandler) Handle(ctx context.Context, cmd RotateKeysCommand) (
 		ExpiresAt:     now.Add(cmd.KeyTTL),
 	}
 
-	// 2. Save new key
-	if err := h.keyRepo.Save(ctx, newKey); err != nil {
-		return "", fmt.Errorf("save new key: %w", err)
-	}
-
-	// 3. Find and deprecate all previous active keys to inactive status
-	keys, err := h.keyRepo.GetAllActiveAndInactiveKeys(ctx)
-	if err == nil {
-		for _, key := range keys {
-			if key.ID != newKey.ID && key.Status == port.KeyStatusActive {
-				if err := h.keyRepo.UpdateStatus(ctx, key.ID, port.KeyStatusInactive); err != nil {
-					log.Printf("WARNING: Failed to deprecate key %s: %v", key.ID, err)
-				}
-			}
+	executeRotation := func(txCtx context.Context) error {
+		// 2. Deactivate all previous active keys
+		if err := h.keyRepo.DeactivateAllActiveKeys(txCtx); err != nil {
+			return fmt.Errorf("deactivate active keys: %w", err)
 		}
+
+		// 3. Save new key
+		if err := h.keyRepo.Save(txCtx, newKey); err != nil {
+			return fmt.Errorf("save new key: %w", err)
+		}
+
+		// 4. Purge expired keys (expired inactive keys)
+		if err := h.keyRepo.DeleteExpiredKeys(txCtx); err != nil {
+			log.Printf("WARNING: Failed to purge expired keys: %v", err)
+		}
+
+		return nil
 	}
 
-	// 4. Purge expired keys (expired inactive keys)
-	if err := h.keyRepo.DeleteExpiredKeys(ctx); err != nil {
-		log.Printf("WARNING: Failed to purge expired keys: %v", err)
+	if h.txManager != nil {
+		if err := h.txManager.WithTransaction(ctx, executeRotation); err != nil {
+			return "", fmt.Errorf("rotate keys transaction: %w", err)
+		}
+	} else {
+		if err := executeRotation(ctx); err != nil {
+			return "", err
+		}
 	}
 
 	return newKey.ID, nil

--- a/internal/auth/application/command/rotate_keys_test.go
+++ b/internal/auth/application/command/rotate_keys_test.go
@@ -14,7 +14,8 @@ func TestRotateKeysHandler(t *testing.T) {
 	ctx := context.Background()
 	keyRepo := &mockKeyRepo{}
 	keyGen := &mockKeyGenerator{privPEM: "mock-priv-pem", pubPEM: "mock-pub-pem"}
-	handler := NewRotateKeysHandler(keyRepo, keyGen)
+	txManager := &mockTxManager{}
+	handler := NewRotateKeysHandler(keyRepo, keyGen, txManager)
 
 	// --- First rotation ---
 	kid, err := handler.Handle(ctx, RotateKeysCommand{KeyTTL: 1 * time.Hour})

--- a/internal/auth/application/port/key_repository.go
+++ b/internal/auth/application/port/key_repository.go
@@ -33,5 +33,6 @@ type KeyRepository interface {
 	GetActiveKey(ctx context.Context) (*JWKRecord, error)
 	GetAllActiveAndInactiveKeys(ctx context.Context) ([]*JWKRecord, error)
 	UpdateStatus(ctx context.Context, id string, status string) error
+	DeactivateAllActiveKeys(ctx context.Context) error
 	DeleteExpiredKeys(ctx context.Context) error
 }

--- a/internal/auth/application/query/get_jwks_test.go
+++ b/internal/auth/application/query/get_jwks_test.go
@@ -45,6 +45,10 @@ func (m *mockKeyRepository) UpdateStatus(ctx context.Context, id string, status 
 	return nil
 }
 
+func (m *mockKeyRepository) DeactivateAllActiveKeys(ctx context.Context) error {
+	return nil
+}
+
 func (m *mockKeyRepository) DeleteExpiredKeys(ctx context.Context) error {
 	return nil
 }

--- a/internal/auth/infrastructure/jwt/signer_test.go
+++ b/internal/auth/infrastructure/jwt/signer_test.go
@@ -56,6 +56,15 @@ func (m *mockKeyRepository) UpdateStatus(ctx context.Context, id string, status 
 	return apperror.ErrKeyNotFound
 }
 
+func (m *mockKeyRepository) DeactivateAllActiveKeys(ctx context.Context) error {
+	for _, key := range m.keys {
+		if key.Status == port.KeyStatusActive {
+			key.Status = port.KeyStatusInactive
+		}
+	}
+	return nil
+}
+
 func (m *mockKeyRepository) DeleteExpiredKeys(ctx context.Context) error {
 	var active []*port.JWKRecord
 	for _, key := range m.keys {

--- a/internal/auth/infrastructure/persistence/postgres/key_repository.go
+++ b/internal/auth/infrastructure/persistence/postgres/key_repository.go
@@ -94,6 +94,20 @@ func (r *KeyRepository) UpdateStatus(ctx context.Context, id string, status stri
 	return nil
 }
 
+// DeactivateAllActiveKeys updates all active keys to inactive status.
+func (r *KeyRepository) DeactivateAllActiveKeys(ctx context.Context) error {
+	err := r.getDB(ctx).
+		Model(&JSONWebKeyModel{}).
+		Where("status = ?", port.KeyStatusActive).
+		Update("status", port.KeyStatusInactive).
+		Error
+
+	if err != nil {
+		return fmt.Errorf("gorm deactivate all active keys: %w", err)
+	}
+	return nil
+}
+
 // DeleteExpiredKeys purges inactive keys whose expiration time has passed.
 func (r *KeyRepository) DeleteExpiredKeys(ctx context.Context) error {
 	err := r.getDB(ctx).

--- a/internal/auth/module.go
+++ b/internal/auth/module.go
@@ -105,7 +105,7 @@ func Initialize(ctx context.Context, deps ModuleDeps) (func(), error) {
 		txManager,
 	)
 	logoutHandler := command.NewLogoutHandler(sessRepo)
-	rotateKeysHandler := command.NewRotateKeysHandler(keyRepo, keyGen)
+	rotateKeysHandler := command.NewRotateKeysHandler(keyRepo, keyGen, txManager)
 	getJWKSHandler := query.NewGetJWKSHandler(keyRepo)
 	getOAuthLoginURLHandler := query.NewGetOAuthLoginURLHandler(oauthServ)
 


### PR DESCRIPTION
## Tổng quan Thay đổi (Summary of Changes)
- **Khắc phục Race Condition & Thiếu DB Transaction khi Rotate Key**:
  - Bọc toàn bộ luồng xử lý trong \RotateKeysHandler.Handle\ vào một DB Transaction duy nhất (\	xManager.WithTransaction\), đảm bảo tính nguyên tố (atomicity) tuyệt đối.
  - Bổ sung phương thức \DeactivateAllActiveKeys\ vào interface \port.KeyRepository\ và triển khai trên PostgreSQL để thực thi 1 câu lệnh SQL atomic:
    \UPDATE json_web_keys SET status = 'inactive' WHERE status = 'active'\
  - Loại bỏ hoàn toàn vòng lặp \or\ đọc/cập nhật lẻ tẻ cũ, tối ưu hiệu năng và ngăn chặn tình trạng tồn tại nhiều khóa \ctive\ cùng lúc khi xảy ra sự cố hoặc request đồng thời.
- **Khởi tạo & Testing**:
  - Cập nhật hàm khởi tạo \NewRotateKeysHandler\ trong \module.go\ nhận thêm \	xManager\.
  - Cập nhật các mock repository và test cases liên quan trong bộ unit test.

## Kiểm thử & Xác minh (Testing & Verification)
- [x] Đã chạy \go vet ./internal/auth/...\ (Vượt qua 100%, không có lỗi).
- [x] Đã chạy \go test -v -tags=unit ./internal/auth/...\ (Vượt qua 100% tất cả test suites).