### PR TITLE
♻️ refactor(workout_execution): remove dead userClient code & support optional BodyMetricUpdated event

### DIFF
--- a/internal/workout_execution/application/command/complete_workout_session.go
+++ b/internal/workout_execution/application/command/complete_workout_session.go
@@ -15,7 +15,7 @@ import (
 type CompleteWorkoutSessionCommand struct {
 	SessionID       string
 	ConfirmOverload bool
-	WeightUpdateKg  *float32
+	WeightUpdateKg  *float32 // optional: nil nếu người dùng không cập nhật cân nặng mới
 }
 
 // CompleteWorkoutSessionResult result.
@@ -33,7 +33,6 @@ type CompleteWorkoutSessionHandler struct {
 	sessionRepo    repository.WorkoutSessionRepository
 	loadGuard      *service.TrainingLoadGuard
 	exerciseClient port.ExerciseCatalogClient
-	userClient     port.UserProfileClient
 	outbox         port.OutboxWriter
 	txManager      port.TxManager
 }
@@ -43,7 +42,6 @@ func NewCompleteWorkoutSessionHandler(
 	sessionRepo repository.WorkoutSessionRepository,
 	loadGuard *service.TrainingLoadGuard,
 	exerciseClient port.ExerciseCatalogClient,
-	userClient port.UserProfileClient,
 	outbox port.OutboxWriter,
 	txManager port.TxManager,
 ) *CompleteWorkoutSessionHandler {
@@ -51,7 +49,6 @@ func NewCompleteWorkoutSessionHandler(
 		sessionRepo:    sessionRepo,
 		loadGuard:      loadGuard,
 		exerciseClient: exerciseClient,
-		userClient:     userClient,
 		outbox:         outbox,
 		txManager:      txManager,
 	}
@@ -98,9 +95,9 @@ func (h *CompleteWorkoutSessionHandler) Handle(
 		return nil, completeErr
 	}
 
-	// 3. User Weight Update (UC-03.4 Alternative Flow A3)
-	if cmd.WeightUpdateKg != nil && h.userClient != nil {
-		_ = h.userClient.UpdateBodyWeight(ctx, session.UserID(), *cmd.WeightUpdateKg)
+	// 3. Record optional BodyMetricUpdated event if weight update was provided by user (UC-03.4 A3)
+	if cmd.WeightUpdateKg != nil && *cmd.WeightUpdateKg > 0 {
+		session.RecordBodyMetricUpdate(*cmd.WeightUpdateKg)
 	}
 
 	// 4. Save and Publish Outbox Events

--- a/internal/workout_execution/application/command/complete_workout_session_test.go
+++ b/internal/workout_execution/application/command/complete_workout_session_test.go
@@ -22,7 +22,7 @@ func (m *mockVolumeProvider) GetRecentVolumesForMuscleGroup(ctx context.Context,
 
 func TestCompleteWorkoutSessionHandler(t *testing.T) {
 	t.Run("invalid input", func(t *testing.T) {
-		h := command.NewCompleteWorkoutSessionHandler(&mockSessionRepo{}, nil, nil, nil, nil, &mockTxManager{})
+		h := command.NewCompleteWorkoutSessionHandler(&mockSessionRepo{}, nil, nil, nil, &mockTxManager{})
 		_, err := h.Handle(context.Background(), command.CompleteWorkoutSessionCommand{})
 		if !errors.Is(err, apperror.ErrInvalidInput) {
 			t.Errorf("got %v, want %v", err, apperror.ErrInvalidInput)
@@ -30,7 +30,7 @@ func TestCompleteWorkoutSessionHandler(t *testing.T) {
 	})
 
 	t.Run("find session error", func(t *testing.T) {
-		h := command.NewCompleteWorkoutSessionHandler(&mockSessionRepo{findErr: errors.New("db error")}, nil, nil, nil, nil, &mockTxManager{})
+		h := command.NewCompleteWorkoutSessionHandler(&mockSessionRepo{findErr: errors.New("db error")}, nil, nil, nil, &mockTxManager{})
 		_, err := h.Handle(context.Background(), command.CompleteWorkoutSessionCommand{SessionID: "s1"})
 		if err == nil {
 			t.Fatal("got nil, want error")
@@ -38,7 +38,7 @@ func TestCompleteWorkoutSessionHandler(t *testing.T) {
 	})
 
 	t.Run("session not found", func(t *testing.T) {
-		h := command.NewCompleteWorkoutSessionHandler(&mockSessionRepo{}, nil, nil, nil, nil, &mockTxManager{})
+		h := command.NewCompleteWorkoutSessionHandler(&mockSessionRepo{}, nil, nil, nil, &mockTxManager{})
 		_, err := h.Handle(context.Background(), command.CompleteWorkoutSessionCommand{SessionID: "s1"})
 		if !errors.Is(err, derror.ErrWorkoutSessionNotFound) {
 			t.Errorf("got %v, want %v", err, derror.ErrWorkoutSessionNotFound)
@@ -61,7 +61,6 @@ func TestCompleteWorkoutSessionHandler(t *testing.T) {
 			guard,
 			&mockExerciseClient{group: "Chest"},
 			nil,
-			nil,
 			&mockTxManager{},
 		)
 
@@ -75,7 +74,7 @@ func TestCompleteWorkoutSessionHandler(t *testing.T) {
 		session, _ := aggregate.NewWorkoutSession("s1", "u1", "p1")
 		h := command.NewCompleteWorkoutSessionHandler(
 			&mockSessionRepo{session: session, saveErr: errors.New("save error")},
-			nil, nil, nil, nil,
+			nil, nil, nil,
 			&mockTxManager{},
 		)
 		_, err := h.Handle(context.Background(), command.CompleteWorkoutSessionCommand{SessionID: "s1"})
@@ -88,7 +87,7 @@ func TestCompleteWorkoutSessionHandler(t *testing.T) {
 		session, _ := aggregate.NewWorkoutSession("s1", "u1", "p1")
 		h := command.NewCompleteWorkoutSessionHandler(
 			&mockSessionRepo{session: session},
-			nil, nil, nil,
+			nil, nil,
 			&mockOutboxWriter{err: errors.New("outbox err")},
 			&mockTxManager{},
 		)
@@ -98,7 +97,7 @@ func TestCompleteWorkoutSessionHandler(t *testing.T) {
 		}
 	})
 
-	t.Run("success with weight update and exercise client", func(t *testing.T) {
+	t.Run("success with exercise client", func(t *testing.T) {
 		session, _ := aggregate.NewWorkoutSession("s1", "u1", "p1")
 		_ = session.LogSet(aggregate.WorkoutSetLog{
 			SetNumber:  1,
@@ -108,23 +107,47 @@ func TestCompleteWorkoutSessionHandler(t *testing.T) {
 			Weight:     50.0,
 		})
 
-		weightKg := float32(75.5)
 		guard := service.NewTrainingLoadGuard(&mockVolumeProvider{volumes: []float32{500.0}})
 		h := command.NewCompleteWorkoutSessionHandler(
 			&mockSessionRepo{session: session},
 			guard,
 			&mockExerciseClient{group: "Chest"},
-			&mockUserClient{},
 			&mockOutboxWriter{},
 			&mockTxManager{},
 		)
 
-		res, err := h.Handle(context.Background(), command.CompleteWorkoutSessionCommand{SessionID: "s1", WeightUpdateKg: &weightKg})
+		res, err := h.Handle(context.Background(), command.CompleteWorkoutSessionCommand{SessionID: "s1"})
 		if err != nil {
 			t.Fatalf("got err = %v, want nil", err)
 		}
 		if res.SessionID != "s1" || res.TotalSets != 1 {
 			t.Errorf("got invalid summary result: %+v", res)
+		}
+	})
+
+	t.Run("success with optional weight update emits BodyMetricUpdated event", func(t *testing.T) {
+		session, _ := aggregate.NewWorkoutSession("s1", "u1", "p1")
+		outbox := &mockOutboxWriter{}
+		h := command.NewCompleteWorkoutSessionHandler(
+			&mockSessionRepo{session: session},
+			nil, nil,
+			outbox,
+			&mockTxManager{},
+		)
+
+		weight := float32(75.5)
+		res, err := h.Handle(context.Background(), command.CompleteWorkoutSessionCommand{
+			SessionID:      "s1",
+			WeightUpdateKg: &weight,
+		})
+		if err != nil {
+			t.Fatalf("got err = %v, want nil", err)
+		}
+		if res.SessionID != "s1" {
+			t.Errorf("got invalid result: %+v", res)
+		}
+		if len(outbox.events) != 3 {
+			t.Errorf("got %d events in outbox, want 3 (WorkoutSessionStarted + WorkoutSessionCompleted + BodyMetricUpdated)", len(outbox.events))
 		}
 	})
 }

--- a/internal/workout_execution/application/command/mocks_test.go
+++ b/internal/workout_execution/application/command/mocks_test.go
@@ -164,12 +164,14 @@ func (m *mockTxManager) WithTransaction(ctx context.Context, fn func(ctx context
 type mockOutboxWriter struct {
 	err          error
 	writtenCount int
+	events       []interface{}
 }
 
 func (m *mockOutboxWriter) WriteEvents(ctx context.Context, aggregateType, aggregateID string, events []interface{}) error {
 	if m.err != nil {
 		return m.err
 	}
+	m.events = append(m.events, events...)
 	m.writtenCount += len(events)
 	return nil
 }

--- a/internal/workout_execution/application/port/external_clients.go
+++ b/internal/workout_execution/application/port/external_clients.go
@@ -11,8 +11,3 @@ type DailyWorkoutPlanClient interface {
 type ExerciseCatalogClient interface {
 	GetExerciseMuscleGroup(ctx context.Context, exerciseID string) (string, error)
 }
-
-// UserProfileClient provides integration with User Profile context (UC-03.4 A3).
-type UserProfileClient interface {
-	UpdateBodyWeight(ctx context.Context, userID string, weightKg float32) error
-}

--- a/internal/workout_execution/domain/aggregate/workout_session.go
+++ b/internal/workout_execution/domain/aggregate/workout_session.go
@@ -425,6 +425,18 @@ func (s *WorkoutSession) Complete(confirmOverload, isOverloaded bool) error {
 	return nil
 }
 
+// RecordBodyMetricUpdate emits a BodyMetricUpdated event if body weight update is provided by user.
+func (s *WorkoutSession) RecordBodyMetricUpdate(weightKg float32) {
+	if weightKg <= 0 {
+		return
+	}
+	s.addDomainEvent(&event.BodyMetricUpdated{
+		UserID:     s.userID,
+		WeightKg:   weightKg,
+		RecordedAt: time.Now().UTC(),
+	})
+}
+
 // Abort transitions status to ABORTED.
 func (s *WorkoutSession) Abort(reason string) error {
 	if s.status == StatusCompleted || s.status == StatusAborted || s.status == StatusAnomalous {

--- a/internal/workout_execution/infrastructure/transport/grpc_handler.go
+++ b/internal/workout_execution/infrastructure/transport/grpc_handler.go
@@ -201,8 +201,16 @@ func (h *GRPCHandler) AbortWorkoutSession(ctx context.Context, req *workoutexecu
 }
 
 func (h *GRPCHandler) CompleteWorkoutSession(ctx context.Context, req *workoutexecutionv1message.CompleteWorkoutSessionRequest) (*workoutexecutionv1message.CompleteWorkoutSessionResponse, error) {
+	var weightUpdate *float32
+	if req.WeightUpdateKg != nil {
+		w := req.GetWeightUpdateKg()
+		weightUpdate = &w
+	}
+
 	cmd := command.CompleteWorkoutSessionCommand{
-		SessionID: req.GetSessionId(),
+		SessionID:       req.GetSessionId(),
+		ConfirmOverload: req.GetConfirmOverload(),
+		WeightUpdateKg:  weightUpdate,
 	}
 
 	res, err := h.completeSessionHandler.Handle(ctx, cmd)

--- a/internal/workout_execution/infrastructure/transport/grpc_handler_test.go
+++ b/internal/workout_execution/infrastructure/transport/grpc_handler_test.go
@@ -146,7 +146,7 @@ func TestGRPCHandler(t *testing.T) {
 	startH := command.NewStartWorkoutSessionHandler(sessionRepo, nil, nil, tx)
 	startScheduledH := command.NewStartScheduledWorkoutSessionHandler(sessionRepo, nil, tx)
 	logSetH := command.NewLogWorkoutSetHandler(sessionRepo)
-	completeH := command.NewCompleteWorkoutSessionHandler(sessionRepo, nil, nil, nil, nil, tx)
+	completeH := command.NewCompleteWorkoutSessionHandler(sessionRepo, nil, nil, nil, tx)
 	abortH := command.NewAbortWorkoutSessionHandler(sessionRepo, nil, tx)
 	syncH := command.NewSyncWorkoutLogsHandler(sessionRepo, nil, tx)
 
@@ -475,7 +475,7 @@ func TestLogWorkoutSet_ErrorMapping(t *testing.T) {
 			startH := command.NewStartWorkoutSessionHandler(repo, nil, nil, tx)
 			startScheduledH := command.NewStartScheduledWorkoutSessionHandler(repo, nil, tx)
 			logSetH := command.NewLogWorkoutSetHandler(repo)
-			completeH := command.NewCompleteWorkoutSessionHandler(repo, nil, nil, nil, nil, tx)
+			completeH := command.NewCompleteWorkoutSessionHandler(repo, nil, nil, nil, tx)
 			abortH := command.NewAbortWorkoutSessionHandler(repo, nil, tx)
 			syncH := command.NewSyncWorkoutLogsHandler(repo, nil, tx)
 			motionQ := query.NewGetMotionSpecificationQueryHandler(motionRepo)

--- a/internal/workout_execution/module.go
+++ b/internal/workout_execution/module.go
@@ -62,7 +62,7 @@ func Initialize(ctx context.Context, deps ModuleDeps) (func(), error) {
 	startSessionHandler := command.NewStartWorkoutSessionHandler(sessionRepo, nil, outboxWriter, txManager)
 	startScheduledSessionHandler := command.NewStartScheduledWorkoutSessionHandler(sessionRepo, outboxWriter, txManager)
 	logSetHandler := command.NewLogWorkoutSetHandler(sessionRepo)
-	completeSessionHandler := command.NewCompleteWorkoutSessionHandler(sessionRepo, loadGuard, nil, nil, outboxWriter, txManager)
+	completeSessionHandler := command.NewCompleteWorkoutSessionHandler(sessionRepo, loadGuard, nil, outboxWriter, txManager)
 	abortSessionHandler := command.NewAbortWorkoutSessionHandler(sessionRepo, outboxWriter, txManager)
 	syncLogsHandler := command.NewSyncWorkoutLogsHandler(sessionRepo, outboxWriter, txManager)
 	prProcessHandler := command.NewProcessCompletedSessionForPRHandler(sessionRepo, prRepo, outboxWriter, txManager)

--- a/proto/contracts/core/workout_execution/v1/message/workout_execution_messages.proto
+++ b/proto/contracts/core/workout_execution/v1/message/workout_execution_messages.proto
@@ -64,6 +64,7 @@ message AbortWorkoutSessionResponse {
 message CompleteWorkoutSessionRequest {
   string session_id = 1;
   optional bool confirm_overload = 2;
+  optional float weight_update_kg = 3;
 }
 
 message CompleteWorkoutSessionResponse {


### PR DESCRIPTION
## 📝 Tóm tắt các Thay đổi
- **Tái cấu trúc CompleteWorkoutSession**: Loại bỏ mã nguồn thừa/đồng bộ userClient.UpdateBodyWeight RPC vốn có nguy cơ vi phạm thuộc tính nguyên tử (Atomicity) của ACID nếu Database Transaction bị sập/rollback.
- **Triển khai tính năng Cập nhật Cân nặng theo chuẩn Event-Driven**: Bổ sung trường không bắt buộc (optional) weight_update_kg vào Protobuf request CompleteWorkoutSessionRequest. Nếu người dùng nhập chỉ số cân nặng mới, hệ thống sẽ phát sinh Domain Event BodyMetricUpdated và lưu đồng thời vào bảng outbox_events trong CÙNG 1 DATABASE TRANSACTION.
- **Đồng bộ Hợp đồng API & Kiến trúc chuẩn**: Cập nhật file Protobuf workout_execution_messages.proto và Go stubs liên quan, đảm bảo tuân thủ tuyệt đối chuẩn Event-Driven Architecture định nghĩa trong docs/02_bounded_context.md.
- **Kiểm thử tự động (Automated Tests)**: Cập nhật và bổ sung đầy đủ unit test cases trong complete_workout_session_test.go và grpc_handler_test.go.

## 🧪 Xác minh & Kiểm thử
- go vet ./internal/workout_execution/... (0 lỗi)
- go test ./internal/workout_execution/... (100% PASS)