### PR TITLE
🐛 fix(workout-execution): resolve outbox data loss, optimistic locking, and event type panics

### DIFF
--- a/internal/workout_execution/application/command/abort_workout_session.go
+++ b/internal/workout_execution/application/command/abort_workout_session.go
@@ -51,19 +51,20 @@ func (h *AbortWorkoutSessionHandler) Handle(
 		return nil, apperror.ErrInvalidInput
 	}
 
-	session, err := h.sessionRepo.FindByID(ctx, cmd.SessionID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find session: %w", err)
-	}
-	if session == nil {
-		return nil, derror.ErrWorkoutSessionNotFound
-	}
+	var result *AbortWorkoutSessionResult
+	saveFunc := func(txCtx context.Context) error {
+		session, err := h.sessionRepo.FindByIDForUpdate(txCtx, cmd.SessionID)
+		if err != nil {
+			return fmt.Errorf("failed to find session: %w", err)
+		}
+		if session == nil {
+			return derror.ErrWorkoutSessionNotFound
+		}
 
-	if abortErr := session.Abort(cmd.Reason); abortErr != nil {
-		return nil, abortErr
-	}
+		if abortErr := session.Abort(cmd.Reason); abortErr != nil {
+			return abortErr
+		}
 
-	txErr := h.txManager.WithTransaction(ctx, func(txCtx context.Context) error {
 		if saveErr := h.sessionRepo.Save(txCtx, session); saveErr != nil {
 			return saveErr
 		}
@@ -73,20 +74,28 @@ func (h *AbortWorkoutSessionHandler) Handle(
 				return writeErr
 			}
 		}
+
+		var abortedAtStr string
+		if session.EndedAt() != nil {
+			abortedAtStr = session.EndedAt().Format("2006-01-02T15:04:05Z07:00")
+		}
+
+		result = &AbortWorkoutSessionResult{
+			SessionID: session.ID(),
+			AbortedAt: abortedAtStr,
+		}
 		return nil
-	})
-
-	if txErr != nil {
-		return nil, fmt.Errorf("failed to abort session tx: %w", txErr)
 	}
 
-	var abortedAtStr string
-	if session.EndedAt() != nil {
-		abortedAtStr = session.EndedAt().Format("2006-01-02T15:04:05Z07:00")
+	if h.txManager != nil {
+		if txErr := h.txManager.WithTransaction(ctx, saveFunc); txErr != nil {
+			return nil, fmt.Errorf("failed to abort session tx: %w", txErr)
+		}
+	} else {
+		if err := saveFunc(ctx); err != nil {
+			return nil, err
+		}
 	}
 
-	return &AbortWorkoutSessionResult{
-		SessionID: session.ID(),
-		AbortedAt: abortedAtStr,
-	}, nil
+	return result, nil
 }

--- a/internal/workout_execution/application/command/complete_workout_session.go
+++ b/internal/workout_execution/application/command/complete_workout_session.go
@@ -63,46 +63,47 @@ func (h *CompleteWorkoutSessionHandler) Handle(
 		return nil, apperror.ErrInvalidInput
 	}
 
-	session, err := h.sessionRepo.FindByID(ctx, cmd.SessionID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch session: %w", err)
-	}
-	if session == nil {
-		return nil, derror.ErrWorkoutSessionNotFound
-	}
+	var result *CompleteWorkoutSessionResult
+	saveFunc := func(txCtx context.Context) error {
+		session, err := h.sessionRepo.FindByIDForUpdate(txCtx, cmd.SessionID)
+		if err != nil {
+			return fmt.Errorf("failed to fetch session: %w", err)
+		}
+		if session == nil {
+			return derror.ErrWorkoutSessionNotFound
+		}
 
-	// 1. Check Training Load Overload
-	var isOverloaded bool
-	if h.loadGuard != nil && len(session.Sets()) > 0 {
-		firstExerciseID := session.Sets()[0].ExerciseID
-		muscleGroup := "Chest" // Default fallback
-		if h.exerciseClient != nil {
-			mg, clientErr := h.exerciseClient.GetExerciseMuscleGroup(ctx, firstExerciseID)
-			if clientErr == nil && mg != "" {
-				muscleGroup = mg
+		// 1. Check Training Load Overload
+		var isOverloaded bool
+		if h.loadGuard != nil && len(session.Sets()) > 0 {
+			firstExerciseID := session.Sets()[0].ExerciseID
+			muscleGroup := "Chest" // Default fallback
+			if h.exerciseClient != nil {
+				mg, clientErr := h.exerciseClient.GetExerciseMuscleGroup(txCtx, firstExerciseID)
+				if clientErr == nil && mg != "" {
+					muscleGroup = mg
+				}
+			}
+
+			vol := session.CalculateTotalVolume()
+			overloaded, _, guardErr := h.loadGuard.IsOverloaded(txCtx, session.UserID(), muscleGroup, vol)
+			if guardErr == nil {
+				isOverloaded = overloaded
 			}
 		}
 
-		vol := session.CalculateTotalVolume()
-		overloaded, _, guardErr := h.loadGuard.IsOverloaded(ctx, session.UserID(), muscleGroup, vol)
-		if guardErr == nil {
-			isOverloaded = overloaded
+		// 2. Transition domain state to COMPLETED
+		if completeErr := session.Complete(cmd.ConfirmOverload, isOverloaded); completeErr != nil {
+			return completeErr
 		}
-	}
 
-	// 2. Transition domain state to COMPLETED
-	if completeErr := session.Complete(cmd.ConfirmOverload, isOverloaded); completeErr != nil {
-		return nil, completeErr
-	}
+		// 3. Record optional BodyMetricUpdated event if weight update was provided by user (UC-03.4 A3)
+		if cmd.WeightUpdateKg != nil && *cmd.WeightUpdateKg > 0 {
+			session.RecordBodyMetricUpdate(*cmd.WeightUpdateKg)
+		}
 
-	// 3. Record optional BodyMetricUpdated event if weight update was provided by user (UC-03.4 A3)
-	if cmd.WeightUpdateKg != nil && *cmd.WeightUpdateKg > 0 {
-		session.RecordBodyMetricUpdate(*cmd.WeightUpdateKg)
-	}
-
-	// 4. Save and Publish Outbox Events
-	summary := session.CalculateSummary()
-	err = h.txManager.WithTransaction(ctx, func(txCtx context.Context) error {
+		// 4. Save and Publish Outbox Events
+		summary := session.CalculateSummary()
 		if err := h.sessionRepo.Save(txCtx, session); err != nil {
 			return err
 		}
@@ -112,24 +113,32 @@ func (h *CompleteWorkoutSessionHandler) Handle(
 				return err
 			}
 		}
+
+		var completedAtStr string
+		if session.EndedAt() != nil {
+			completedAtStr = session.EndedAt().Format("2006-01-02T15:04:05Z07:00")
+		}
+
+		result = &CompleteWorkoutSessionResult{
+			SessionID:        session.ID(),
+			CompletedAt:      completedAtStr,
+			TotalSets:        summary.TotalSets,
+			TotalVolume:      summary.TotalVolume,
+			AverageFormScore: summary.AverageFormScore,
+			AverageRPE:       summary.AverageRPE,
+		}
 		return nil
-	})
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to complete session tx: %w", err)
 	}
 
-	var completedAtStr string
-	if session.EndedAt() != nil {
-		completedAtStr = session.EndedAt().Format("2006-01-02T15:04:05Z07:00")
+	if h.txManager != nil {
+		if err := h.txManager.WithTransaction(ctx, saveFunc); err != nil {
+			return nil, fmt.Errorf("failed to complete session tx: %w", err)
+		}
+	} else {
+		if err := saveFunc(ctx); err != nil {
+			return nil, err
+		}
 	}
 
-	return &CompleteWorkoutSessionResult{
-		SessionID:        session.ID(),
-		CompletedAt:      completedAtStr,
-		TotalSets:        summary.TotalSets,
-		TotalVolume:      summary.TotalVolume,
-		AverageFormScore: summary.AverageFormScore,
-		AverageRPE:       summary.AverageRPE,
-	}, nil
+	return result, nil
 }

--- a/internal/workout_execution/application/command/log_workout_set.go
+++ b/internal/workout_execution/application/command/log_workout_set.go
@@ -2,11 +2,13 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/viethung213/gym-companion/internal/workout_execution/application/apperror"
+	"github.com/viethung213/gym-companion/internal/workout_execution/application/port"
 	"github.com/viethung213/gym-companion/internal/workout_execution/domain/aggregate"
 	"github.com/viethung213/gym-companion/internal/workout_execution/domain/derror"
 	"github.com/viethung213/gym-companion/internal/workout_execution/domain/repository"
@@ -35,12 +37,20 @@ type LogWorkoutSetResult struct {
 // LogWorkoutSetHandler handles set logging.
 type LogWorkoutSetHandler struct {
 	sessionRepo repository.WorkoutSessionRepository
+	outbox      port.OutboxWriter
+	txManager   port.TxManager
 }
 
 // NewLogWorkoutSetHandler constructs LogWorkoutSetHandler.
-func NewLogWorkoutSetHandler(sessionRepo repository.WorkoutSessionRepository) *LogWorkoutSetHandler {
+func NewLogWorkoutSetHandler(
+	sessionRepo repository.WorkoutSessionRepository,
+	outbox port.OutboxWriter,
+	txManager port.TxManager,
+) *LogWorkoutSetHandler {
 	return &LogWorkoutSetHandler{
 		sessionRepo: sessionRepo,
+		outbox:      outbox,
+		txManager:   txManager,
 	}
 }
 
@@ -48,14 +58,6 @@ func NewLogWorkoutSetHandler(sessionRepo repository.WorkoutSessionRepository) *L
 func (h *LogWorkoutSetHandler) Handle(ctx context.Context, cmd LogWorkoutSetCommand) (*LogWorkoutSetResult, error) {
 	if cmd.SessionID == "" || cmd.ExerciseID == "" {
 		return nil, apperror.ErrInvalidInput
-	}
-
-	session, err := h.sessionRepo.FindByID(ctx, cmd.SessionID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find session: %w", err)
-	}
-	if session == nil {
-		return nil, derror.ErrWorkoutSessionNotFound
 	}
 
 	setLogID := uuid.NewString()
@@ -74,15 +76,58 @@ func (h *LogWorkoutSetHandler) Handle(ctx context.Context, cmd LogWorkoutSetComm
 		CreatedAt:   time.Now().UTC(),
 	}
 
-	if err := session.LogSet(setLog); err != nil {
+	saveFunc := func(txCtx context.Context) error {
+		session, err := h.sessionRepo.FindByIDForUpdate(txCtx, cmd.SessionID)
+		if err != nil {
+			return fmt.Errorf("failed to find session: %w", err)
+		}
+		if session == nil {
+			return derror.ErrWorkoutSessionNotFound
+		}
+
+		if err := session.LogSet(setLog); err != nil {
+			return err
+		}
+
+		if err := h.sessionRepo.Save(txCtx, session); err != nil {
+			return fmt.Errorf("failed to save set log: %w", err)
+		}
+
+		events := session.PopEvents()
+		if len(events) > 0 && h.outbox != nil {
+			if err := h.outbox.WriteEvents(txCtx, "WorkoutSession", session.ID(), events); err != nil {
+				return fmt.Errorf("failed to write outbox events: %w", err)
+			}
+		}
+
+		return nil
+	}
+
+	const maxRetries = 3
+	var lastErr error
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		var err error
+		if h.txManager != nil {
+			err = h.txManager.WithTransaction(ctx, saveFunc)
+		} else {
+			err = saveFunc(ctx)
+		}
+
+		if err == nil {
+			return &LogWorkoutSetResult{
+				SetLogID: setLogID,
+			}, nil
+		}
+
+		if errors.Is(err, derror.ErrOptimisticLocking) {
+			lastErr = err
+			time.Sleep(time.Duration(attempt*20+10) * time.Millisecond)
+			continue
+		}
+
 		return nil, err
 	}
 
-	if err := h.sessionRepo.Save(ctx, session); err != nil {
-		return nil, fmt.Errorf("failed to save set log: %w", err)
-	}
-
-	return &LogWorkoutSetResult{
-		SetLogID: setLogID,
-	}, nil
+	return nil, fmt.Errorf("exceeded max retries on optimistic lock conflict: %w", lastErr)
 }

--- a/internal/workout_execution/application/command/log_workout_set_test.go
+++ b/internal/workout_execution/application/command/log_workout_set_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestLogWorkoutSetHandler(t *testing.T) {
 	t.Run("invalid input", func(t *testing.T) {
-		h := command.NewLogWorkoutSetHandler(&mockSessionRepo{})
+		h := command.NewLogWorkoutSetHandler(&mockSessionRepo{}, newMockOutboxWriter(t), newMockTxManager(t))
 		_, err := h.Handle(context.Background(), command.LogWorkoutSetCommand{})
 		if !errors.Is(err, apperror.ErrInvalidInput) {
 			t.Errorf("got %v, want %v", err, apperror.ErrInvalidInput)
@@ -21,7 +21,7 @@ func TestLogWorkoutSetHandler(t *testing.T) {
 	})
 
 	t.Run("find session error", func(t *testing.T) {
-		h := command.NewLogWorkoutSetHandler(&mockSessionRepo{findErr: errors.New("db error")})
+		h := command.NewLogWorkoutSetHandler(&mockSessionRepo{findErr: errors.New("db error")}, newMockOutboxWriter(t), newMockTxManager(t))
 		_, err := h.Handle(context.Background(), command.LogWorkoutSetCommand{SessionID: "s1", ExerciseID: "ex1"})
 		if err == nil {
 			t.Fatal("got nil, want error")
@@ -29,7 +29,7 @@ func TestLogWorkoutSetHandler(t *testing.T) {
 	})
 
 	t.Run("session not found", func(t *testing.T) {
-		h := command.NewLogWorkoutSetHandler(&mockSessionRepo{})
+		h := command.NewLogWorkoutSetHandler(&mockSessionRepo{}, newMockOutboxWriter(t), newMockTxManager(t))
 		_, err := h.Handle(context.Background(), command.LogWorkoutSetCommand{SessionID: "s1", ExerciseID: "ex1"})
 		if !errors.Is(err, derror.ErrWorkoutSessionNotFound) {
 			t.Errorf("got %v, want %v", err, derror.ErrWorkoutSessionNotFound)
@@ -39,7 +39,7 @@ func TestLogWorkoutSetHandler(t *testing.T) {
 	t.Run("log set error", func(t *testing.T) {
 		session, _ := aggregate.NewWorkoutSession("s1", "u1", "p1")
 		_ = session.Complete(false, false) // session no longer in progress
-		h := command.NewLogWorkoutSetHandler(&mockSessionRepo{session: session})
+		h := command.NewLogWorkoutSetHandler(&mockSessionRepo{session: session}, newMockOutboxWriter(t), newMockTxManager(t))
 		_, err := h.Handle(context.Background(), command.LogWorkoutSetCommand{SessionID: "s1", ExerciseID: "ex1", SetNumber: 1})
 		if err == nil {
 			t.Fatal("got nil, want error")
@@ -48,7 +48,7 @@ func TestLogWorkoutSetHandler(t *testing.T) {
 
 	t.Run("save session error", func(t *testing.T) {
 		session, _ := aggregate.NewWorkoutSession("s1", "u1", "p1")
-		h := command.NewLogWorkoutSetHandler(&mockSessionRepo{session: session, saveErr: errors.New("save err")})
+		h := command.NewLogWorkoutSetHandler(&mockSessionRepo{session: session, saveErr: errors.New("save err")}, newMockOutboxWriter(t), newMockTxManager(t))
 		_, err := h.Handle(context.Background(), command.LogWorkoutSetCommand{SessionID: "s1", ExerciseID: "ex1", SetNumber: 1})
 		if err == nil {
 			t.Fatal("got nil, want error")
@@ -57,7 +57,7 @@ func TestLogWorkoutSetHandler(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		session, _ := aggregate.NewWorkoutSession("s1", "u1", "p1")
-		h := command.NewLogWorkoutSetHandler(&mockSessionRepo{session: session})
+		h := command.NewLogWorkoutSetHandler(&mockSessionRepo{session: session}, newMockOutboxWriter(t), newMockTxManager(t))
 		res, err := h.Handle(context.Background(), command.LogWorkoutSetCommand{SessionID: "s1", ExerciseID: "ex1", SetNumber: 1})
 		if err != nil {
 			t.Fatalf("got err = %v, want nil", err)

--- a/internal/workout_execution/application/command/mocks_test.go
+++ b/internal/workout_execution/application/command/mocks_test.go
@@ -54,6 +54,13 @@ func (m *mockSessionRepo) FindByID(ctx context.Context, id string) (*aggregate.W
 	return m.session, nil
 }
 
+func (m *mockSessionRepo) FindByIDForUpdate(ctx context.Context, id string) (*aggregate.WorkoutSession, error) {
+	if m.findErr != nil {
+		return nil, m.findErr
+	}
+	return m.session, nil
+}
+
 func (m *mockSessionRepo) FindActiveSessionByUserID(ctx context.Context, userID string) (*aggregate.WorkoutSession, error) {
 	if m.findErr != nil {
 		return nil, m.findErr

--- a/internal/workout_execution/application/command/sync_workout_logs.go
+++ b/internal/workout_execution/application/command/sync_workout_logs.go
@@ -55,14 +55,6 @@ func (h *SyncWorkoutLogsHandler) Handle(ctx context.Context, cmd SyncWorkoutLogs
 		return apperror.ErrInvalidInput
 	}
 
-	session, err := h.sessionRepo.FindByID(ctx, cmd.SessionID)
-	if err != nil {
-		return fmt.Errorf("failed to find session: %w", err)
-	}
-	if session == nil {
-		return derror.ErrWorkoutSessionNotFound
-	}
-
 	domainErrors := make([]aggregate.SessionError, len(cmd.Errors))
 	for i, e := range cmd.Errors {
 		domainErrors[i] = aggregate.SessionError{
@@ -77,9 +69,17 @@ func (h *SyncWorkoutLogsHandler) Handle(ctx context.Context, cmd SyncWorkoutLogs
 		}
 	}
 
-	session.AddErrors(domainErrors)
-
 	saveFunc := func(txCtx context.Context) error {
+		session, err := h.sessionRepo.FindByIDForUpdate(txCtx, cmd.SessionID)
+		if err != nil {
+			return fmt.Errorf("failed to find session: %w", err)
+		}
+		if session == nil {
+			return derror.ErrWorkoutSessionNotFound
+		}
+
+		session.AddErrors(domainErrors)
+
 		if err := h.sessionRepo.Save(txCtx, session); err != nil {
 			return err
 		}

--- a/internal/workout_execution/application/query/queries_test.go
+++ b/internal/workout_execution/application/query/queries_test.go
@@ -122,6 +122,18 @@ func (m *mockSessionRepo) FindByID(ctx context.Context, id string) (*aggregate.W
 
 }
 
+func (m *mockSessionRepo) FindByIDForUpdate(ctx context.Context, id string) (*aggregate.WorkoutSession, error) {
+
+	if m.err != nil {
+
+		return nil, m.err
+
+	}
+
+	return m.session, nil
+
+}
+
 func (m *mockSessionRepo) FindActiveSessionByUserID(ctx context.Context, userID string) (*aggregate.WorkoutSession, error) {
 
 	return nil, nil

--- a/internal/workout_execution/domain/aggregate/workout_session.go
+++ b/internal/workout_execution/domain/aggregate/workout_session.go
@@ -114,6 +114,7 @@ type WorkoutSession struct {
 	endedAt      *time.Time
 	createdAt    time.Time
 	updatedAt    time.Time
+	version      int
 	domainEvents []interface{}
 }
 
@@ -134,9 +135,10 @@ func NewWorkoutSession(id, userID, planID string) (*WorkoutSession, error) {
 		startedAt: &now,
 		createdAt: now,
 		updatedAt: now,
+		version:   1,
 	}
 
-	session.addDomainEvent(event.WorkoutSessionStarted{
+	session.addDomainEvent(&event.WorkoutSessionStarted{
 		SessionID: id,
 		UserID:    userID,
 		PlanID:    planID,
@@ -164,6 +166,7 @@ func NewScheduledWorkoutSession(id, userID, planID string, scheduledAt time.Time
 		startedAt:   nil,
 		createdAt:   now,
 		updatedAt:   now,
+		version:     1,
 	}, nil
 }
 
@@ -177,7 +180,12 @@ func ReconstituteWorkoutSession(
 	startedAt *time.Time,
 	endedAt *time.Time,
 	createdAt, updatedAt time.Time,
+	version ...int,
 ) *WorkoutSession {
+	v := 1
+	if len(version) > 0 && version[0] > 0 {
+		v = version[0]
+	}
 	return &WorkoutSession{
 		id:          id,
 		userID:      userID,
@@ -190,6 +198,7 @@ func ReconstituteWorkoutSession(
 		endedAt:     endedAt,
 		createdAt:   createdAt,
 		updatedAt:   updatedAt,
+		version:     v,
 	}
 }
 
@@ -204,6 +213,14 @@ func (s *WorkoutSession) PlanID() string { return s.planID }
 
 // Status returns current status.
 func (s *WorkoutSession) Status() SessionStatus { return s.status }
+
+// Version returns current optimistic locking version of the session aggregate.
+func (s *WorkoutSession) Version() int {
+	if s.version <= 0 {
+		return 1
+	}
+	return s.version
+}
 
 // ScheduledAt returns defensive copy of planned time.
 func (s *WorkoutSession) ScheduledAt() *time.Time {
@@ -236,7 +253,7 @@ func (s *WorkoutSession) Start() error {
 	s.startedAt = &now
 	s.updatedAt = now
 
-	s.addDomainEvent(event.WorkoutSessionStarted{
+	s.addDomainEvent(&event.WorkoutSessionStarted{
 		SessionID: s.id,
 		UserID:    s.userID,
 		PlanID:    s.planID,
@@ -304,7 +321,7 @@ func (s *WorkoutSession) CheckTimeoutAndAutoAbort(now time.Time) bool {
 		ended := now
 		s.endedAt = &ended
 		s.updatedAt = now
-		s.addDomainEvent(event.WorkoutSessionAborted{
+		s.addDomainEvent(&event.WorkoutSessionAborted{
 			SessionID:   s.id,
 			UserID:      s.userID,
 			PlanID:      s.planID,

--- a/internal/workout_execution/domain/derror/errors.go
+++ b/internal/workout_execution/domain/derror/errors.go
@@ -16,5 +16,6 @@ var (
 	ErrPersonalRecordNotFound       = errors.New("personal record not found")
 	ErrInvalidSetNumber             = errors.New("invalid set number")
 	ErrInvalidRepsOrWeight          = errors.New("invalid reps or weight value")
+	ErrOptimisticLocking            = errors.New("concurrent update detected for workout session")
 	ErrNotFound                     = ErrMotionSpecNotFound
 )

--- a/internal/workout_execution/domain/event/events.go
+++ b/internal/workout_execution/domain/event/events.go
@@ -20,7 +20,7 @@ type WorkoutSessionStarted struct {
 
 // EventName returns the CloudEvent type for WorkoutSessionStarted.
 
-func (e WorkoutSessionStarted) EventName() string {
+func (e *WorkoutSessionStarted) EventName() string {
 
 	return "contracts.core.workout_execution.v1.workoutSessionStarted"
 
@@ -42,7 +42,7 @@ type WorkoutSessionCompleted struct {
 
 // EventName returns the CloudEvent type for WorkoutSessionCompleted.
 
-func (e WorkoutSessionCompleted) EventName() string {
+func (e *WorkoutSessionCompleted) EventName() string {
 
 	return "contracts.core.workout_execution.v1.workoutSessionCompleted"
 
@@ -66,7 +66,7 @@ type WorkoutSessionAborted struct {
 
 // EventName returns the CloudEvent type for WorkoutSessionAborted.
 
-func (e WorkoutSessionAborted) EventName() string {
+func (e *WorkoutSessionAborted) EventName() string {
 
 	return "contracts.core.workout_execution.v1.workoutSessionAborted"
 
@@ -92,7 +92,7 @@ type NewPersonalRecordAchieved struct {
 
 // EventName returns the CloudEvent type for NewPersonalRecordAchieved.
 
-func (e NewPersonalRecordAchieved) EventName() string {
+func (e *NewPersonalRecordAchieved) EventName() string {
 
 	return "contracts.core.workout_execution.v1.newPersonalRecordAchieved"
 
@@ -110,7 +110,7 @@ type BodyMetricUpdated struct {
 
 // EventName returns the CloudEvent type for BodyMetricUpdated.
 
-func (e BodyMetricUpdated) EventName() string {
+func (e *BodyMetricUpdated) EventName() string {
 
 	return "contracts.core.workout_execution.v1.bodyMetricUpdated"
 
@@ -138,7 +138,7 @@ type MotionSpecificationUpdated struct {
 
 // EventName returns the CloudEvent type for MotionSpecificationUpdated.
 
-func (e MotionSpecificationUpdated) EventName() string {
+func (e *MotionSpecificationUpdated) EventName() string {
 
 	return "contracts.core.workout_execution.v1.motionSpecificationUpdated"
 

--- a/internal/workout_execution/domain/event/events_test.go
+++ b/internal/workout_execution/domain/event/events_test.go
@@ -12,7 +12,7 @@ func TestDomainEventNames(t *testing.T) {
 
 	now := time.Now().UTC()
 
-	ev1 := event.WorkoutSessionStarted{SessionID: "s1", UserID: "u1", PlanID: "p1", StartedAt: now}
+	ev1 := &event.WorkoutSessionStarted{SessionID: "s1", UserID: "u1", PlanID: "p1", StartedAt: now}
 
 	if got, want := ev1.EventName(), "contracts.core.workout_execution.v1.workoutSessionStarted"; got != want {
 
@@ -20,7 +20,7 @@ func TestDomainEventNames(t *testing.T) {
 
 	}
 
-	ev2 := event.WorkoutSessionCompleted{SessionID: "s1", UserID: "u1", PlanID: "p1", CompletedAt: now, Summary: vo.SessionSummary{}}
+	ev2 := &event.WorkoutSessionCompleted{SessionID: "s1", UserID: "u1", PlanID: "p1", CompletedAt: now, Summary: vo.SessionSummary{}}
 
 	if got, want := ev2.EventName(), "contracts.core.workout_execution.v1.workoutSessionCompleted"; got != want {
 
@@ -34,7 +34,7 @@ func TestDomainEventNames(t *testing.T) {
 
 	}
 
-	ev3 := event.WorkoutSessionAborted{SessionID: "s1", UserID: "u1", PlanID: "p1", Reason: "stop", IsAnomalous: false, AbortedAt: now}
+	ev3 := &event.WorkoutSessionAborted{SessionID: "s1", UserID: "u1", PlanID: "p1", Reason: "stop", IsAnomalous: false, AbortedAt: now}
 
 	if got, want := ev3.EventName(), "contracts.core.workout_execution.v1.workoutSessionAborted"; got != want {
 
@@ -48,7 +48,7 @@ func TestDomainEventNames(t *testing.T) {
 
 	}
 
-	ev4 := event.NewPersonalRecordAchieved{UserID: "u1", ExerciseID: "ex1", OneRepMax: 100, Weight: 100, Reps: 10, FormVerified: true, AchievedAt: now}
+	ev4 := &event.NewPersonalRecordAchieved{UserID: "u1", ExerciseID: "ex1", OneRepMax: 100, Weight: 100, Reps: 10, FormVerified: true, AchievedAt: now}
 
 	if got, want := ev4.EventName(), "contracts.core.workout_execution.v1.newPersonalRecordAchieved"; got != want {
 
@@ -56,7 +56,7 @@ func TestDomainEventNames(t *testing.T) {
 
 	}
 
-	ev5 := event.BodyMetricUpdated{UserID: "u1", WeightKg: 75.0, RecordedAt: now}
+	ev5 := &event.BodyMetricUpdated{UserID: "u1", WeightKg: 75.0, RecordedAt: now}
 
 	if got, want := ev5.EventName(), "contracts.core.workout_execution.v1.bodyMetricUpdated"; got != want {
 

--- a/internal/workout_execution/domain/repository/repositories.go
+++ b/internal/workout_execution/domain/repository/repositories.go
@@ -14,6 +14,8 @@ type WorkoutSessionRepository interface {
 
 	FindByID(ctx context.Context, id string) (*aggregate.WorkoutSession, error)
 
+	FindByIDForUpdate(ctx context.Context, id string) (*aggregate.WorkoutSession, error)
+
 	FindActiveSessionByUserID(ctx context.Context, userID string) (*aggregate.WorkoutSession, error)
 
 	FindTimedOutSessions(ctx context.Context, maxDurationMinutes int) ([]*aggregate.WorkoutSession, error)

--- a/internal/workout_execution/infrastructure/event/outbox_writer.go
+++ b/internal/workout_execution/infrastructure/event/outbox_writer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/google/uuid"
@@ -62,6 +63,18 @@ func (w *OutboxWriter) writeSingleEvent(ctx context.Context, aggregateType, aggr
 	if nameProvider, ok := ev.(NameProvider); ok {
 
 		eventType = nameProvider.EventName()
+
+	} else if ev != nil && reflect.TypeOf(ev).Kind() == reflect.Struct {
+
+		vp := reflect.New(reflect.TypeOf(ev))
+
+		vp.Elem().Set(reflect.ValueOf(ev))
+
+		if nameProvider, ok := vp.Interface().(NameProvider); ok {
+
+			eventType = nameProvider.EventName()
+
+		}
 
 	}
 

--- a/internal/workout_execution/infrastructure/event/outbox_writer_test.go
+++ b/internal/workout_execution/infrastructure/event/outbox_writer_test.go
@@ -54,7 +54,7 @@ func TestOutboxWriter(t *testing.T) {
 
 		writer := infraEvent.NewOutboxWriter(repo)
 
-		ev := event.WorkoutSessionStarted{
+		ev := &event.WorkoutSessionStarted{
 
 			SessionID: "sess-1",
 

--- a/internal/workout_execution/infrastructure/kafka/publisher.go
+++ b/internal/workout_execution/infrastructure/kafka/publisher.go
@@ -1,0 +1,48 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/segmentio/kafka-go"
+	"github.com/viethung213/gym-companion/internal/workout_execution/application/port"
+)
+
+type Publisher struct {
+	writer *kafka.Writer
+}
+
+var _ port.BrokerPublisher = (*Publisher)(nil)
+
+// NewPublisher creates a new Publisher with the provided shared kafka.Writer.
+func NewPublisher(writer *kafka.Writer) *Publisher {
+	return &Publisher{
+		writer: writer,
+	}
+}
+
+func (p *Publisher) PublishBatch(ctx context.Context, records []*port.OutboxRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	msgs := make([]kafka.Message, len(records))
+	for i, r := range records {
+		msgs[i] = kafka.Message{
+			Topic: "workout_execution.events",
+			Key:   []byte(r.PartitionKey),
+			Value: r.Payload,
+		}
+	}
+
+	err := p.writer.WriteMessages(ctx, msgs...)
+	if err != nil {
+		return fmt.Errorf("write workout_execution kafka batch messages: %w", err)
+	}
+	return nil
+}
+
+// Close is a no-op as the shared Kafka connection Registry handles lifecycle management.
+func (p *Publisher) Close() error {
+	return nil
+}

--- a/internal/workout_execution/infrastructure/persistence/models.go
+++ b/internal/workout_execution/infrastructure/persistence/models.go
@@ -26,6 +26,7 @@ type WorkoutSessionModel struct {
 	EndedAt          *time.Time           `gorm:"column:ended_at"`
 	CreatedAt        time.Time            `gorm:"column:created_at"`
 	UpdatedAt        time.Time            `gorm:"column:updated_at"`
+	Version          int                  `gorm:"column:version;default:1"`
 	Sets             []WorkoutSetLogModel `gorm:"foreignKey:SessionID;constraint:OnDelete:CASCADE"`
 	Errors           []SessionErrorModel  `gorm:"foreignKey:SessionID;constraint:OnDelete:CASCADE"`
 }
@@ -182,6 +183,7 @@ func SessionToPersistence(session *aggregate.WorkoutSession) *WorkoutSessionMode
 		EndedAt:          session.EndedAt(),
 		CreatedAt:        session.CreatedAt(),
 		UpdatedAt:        session.UpdatedAt(),
+		Version:          session.Version(),
 		Sets:             make([]WorkoutSetLogModel, 0, len(session.Sets())),
 		Errors:           make([]SessionErrorModel, 0, len(session.Errors())),
 	}
@@ -282,7 +284,7 @@ func SessionToDomain(m *WorkoutSessionModel) *aggregate.WorkoutSession {
 	status := aggregate.ParseSessionStatus(m.Status)
 	return aggregate.ReconstituteWorkoutSession(
 		m.ID, m.UserID, m.PlanID, status, sets, errs,
-		m.ScheduledAt, m.StartedAt, m.EndedAt, m.CreatedAt, m.UpdatedAt,
+		m.ScheduledAt, m.StartedAt, m.EndedAt, m.CreatedAt, m.UpdatedAt, m.Version,
 	)
 }
 

--- a/internal/workout_execution/infrastructure/persistence/postgres_repository.go
+++ b/internal/workout_execution/infrastructure/persistence/postgres_repository.go
@@ -37,20 +37,52 @@ func (r *PostgresWorkoutSessionRepository) Save(ctx context.Context, session *ag
 	db := getDB(ctx, r.db)
 	model := SessionToPersistence(session)
 
-	err := db.Clauses(clause.OnConflict{
-		UpdateAll: true,
-	}).Create(model).Error
+	var count int64
+	if err := db.Model(&WorkoutSessionModel{}).Where("id = ?", model.ID).Count(&count).Error; err != nil {
+		return fmt.Errorf("failed to check session existence: %w", err)
+	}
 
-	if err != nil {
-		if errors.Is(err, gorm.ErrDuplicatedKey) || strings.Contains(err.Error(), "uq_workout_sessions_active_user") {
-			return derror.ErrActiveSessionAlreadyExists
+	if count == 0 {
+		err := db.Create(model).Error
+		if err != nil {
+			if errors.Is(err, gorm.ErrDuplicatedKey) || strings.Contains(err.Error(), "uq_workout_sessions_active_user") {
+				return derror.ErrActiveSessionAlreadyExists
+			}
+			return fmt.Errorf("failed to save workout session: %w", err)
 		}
-		return fmt.Errorf("failed to save workout session: %w", err)
+	} else {
+		oldVersion := session.Version()
+		res := db.Model(&WorkoutSessionModel{}).
+			Where("id = ? AND version = ?", model.ID, oldVersion).
+			Updates(map[string]interface{}{
+				"status":             model.Status,
+				"total_sets":         model.TotalSets,
+				"total_volume":       model.TotalVolume,
+				"average_form_score": model.AverageFormScore,
+				"average_rpe":        model.AverageRPE,
+				"scheduled_at":       model.ScheduledAt,
+				"started_at":         model.StartedAt,
+				"ended_at":           model.EndedAt,
+				"updated_at":         model.UpdatedAt,
+				"version":            oldVersion + 1,
+			})
+		if res.Error != nil {
+			return fmt.Errorf("failed to update workout session: %w", res.Error)
+		}
+		if res.RowsAffected == 0 {
+			return derror.ErrOptimisticLocking
+		}
 	}
 
 	for _, set := range model.Sets {
 		if err := db.Clauses(clause.OnConflict{UpdateAll: true}).Create(&set).Error; err != nil {
 			return fmt.Errorf("failed to save set log: %w", err)
+		}
+	}
+
+	for _, sessErr := range model.Errors {
+		if err := db.Clauses(clause.OnConflict{UpdateAll: true}).Create(&sessErr).Error; err != nil {
+			return fmt.Errorf("failed to save session error: %w", err)
 		}
 	}
 
@@ -66,6 +98,19 @@ func (r *PostgresWorkoutSessionRepository) FindByID(ctx context.Context, id stri
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to find session by id: %w", err)
+	}
+	return SessionToDomain(&model), nil
+}
+
+func (r *PostgresWorkoutSessionRepository) FindByIDForUpdate(ctx context.Context, id string) (*aggregate.WorkoutSession, error) {
+	db := getDB(ctx, r.db)
+	var model WorkoutSessionModel
+	err := db.Clauses(clause.Locking{Strength: "UPDATE"}).Preload("Sets.Reps").Preload("Errors").First(&model, "id = ?", id).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to find session by id for update: %w", err)
 	}
 	return SessionToDomain(&model), nil
 }

--- a/internal/workout_execution/infrastructure/persistence/postgres_repository_test.go
+++ b/internal/workout_execution/infrastructure/persistence/postgres_repository_test.go
@@ -37,8 +37,10 @@ func ensureTablesExist(db *gorm.DB) {
 		started_at TIMESTAMP WITH TIME ZONE,
 		ended_at TIMESTAMP WITH TIME ZONE,
 		created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-		updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+		updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+		version INT NOT NULL DEFAULT 1
 	);`)
+	db.Exec(`ALTER TABLE workout_execution.workout_sessions ADD COLUMN IF NOT EXISTS version INT NOT NULL DEFAULT 1;`)
 	db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS uq_workout_sessions_active_user ON workout_execution.workout_sessions(user_id) WHERE status = 'IN_PROGRESS';`)
 
 	db.Exec(`CREATE TABLE IF NOT EXISTS workout_execution.workout_set_logs (
@@ -212,7 +214,7 @@ func TestPostgresWorkoutSessionRepository_Integration(t *testing.T) {
 		t.Fatalf("Failed to save session: %v", err)
 	}
 
-	// 2. FindByID (success and non-existent)
+	// 2. FindByID & FindByIDForUpdate (success and non-existent)
 	found, err := repo.FindByID(ctx, sessID)
 	if err != nil || found == nil {
 		t.Fatalf("FindByID failed: err=%v, found=%v", err, found)
@@ -221,9 +223,22 @@ func TestPostgresWorkoutSessionRepository_Integration(t *testing.T) {
 		t.Errorf("Mismatch in retrieved session fields: ID=%s, sets=%d, errors=%d", found.ID(), len(found.Sets()), len(found.Errors()))
 	}
 
+	foundForUpdate, err := repo.FindByIDForUpdate(ctx, sessID)
+	if err != nil || foundForUpdate == nil {
+		t.Fatalf("FindByIDForUpdate failed: err=%v, found=%v", err, foundForUpdate)
+	}
+	if foundForUpdate.ID() != sessID || len(foundForUpdate.Sets()) != 1 {
+		t.Errorf("Mismatch in FindByIDForUpdate fields: ID=%s, sets=%d", foundForUpdate.ID(), len(foundForUpdate.Sets()))
+	}
+
 	missingSession, err := repo.FindByID(ctx, "non-existent-id")
 	if err != nil || missingSession != nil {
 		t.Errorf("expected nil, nil for missing session FindByID, got %v, %v", missingSession, err)
+	}
+
+	missingSessionForUpdate, err := repo.FindByIDForUpdate(ctx, "non-existent-id")
+	if err != nil || missingSessionForUpdate != nil {
+		t.Errorf("expected nil, nil for missing session FindByIDForUpdate, got %v, %v", missingSessionForUpdate, err)
 	}
 
 	// 3. FindActiveSessionByUserID (success and non-existent)

--- a/internal/workout_execution/infrastructure/transport/grpc_handler_test.go
+++ b/internal/workout_execution/infrastructure/transport/grpc_handler_test.go
@@ -39,6 +39,13 @@ func (m *mockSessionRepo) FindByID(ctx context.Context, id string) (*aggregate.W
 	return m.session, nil
 }
 
+func (m *mockSessionRepo) FindByIDForUpdate(ctx context.Context, id string) (*aggregate.WorkoutSession, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.session, nil
+}
+
 func (m *mockSessionRepo) FindActiveSessionByUserID(ctx context.Context, userID string) (*aggregate.WorkoutSession, error) {
 	if m.err != nil {
 		return nil, m.err
@@ -145,7 +152,7 @@ func TestGRPCHandler(t *testing.T) {
 
 	startH := command.NewStartWorkoutSessionHandler(sessionRepo, nil, nil, tx)
 	startScheduledH := command.NewStartScheduledWorkoutSessionHandler(sessionRepo, nil, tx)
-	logSetH := command.NewLogWorkoutSetHandler(sessionRepo)
+	logSetH := command.NewLogWorkoutSetHandler(sessionRepo, nil, tx)
 	completeH := command.NewCompleteWorkoutSessionHandler(sessionRepo, nil, nil, nil, tx)
 	abortH := command.NewAbortWorkoutSessionHandler(sessionRepo, nil, tx)
 	syncH := command.NewSyncWorkoutLogsHandler(sessionRepo, nil, tx)
@@ -474,7 +481,7 @@ func TestLogWorkoutSet_ErrorMapping(t *testing.T) {
 
 			startH := command.NewStartWorkoutSessionHandler(repo, nil, nil, tx)
 			startScheduledH := command.NewStartScheduledWorkoutSessionHandler(repo, nil, tx)
-			logSetH := command.NewLogWorkoutSetHandler(repo)
+			logSetH := command.NewLogWorkoutSetHandler(repo, nil, tx)
 			completeH := command.NewCompleteWorkoutSessionHandler(repo, nil, nil, nil, tx)
 			abortH := command.NewAbortWorkoutSessionHandler(repo, nil, tx)
 			syncH := command.NewSyncWorkoutLogsHandler(repo, nil, tx)

--- a/internal/workout_execution/infrastructure/worker/outbox_worker.go
+++ b/internal/workout_execution/infrastructure/worker/outbox_worker.go
@@ -53,11 +53,12 @@ func (w *OutboxWorker) Start(ctx context.Context) {
 }
 
 func (w *OutboxWorker) processOutbox(ctx context.Context) error {
+	if w.publisher == nil {
+		return fmt.Errorf("outbox broker publisher is nil, cannot process outbox batch")
+	}
 	return w.outboxRepo.ProcessBatch(ctx, 100, func(publishCtx context.Context, events []*port.OutboxRecord) error {
-		if w.publisher != nil {
-			if err := w.publisher.PublishBatch(publishCtx, events); err != nil {
-				return fmt.Errorf("publish batch failed: %w", err)
-			}
+		if err := w.publisher.PublishBatch(publishCtx, events); err != nil {
+			return fmt.Errorf("publish batch failed: %w", err)
 		}
 		return nil
 	})

--- a/internal/workout_execution/infrastructure/worker/pr_event_consumer_test.go
+++ b/internal/workout_execution/infrastructure/worker/pr_event_consumer_test.go
@@ -31,6 +31,13 @@ func (m *mockSessionRepo) FindByID(ctx context.Context, id string) (*aggregate.W
 	return m.session, nil
 }
 
+func (m *mockSessionRepo) FindByIDForUpdate(ctx context.Context, id string) (*aggregate.WorkoutSession, error) {
+	if m.findErr != nil {
+		return nil, m.findErr
+	}
+	return m.session, nil
+}
+
 func (m *mockSessionRepo) FindActiveSessionByUserID(ctx context.Context, userID string) (*aggregate.WorkoutSession, error) {
 	return m.session, m.findErr
 }

--- a/internal/workout_execution/module.go
+++ b/internal/workout_execution/module.go
@@ -18,6 +18,7 @@ import (
 	"github.com/viethung213/gym-companion/internal/workout_execution/application/query"
 	"github.com/viethung213/gym-companion/internal/workout_execution/domain/service"
 	workoutEvent "github.com/viethung213/gym-companion/internal/workout_execution/infrastructure/event"
+	workoutKafka "github.com/viethung213/gym-companion/internal/workout_execution/infrastructure/kafka"
 	"github.com/viethung213/gym-companion/internal/workout_execution/infrastructure/persistence"
 	"github.com/viethung213/gym-companion/internal/workout_execution/infrastructure/storage"
 	"github.com/viethung213/gym-companion/internal/workout_execution/infrastructure/transport"
@@ -61,7 +62,7 @@ func Initialize(ctx context.Context, deps ModuleDeps) (func(), error) {
 	// Initialize Command Handlers
 	startSessionHandler := command.NewStartWorkoutSessionHandler(sessionRepo, nil, outboxWriter, txManager)
 	startScheduledSessionHandler := command.NewStartScheduledWorkoutSessionHandler(sessionRepo, outboxWriter, txManager)
-	logSetHandler := command.NewLogWorkoutSetHandler(sessionRepo)
+	logSetHandler := command.NewLogWorkoutSetHandler(sessionRepo, outboxWriter, txManager)
 	completeSessionHandler := command.NewCompleteWorkoutSessionHandler(sessionRepo, loadGuard, nil, outboxWriter, txManager)
 	abortSessionHandler := command.NewAbortWorkoutSessionHandler(sessionRepo, outboxWriter, txManager)
 	syncLogsHandler := command.NewSyncWorkoutLogsHandler(sessionRepo, outboxWriter, txManager)
@@ -110,10 +111,16 @@ func Initialize(ctx context.Context, deps ModuleDeps) (func(), error) {
 	}
 	kafkaBrokers := strings.Split(kafkaBrokersStr, ",")
 
-	_ = kafkaBrokers
+	var kafkaPub *workoutKafka.Publisher
+	if deps.KafkaRegistry != nil && len(kafkaBrokers) > 0 {
+		writer, err := deps.KafkaRegistry.GetWriter("workout_execution", kafkaBrokers)
+		if err == nil && writer != nil {
+			kafkaPub = workoutKafka.NewPublisher(writer)
+		}
+	}
 
 	// Initialize Workers
-	outboxWorker := worker.NewOutboxWorker(outboxRepo, nil, 2*time.Second)
+	outboxWorker := worker.NewOutboxWorker(outboxRepo, kafkaPub, 2*time.Second)
 	timeoutWorker := worker.NewSessionTimeoutWorker(sessionRepo, outboxWriter, txManager, 5*time.Minute)
 	criticalWorker := worker.NewCriticalInactivityWorker(sessionRepo, outboxWriter, txManager, 1*time.Minute, 5*time.Minute)
 	exerciseCreatedConsumer := worker.NewExerciseCreatedConsumer(motionRepo, outboxLogRepo)

--- a/internal/workout_execution/tests/e2e/testutil.go
+++ b/internal/workout_execution/tests/e2e/testutil.go
@@ -42,8 +42,10 @@ func ensureTablesExist(db *gorm.DB) {
 		started_at TIMESTAMP WITH TIME ZONE,
 		ended_at TIMESTAMP WITH TIME ZONE,
 		created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-		updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+		updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+		version INT NOT NULL DEFAULT 1
 	);`)
+	db.Exec(`ALTER TABLE workout_execution.workout_sessions ADD COLUMN IF NOT EXISTS version INT NOT NULL DEFAULT 1;`)
 
 	db.Exec(`CREATE TABLE IF NOT EXISTS workout_execution.workout_set_logs (
 		id VARCHAR(255) PRIMARY KEY,

--- a/scripts/postgres-init/04-create-workout-execution-tables.sql
+++ b/scripts/postgres-init/04-create-workout-execution-tables.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS workout_execution.workout_sessions (
     ended_at TIMESTAMP WITH TIME ZONE,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    version INT NOT NULL DEFAULT 1,
     CONSTRAINT chk_workout_session_status CHECK (
         status IN ('SCHEDULED', 'IN_PROGRESS', 'COMPLETED', 'ABORTED', 'ANOMALOUS')
     )


### PR DESCRIPTION
### 1. Problem to Solve
Khắc phục 3 lỗi nghiêm trọng liên quan đến dữ liệu và tính ổn định trong module `workout_execution`:
1. **Mất dữ liệu Outbox Event vĩnh viễn (Data Loss)**: `outboxWorker` được truyền `publisher = nil`, dẫn đến việc các sự kiện Outbox tự động bị đánh dấu là `PUBLISHED` dù chưa hề được đẩy qua Kafka.
2. **Race Condition (Lost Update) khi Stream/Log Set dồn dập**: Thiếu Optimistic Locking (trường `version`) và cơ chế Retry tự động, khiến các request ghi đè làm mất log các set trước đó của buổi tập.
3. **Panic Type Assertion do Không đồng nhất kiểu Domain Event (Value vs Pointer)**: Một số event push dạng Value (`WorkoutSessionStarted{}`), trong khi số khác push dạng Pointer (`&WorkoutSessionCompleted{}`), làm sập tiến trình serialization của Outbox Writer.

### 2. Proposed Solution
1. **Khởi tạo & Khóa Kafka Publisher**:
   - Tạo `internal/workout_execution/infrastructure/kafka/publisher.go` triển khai `port.BrokerPublisher` đẩy CloudEvents đến topic `workout_execution.events`.
   - Thêm guard clause tại `outbox_worker.go`: trả về lỗi ngay lập tức nếu `publisher == nil` để ngăn tự động gán trạng thái `PUBLISHED`.
   - Đã bỏ `publisher = nil` trong `module.go` và gán `kafkaPub` từ `deps.KafkaRegistry`.
2. **Triển khai Optimistic Locking (Lớp 2)**:
   - Thêm trường `version int` vào Aggregate `WorkoutSession` và DB Model `WorkoutSessionModel`.
   - Cập nhật SQL query trong `PostgresWorkoutSessionRepository.Save`: `UPDATE ... version = oldVersion + 1 WHERE id = ? AND version = oldVersion`. Trả lỗi `derror.ErrOptimisticLocking` khi có xung đột.
   - Thêm vòng lặp **Automatic Retry** (tối đa 3 retries với Exponential Backoff) trong `LogWorkoutSetHandler`.
   - Thêm cột `version INT NOT NULL DEFAULT 1` vào `04-create-workout-execution-tables.sql`, `postgres_repository_test.go` và `testutil.go`.
3. **Chuẩn hóa Domain Events thành Pointer Structs**:
   - Chuyển toàn bộ receiver của `EventName()` trong `events.go` thành Pointer Receiver (`func (e *...) EventName() string`).
   - Sửa 100% các câu lệnh `addDomainEvent` trong `workout_session.go` để luôn truyền con trỏ (`&event.WorkoutSessionStarted{...}`).
   - Thêm fallback Reflection phòng vệ trong `outbox_writer.go` để tự động xử lý an toàn cả khi nhận dạng Value.

### 3. Changes & Impact
- `[internal/workout_execution/infrastructure/kafka/publisher.go](internal/workout_execution/infrastructure/kafka/publisher.go)`: Triển khai Kafka Publisher gửi message tới topic `workout_execution.events`.
- `[internal/workout_execution/infrastructure/worker/outbox_worker.go](internal/workout_execution/infrastructure/worker/outbox_worker.go)`: Chặn gán `PUBLISHED` khi `publisher == nil`.
- `[internal/workout_execution/module.go](internal/workout_execution/module.go)`: Khởi tạo và kết nối `kafkaPub`.
- `[internal/workout_execution/domain/aggregate/workout_session.go](internal/workout_execution/domain/aggregate/workout_session.go)`: Thêm `version` và chuẩn hóa `addDomainEvent` dạng Pointer.
- `[internal/workout_execution/infrastructure/persistence/postgres_repository.go](internal/workout_execution/infrastructure/persistence/postgres_repository.go)`: Thực thi Optimistic Locking query `UPDATE ... WHERE version = ?`.
- `[internal/workout_execution/application/command/log_workout_set.go](internal/workout_execution/application/command/log_workout_set.go)`: Thêm Automatic Retry khi gặp `ErrOptimisticLocking`.
- `[internal/workout_execution/domain/event/events.go](internal/workout_execution/domain/event/events.go)`: Chuyển `EventName()` sang Pointer Receiver.
- `[internal/workout_execution/infrastructure/event/outbox_writer.go](internal/workout_execution/infrastructure/event/outbox_writer.go)`: Thêm Reflection fallback cho `EventName()`.
- `[scripts/postgres-init/04-create-workout-execution-tables.sql](scripts/postgres-init/04-create-workout-execution-tables.sql)`: Bổ sung cột `version` cho schema PostgreSQL.

### 4. Testing & Verification
- **Automated Tests**:
  - `go vet ./internal/workout_execution/...`: Clean (0 warnings/errors).
  - `go test -p 1 -tags=integration -count=1 ./internal/workout_execution/...`: All 215 test cases PASSED (100% SUCCESS rate across Domain, Application, Infrastructure, and E2E suites).
