### PR TITLE
🐛 fix(workout-execution): khắc phục lỗi race condition PR, bảo mật phân quyền và nâng cao độ tin cậy worker

### DIFF
--- a/internal/workout_execution/application/command/complete_workout_session.go
+++ b/internal/workout_execution/application/command/complete_workout_session.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/viethung213/gym-companion/internal/workout_execution/application/apperror"
@@ -65,6 +66,7 @@ func (h *CompleteWorkoutSessionHandler) Handle(
 	}
 
 	var result *CompleteWorkoutSessionResult
+	var isTimeout bool
 	saveFunc := func(txCtx context.Context) error {
 		session, err := h.sessionRepo.FindByIDForUpdate(txCtx, cmd.SessionID)
 		if err != nil {
@@ -96,18 +98,21 @@ func (h *CompleteWorkoutSessionHandler) Handle(
 			}
 		}
 
-		// 2. Transition domain state to COMPLETED
+		// 2. Transition domain state to COMPLETED (or ANOMALOUS if timed out)
 		if completeErr := session.Complete(cmd.ConfirmOverload, isOverloaded); completeErr != nil {
-			return completeErr
+			if errors.Is(completeErr, derror.ErrAnomalousSessionTimeout) {
+				isTimeout = true
+			} else {
+				return completeErr
+			}
 		}
 
 		// 3. Record optional BodyMetricUpdated event if weight update was provided by user (UC-03.4 A3)
-		if cmd.WeightUpdateKg != nil && *cmd.WeightUpdateKg > 0 {
+		if !isTimeout && cmd.WeightUpdateKg != nil && *cmd.WeightUpdateKg > 0 {
 			session.RecordBodyMetricUpdate(*cmd.WeightUpdateKg)
 		}
 
 		// 4. Save and Publish Outbox Events
-		summary := session.CalculateSummary()
 		if err := h.sessionRepo.Save(txCtx, session); err != nil {
 			return err
 		}
@@ -118,6 +123,11 @@ func (h *CompleteWorkoutSessionHandler) Handle(
 			}
 		}
 
+		if isTimeout {
+			return nil
+		}
+
+		summary := session.CalculateSummary()
 		var completedAtStr string
 		if session.EndedAt() != nil {
 			completedAtStr = session.EndedAt().Format("2006-01-02T15:04:05Z07:00")
@@ -142,6 +152,10 @@ func (h *CompleteWorkoutSessionHandler) Handle(
 		if err := saveFunc(ctx); err != nil {
 			return nil, err
 		}
+	}
+
+	if isTimeout {
+		return nil, derror.ErrAnomalousSessionTimeout
 	}
 
 	return result, nil

--- a/internal/workout_execution/application/command/complete_workout_session_test.go
+++ b/internal/workout_execution/application/command/complete_workout_session_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/viethung213/gym-companion/internal/workout_execution/application/apperror"
 	"github.com/viethung213/gym-companion/internal/workout_execution/application/command"
@@ -148,6 +149,28 @@ func TestCompleteWorkoutSessionHandler(t *testing.T) {
 		}
 		if len(outbox.events) != 3 {
 			t.Errorf("got %d events in outbox, want 3 (WorkoutSessionStarted + WorkoutSessionCompleted + BodyMetricUpdated)", len(outbox.events))
+		}
+	})
+
+	t.Run("anomalous timeout persists session state and returns error during completion", func(t *testing.T) {
+		now := time.Now().UTC()
+		started := now.Add(-250 * time.Minute)
+		session := aggregate.ReconstituteWorkoutSession(
+			"s1", "u1", "p1",
+			aggregate.StatusInProgress,
+			nil, nil, nil, &started, nil,
+			started, started,
+		)
+		repo := &mockSessionRepo{session: session}
+		outbox := &mockOutboxWriter{}
+		h := command.NewCompleteWorkoutSessionHandler(repo, nil, nil, outbox, &mockTxManager{})
+
+		_, err := h.Handle(context.Background(), command.CompleteWorkoutSessionCommand{SessionID: "s1"})
+		if !errors.Is(err, derror.ErrAnomalousSessionTimeout) {
+			t.Fatalf("got err = %v, want %v", err, derror.ErrAnomalousSessionTimeout)
+		}
+		if repo.session.Status() != aggregate.StatusAnomalous {
+			t.Errorf("got session status = %v, want StatusAnomalous", repo.session.Status())
 		}
 	})
 }

--- a/internal/workout_execution/application/command/log_workout_set.go
+++ b/internal/workout_execution/application/command/log_workout_set.go
@@ -76,6 +76,7 @@ func (h *LogWorkoutSetHandler) Handle(ctx context.Context, cmd LogWorkoutSetComm
 		CreatedAt:   time.Now().UTC(),
 	}
 
+	var isTimeout bool
 	saveFunc := func(txCtx context.Context) error {
 		session, err := h.sessionRepo.FindByIDForUpdate(txCtx, cmd.SessionID)
 		if err != nil {
@@ -89,7 +90,11 @@ func (h *LogWorkoutSetHandler) Handle(ctx context.Context, cmd LogWorkoutSetComm
 		}
 
 		if err := session.LogSet(setLog); err != nil {
-			return err
+			if errors.Is(err, derror.ErrAnomalousSessionTimeout) {
+				isTimeout = true
+			} else {
+				return err
+			}
 		}
 
 		if err := h.sessionRepo.Save(txCtx, session); err != nil {
@@ -118,6 +123,9 @@ func (h *LogWorkoutSetHandler) Handle(ctx context.Context, cmd LogWorkoutSetComm
 		}
 
 		if err == nil {
+			if isTimeout {
+				return nil, derror.ErrAnomalousSessionTimeout
+			}
 			return &LogWorkoutSetResult{
 				SetLogID: setLogID,
 			}, nil

--- a/internal/workout_execution/application/command/log_workout_set_test.go
+++ b/internal/workout_execution/application/command/log_workout_set_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/viethung213/gym-companion/internal/workout_execution/application/apperror"
 	"github.com/viethung213/gym-companion/internal/workout_execution/application/command"
@@ -64,6 +65,28 @@ func TestLogWorkoutSetHandler(t *testing.T) {
 		}
 		if res.SetLogID == "" {
 			t.Errorf("got empty SetLogID")
+		}
+	})
+
+	t.Run("anomalous timeout persists session state and returns error", func(t *testing.T) {
+		now := time.Now().UTC()
+		started := now.Add(-250 * time.Minute)
+		session := aggregate.ReconstituteWorkoutSession(
+			"s1", "u1", "p1",
+			aggregate.StatusInProgress,
+			nil, nil, nil, &started, nil,
+			started, started,
+		)
+		repo := &mockSessionRepo{session: session}
+		outbox := newMockOutboxWriter(t)
+		h := command.NewLogWorkoutSetHandler(repo, outbox, newMockTxManager(t))
+
+		_, err := h.Handle(context.Background(), command.LogWorkoutSetCommand{SessionID: "s1", ExerciseID: "ex1", SetNumber: 1})
+		if !errors.Is(err, derror.ErrAnomalousSessionTimeout) {
+			t.Fatalf("got err = %v, want %v", err, derror.ErrAnomalousSessionTimeout)
+		}
+		if repo.session.Status() != aggregate.StatusAnomalous {
+			t.Errorf("got session status = %v, want StatusAnomalous", repo.session.Status())
 		}
 	})
 }

--- a/internal/workout_execution/application/command/mocks_test.go
+++ b/internal/workout_execution/application/command/mocks_test.go
@@ -121,6 +121,13 @@ func (m *mockPRRepo) FindByUserIDAndExerciseID(ctx context.Context, userID, exer
 	return m.pr, nil
 }
 
+func (m *mockPRRepo) FindByUserIDAndExerciseIDForUpdate(ctx context.Context, userID, exerciseID string) (*aggregate.PersonalRecord, error) {
+	if m.findErr != nil {
+		return nil, m.findErr
+	}
+	return m.pr, nil
+}
+
 func (m *mockPRRepo) FindByUserIDAndExerciseIDs(ctx context.Context, userID string, exerciseIDs []string) ([]*aggregate.PersonalRecord, error) {
 	if m.findErr != nil {
 		return nil, m.findErr

--- a/internal/workout_execution/application/command/process_completed_session_pr.go
+++ b/internal/workout_execution/application/command/process_completed_session_pr.go
@@ -71,35 +71,37 @@ func (h *ProcessCompletedSessionForPRHandler) HandleProcess(
 	}
 
 	for exerciseID, set := range bestSets {
-		formVerified := set.FormScore != nil && *set.FormScore >= 70.0
-		existingPR, findErr := h.prRepo.FindByUserIDAndExerciseID(ctx, userID, exerciseID)
-		if findErr != nil {
-			continue
-		}
-
-		var pr *aggregate.PersonalRecord
-		achievedAt := session.EndedAt()
-		var t time.Time
-		if achievedAt != nil {
-			t = *achievedAt
-		} else {
-			t = time.Now().UTC()
-		}
-
-		if existingPR == nil {
-			prID := uuid.NewString()
-			pr = aggregate.NewPersonalRecord(
-				prID, userID, exerciseID, set.Weight, set.ActualReps, formVerified, t,
-			)
-		} else {
-			pr = existingPR
-			updated := pr.UpdateIfHigher(set.Weight, set.ActualReps, formVerified, t)
-			if !updated {
-				continue
+		exerciseID := exerciseID
+		set := set
+		processExercisePR := func(txCtx context.Context) error {
+			formVerified := set.FormScore != nil && *set.FormScore >= 70.0
+			existingPR, findErr := h.prRepo.FindByUserIDAndExerciseIDForUpdate(txCtx, userID, exerciseID)
+			if findErr != nil {
+				return nil
 			}
-		}
 
-		saveFunc := func(txCtx context.Context) error {
+			var pr *aggregate.PersonalRecord
+			achievedAt := session.EndedAt()
+			var t time.Time
+			if achievedAt != nil {
+				t = *achievedAt
+			} else {
+				t = time.Now().UTC()
+			}
+
+			if existingPR == nil {
+				prID := uuid.NewString()
+				pr = aggregate.NewPersonalRecord(
+					prID, userID, exerciseID, set.Weight, set.ActualReps, formVerified, t,
+				)
+			} else {
+				pr = existingPR
+				updated := pr.UpdateIfHigher(set.Weight, set.ActualReps, formVerified, t)
+				if !updated {
+					return nil
+				}
+			}
+
 			if saveErr := h.prRepo.Save(txCtx, pr); saveErr != nil {
 				return saveErr
 			}
@@ -114,9 +116,9 @@ func (h *ProcessCompletedSessionForPRHandler) HandleProcess(
 
 		var txErr error
 		if h.txManager != nil {
-			txErr = h.txManager.WithTransaction(ctx, saveFunc)
+			txErr = h.txManager.WithTransaction(ctx, processExercisePR)
 		} else {
-			txErr = saveFunc(ctx)
+			txErr = processExercisePR(ctx)
 		}
 		if txErr != nil {
 			return fmt.Errorf("failed to save PR for exercise %s: %w", exerciseID, txErr)

--- a/internal/workout_execution/application/query/queries_test.go
+++ b/internal/workout_execution/application/query/queries_test.go
@@ -82,6 +82,12 @@ func (m *mockPRRepo) FindByUserIDAndExerciseID(ctx context.Context, userID, exer
 
 }
 
+func (m *mockPRRepo) FindByUserIDAndExerciseIDForUpdate(ctx context.Context, userID, exerciseID string) (*aggregate.PersonalRecord, error) {
+
+	return nil, nil
+
+}
+
 func (m *mockPRRepo) FindByUserIDAndExerciseIDs(ctx context.Context, userID string, exerciseIDs []string) ([]*aggregate.PersonalRecord, error) {
 
 	if m.err != nil {

--- a/internal/workout_execution/domain/repository/repositories.go
+++ b/internal/workout_execution/domain/repository/repositories.go
@@ -38,6 +38,8 @@ type PersonalRecordRepository interface {
 
 	FindByUserIDAndExerciseID(ctx context.Context, userID, exerciseID string) (*aggregate.PersonalRecord, error)
 
+	FindByUserIDAndExerciseIDForUpdate(ctx context.Context, userID, exerciseID string) (*aggregate.PersonalRecord, error)
+
 	FindByUserIDAndExerciseIDs(ctx context.Context, userID string, exerciseIDs []string) ([]*aggregate.PersonalRecord, error)
 }
 

--- a/internal/workout_execution/infrastructure/persistence/postgres_repository.go
+++ b/internal/workout_execution/infrastructure/persistence/postgres_repository.go
@@ -139,8 +139,9 @@ func (r *PostgresWorkoutSessionRepository) FindTimedOutSessions(ctx context.Cont
 	threshold := time.Now().UTC().Add(-time.Duration(maxDurationMinutes) * time.Minute)
 
 	var models []WorkoutSessionModel
-	err := db.Preload("Sets.Reps").Preload("Errors").
+	err := db.Preload("Errors").
 		Where("status = ? AND started_at <= ?", "IN_PROGRESS", threshold).
+		Limit(100).
 		Find(&models).Error
 	if err != nil {
 		return nil, fmt.Errorf("failed to find timed out sessions: %w", err)
@@ -161,7 +162,7 @@ func (r *PostgresWorkoutSessionRepository) FindSessionsWithCriticalInactivity(
 	updatedBefore := time.Now().UTC().Add(-inactivityThreshold)
 
 	var models []WorkoutSessionModel
-	err := db.Preload("Sets.Reps").Preload("Errors").
+	err := db.Preload("Errors").
 		Where(
 			`status = ? AND updated_at <= ? AND EXISTS (
 				SELECT 1 FROM workout_execution.session_errors se
@@ -171,6 +172,7 @@ func (r *PostgresWorkoutSessionRepository) FindSessionsWithCriticalInactivity(
 			)`,
 			"IN_PROGRESS", updatedBefore,
 		).
+		Limit(100).
 		Find(&models).Error
 	if err != nil {
 		return nil, fmt.Errorf("failed to find sessions with critical inactivity: %w", err)
@@ -188,6 +190,14 @@ func (r *PostgresWorkoutSessionRepository) FindHistoryByUserID(
 	userID string,
 	limit, offset int,
 ) ([]*aggregate.WorkoutSession, error) {
+	if limit <= 0 {
+		limit = 20
+	} else if limit > 100 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
 	db := getDB(ctx, r.db)
 	var models []WorkoutSessionModel
 	err := db.Preload("Sets.Reps").Preload("Errors").
@@ -243,8 +253,15 @@ func (r *PostgresPersonalRecordRepository) Save(ctx context.Context, pr *aggrega
 	db := getDB(ctx, r.db)
 	model := PersonalRecordToPersistence(pr)
 	err := db.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "user_id"}, {Name: "exercise_id"}},
-		UpdateAll: true,
+		Columns: []clause.Column{{Name: "user_id"}, {Name: "exercise_id"}},
+		DoUpdates: clause.Assignments(map[string]interface{}{
+			"one_rep_max":   gorm.Expr("GREATEST(personal_records.one_rep_max, EXCLUDED.one_rep_max)"),
+			"weight":        gorm.Expr("CASE WHEN EXCLUDED.one_rep_max > personal_records.one_rep_max THEN EXCLUDED.weight ELSE personal_records.weight END"),
+			"reps":          gorm.Expr("CASE WHEN EXCLUDED.one_rep_max > personal_records.one_rep_max THEN EXCLUDED.reps ELSE personal_records.reps END"),
+			"form_verified": gorm.Expr("CASE WHEN EXCLUDED.one_rep_max > personal_records.one_rep_max THEN EXCLUDED.form_verified ELSE personal_records.form_verified END"),
+			"achieved_at":   gorm.Expr("CASE WHEN EXCLUDED.one_rep_max > personal_records.one_rep_max THEN EXCLUDED.achieved_at ELSE personal_records.achieved_at END"),
+			"updated_at":    gorm.Expr("CASE WHEN EXCLUDED.one_rep_max > personal_records.one_rep_max THEN EXCLUDED.updated_at ELSE personal_records.updated_at END"),
+		}),
 	}).Create(model).Error
 	if err != nil {
 		return fmt.Errorf("failed to save personal record: %w", err)
@@ -264,6 +281,23 @@ func (r *PostgresPersonalRecordRepository) FindByUserIDAndExerciseID(
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to find personal record: %w", err)
+	}
+	return PersonalRecordToDomain(&model), nil
+}
+
+func (r *PostgresPersonalRecordRepository) FindByUserIDAndExerciseIDForUpdate(
+	ctx context.Context,
+	userID, exerciseID string,
+) (*aggregate.PersonalRecord, error) {
+	db := getDB(ctx, r.db)
+	var model PersonalRecordModel
+	err := db.Clauses(clause.Locking{Strength: "UPDATE"}).
+		First(&model, "user_id = ? AND exercise_id = ?", userID, exerciseID).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to find personal record for update: %w", err)
 	}
 	return PersonalRecordToDomain(&model), nil
 }
@@ -356,6 +390,14 @@ func (r *PostgresMotionSpecificationRepository) Delete(ctx context.Context, exer
 }
 
 func (r *PostgresMotionSpecificationRepository) List(ctx context.Context, limit, offset int) ([]*aggregate.MotionSpecification, int, error) {
+	if limit <= 0 {
+		limit = 20
+	} else if limit > 100 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
 	db := getDB(ctx, r.db)
 
 	var total int64

--- a/internal/workout_execution/infrastructure/transport/grpc_handler.go
+++ b/internal/workout_execution/infrastructure/transport/grpc_handler.go
@@ -450,6 +450,10 @@ func (h *GRPCHandler) AdminGetWorkoutHistory(ctx context.Context, req *workoutex
 
 // GetPresignedUploadURL generates a presigned URL allowing the Client to upload files directly to Cloud Storage.
 func (h *GRPCHandler) GetPresignedUploadURL(ctx context.Context, req *workoutexecutionv1message.GetPresignedUploadURLRequest) (*workoutexecutionv1message.GetPresignedUploadURLResponse, error) {
+	if _, err := requireAdminOrCoach(ctx); err != nil {
+		return nil, err
+	}
+
 	if req == nil || req.GetFileName() == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "file_name is required")
 	}
@@ -471,6 +475,10 @@ func (h *GRPCHandler) GetPresignedUploadURL(ctx context.Context, req *workoutexe
 
 // UpdateMotionSpecification updates motion specification files/rules for an exercise.
 func (h *GRPCHandler) UpdateMotionSpecification(ctx context.Context, req *workoutexecutionv1message.UpdateMotionSpecificationRequest) (*workoutexecutionv1message.UpdateMotionSpecificationResponse, error) {
+	if _, err := requireAdminOrCoach(ctx); err != nil {
+		return nil, err
+	}
+
 	if req == nil || req.GetExerciseId() == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "exercise_id is required")
 	}
@@ -496,6 +504,10 @@ func (h *GRPCHandler) UpdateMotionSpecification(ctx context.Context, req *workou
 
 // PatchMotionSpecificationAsset updates partial JSON contents of pose rules or dialogue config on S3.
 func (h *GRPCHandler) PatchMotionSpecificationAsset(ctx context.Context, req *workoutexecutionv1message.PatchMotionSpecificationAssetRequest) (*workoutexecutionv1message.PatchMotionSpecificationAssetResponse, error) {
+	if _, err := requireAdminOrCoach(ctx); err != nil {
+		return nil, err
+	}
+
 	if req == nil || req.GetExerciseId() == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "exercise_id is required")
 	}
@@ -521,8 +533,11 @@ func (h *GRPCHandler) PatchMotionSpecificationAsset(ctx context.Context, req *wo
 }
 
 // DeleteMotionSpecification deletes a MotionSpecification.
-
 func (h *GRPCHandler) DeleteMotionSpecification(ctx context.Context, req *workoutexecutionv1message.DeleteMotionSpecificationRequest) (*workoutexecutionv1message.DeleteMotionSpecificationResponse, error) {
+	if _, err := requireAdminOrCoach(ctx); err != nil {
+		return nil, err
+	}
+
 	if req == nil || req.GetExerciseId() == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "exercise_id is required")
 	}

--- a/internal/workout_execution/infrastructure/transport/grpc_handler_test.go
+++ b/internal/workout_execution/infrastructure/transport/grpc_handler_test.go
@@ -93,6 +93,10 @@ func (m *mockPRRepo) FindByUserIDAndExerciseID(ctx context.Context, userID, exer
 	return nil, m.err
 }
 
+func (m *mockPRRepo) FindByUserIDAndExerciseIDForUpdate(ctx context.Context, userID, exerciseID string) (*aggregate.PersonalRecord, error) {
+	return nil, m.err
+}
+
 func (m *mockPRRepo) FindByUserIDAndExerciseIDs(ctx context.Context, userID string, exerciseIDs []string) ([]*aggregate.PersonalRecord, error) {
 	if m.err != nil {
 		return nil, m.err
@@ -440,6 +444,26 @@ func TestGRPCHandler(t *testing.T) {
 		}
 		if len(res.GetSessions()) != 1 {
 			t.Errorf("got count = %d, want 1", len(res.GetSessions()))
+		}
+	})
+
+	t.Run("GetPresignedUploadURL forbidden for User and success for Admin", func(t *testing.T) {
+		ctxUser := context.WithValue(context.WithValue(context.Background(), middleware.UserIDKey, "u1"), middleware.UserRoleKey, "User")
+		ctxAdmin := context.WithValue(context.WithValue(context.Background(), middleware.UserIDKey, "admin1"), middleware.UserRoleKey, "Admin")
+
+		// User attempt -> Forbidden
+		_, err := grpcHandler.GetPresignedUploadURL(ctxUser, &workoutexecutionv1message.GetPresignedUploadURLRequest{FileName: "model.onnx"})
+		if err == nil {
+			t.Fatal("expected forbidden error for User calling GetPresignedUploadURL, got nil")
+		}
+
+		// Admin attempt -> Success
+		res, err := grpcHandler.GetPresignedUploadURL(ctxAdmin, &workoutexecutionv1message.GetPresignedUploadURLRequest{FileName: "model.onnx"})
+		if err != nil {
+			t.Fatalf("got err = %v, want nil", err)
+		}
+		if res.GetUploadUrl() == "" {
+			t.Error("expected non-empty upload url")
 		}
 	})
 }

--- a/internal/workout_execution/infrastructure/worker/critical_inactivity_worker.go
+++ b/internal/workout_execution/infrastructure/worker/critical_inactivity_worker.go
@@ -67,9 +67,16 @@ func (w *CriticalInactivityWorker) Start(ctx context.Context) {
 			log.Println("[WorkoutExecution] Stopping Critical Inactivity worker.")
 			return
 		case <-ticker.C:
-			if err := w.processCriticalInactiveSessions(ctx); err != nil {
-				log.Printf("[WorkoutExecution] Critical Inactivity worker error: %v", err)
-			}
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Printf("[WorkoutExecution] PANIC RECOVERED in Critical Inactivity worker tick: %v", r)
+					}
+				}()
+				if err := w.processCriticalInactiveSessions(ctx); err != nil {
+					log.Printf("[WorkoutExecution] Critical Inactivity worker error: %v", err)
+				}
+			}()
 		}
 	}
 }

--- a/internal/workout_execution/infrastructure/worker/outbox_worker.go
+++ b/internal/workout_execution/infrastructure/worker/outbox_worker.go
@@ -45,9 +45,16 @@ func (w *OutboxWorker) Start(ctx context.Context) {
 			log.Println("[WorkoutExecution] Stopping Outbox worker due to context cancellation.")
 			return
 		case <-ticker.C:
-			if err := w.processOutbox(ctx); err != nil {
-				log.Printf("[WorkoutExecution] Outbox worker processing error: %v", err)
-			}
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Printf("[WorkoutExecution] PANIC RECOVERED in Outbox worker tick: %v", r)
+					}
+				}()
+				if err := w.processOutbox(ctx); err != nil {
+					log.Printf("[WorkoutExecution] Outbox worker processing error: %v", err)
+				}
+			}()
 		}
 	}
 }

--- a/internal/workout_execution/infrastructure/worker/pr_event_consumer_test.go
+++ b/internal/workout_execution/infrastructure/worker/pr_event_consumer_test.go
@@ -80,6 +80,10 @@ func (m *mockPRRepo) FindByUserIDAndExerciseID(ctx context.Context, userID, exer
 	return nil, m.err
 }
 
+func (m *mockPRRepo) FindByUserIDAndExerciseIDForUpdate(ctx context.Context, userID, exerciseID string) (*aggregate.PersonalRecord, error) {
+	return nil, m.err
+}
+
 func (m *mockPRRepo) FindByUserIDAndExerciseIDs(ctx context.Context, userID string, exerciseIDs []string) ([]*aggregate.PersonalRecord, error) {
 	return nil, m.err
 }

--- a/internal/workout_execution/infrastructure/worker/session_timeout_worker.go
+++ b/internal/workout_execution/infrastructure/worker/session_timeout_worker.go
@@ -48,9 +48,16 @@ func (w *SessionTimeoutWorker) Start(ctx context.Context) {
 			log.Println("[WorkoutExecution] Stopping Session Timeout worker.")
 			return
 		case <-ticker.C:
-			if err := w.processTimedOutSessions(ctx); err != nil {
-				log.Printf("[WorkoutExecution] Session Timeout worker error: %v", err)
-			}
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Printf("[WorkoutExecution] PANIC RECOVERED in Session Timeout worker tick: %v", r)
+					}
+				}()
+				if err := w.processTimedOutSessions(ctx); err != nil {
+					log.Printf("[WorkoutExecution] Session Timeout worker error: %v", err)
+				}
+			}()
 		}
 	}
 }

--- a/internal/workout_execution/module.go
+++ b/internal/workout_execution/module.go
@@ -190,9 +190,16 @@ func Initialize(ctx context.Context, deps ModuleDeps) (func(), error) {
 							continue
 						}
 
-						if err := exerciseCreatedConsumer.HandleMessage(workerCtx, msg.Value); err != nil {
-							log.Printf("WorkoutExecution failed to process ExerciseCreated event: %v", err)
-						}
+						func() {
+							defer func() {
+								if r := recover(); r != nil {
+									log.Printf("PANIC RECOVERED in ExerciseCreated event handling: %v", r)
+								}
+							}()
+							if err := exerciseCreatedConsumer.HandleMessage(workerCtx, msg.Value); err != nil {
+								log.Printf("WorkoutExecution failed to process ExerciseCreated event: %v", err)
+							}
+						}()
 					}
 				}
 			}()
@@ -225,9 +232,16 @@ func Initialize(ctx context.Context, deps ModuleDeps) (func(), error) {
 							continue
 						}
 
-						if err := prConsumer.HandleMessage(workerCtx, msg.Value); err != nil {
-							log.Printf("WorkoutExecution failed to process WorkoutSessionCompleted event for PR: %v", err)
-						}
+						func() {
+							defer func() {
+								if r := recover(); r != nil {
+									log.Printf("PANIC RECOVERED in PREventConsumer event handling: %v", r)
+								}
+							}()
+							if err := prConsumer.HandleMessage(workerCtx, msg.Value); err != nil {
+								log.Printf("WorkoutExecution failed to process WorkoutSessionCompleted event for PR: %v", err)
+							}
+						}()
 					}
 				}
 			}()


### PR DESCRIPTION
### 1. Vấn Đề Cần Giải Quyết (Problem to Solve)
Qua quá trình kiểm tra chuyên sâu module `workout_execution`, hệ thống phát hiện các lỗ hổng nghiêm trọng ảnh hưởng đến tính toàn vẹn dữ liệu, bảo mật và khả năng vận hành Production:
1. **Race Condition Mất Dữ Liệu PR (Lost Update PR)**: Khi 2 buổi tập của cùng 1 người dùng hoàn thành đồng thời, thao tác cập nhật kỷ lục cá nhân 1RM PR thiếu lock DB làm kỷ lục cao hơn (150kg) bị đè mất bởi kỷ lục thấp hơn (120kg).
2. **Lỗ Hổng Phân Quyền Security Bypass**: RPC `GetPresignedUploadURL`, `UpdateMotionSpecification`, `PatchMotionSpecificationAsset` và `DeleteMotionSpecification` thiếu kiểm tra vai trò `requireAdminOrCoach(ctx)`, cho phép bất kỳ người dùng thông thường nào cũng lấy được URL upload file S3.
3. **Mất Trạng Thái `ANOMALOUS` khi Timeout**: Khi session bị timeout (>240 phút inactivity), handler trả về lỗi trực tiếp khiến CSDL thực thi Rollback, dẫn đến trạng thái `ANOMALOUS` bị xóa khỏi DB và session bị treo `IN_PROGRESS` vĩnh viễn.
4. **Goroutine Worker Chết Vĩnh Viễn khi Panic**: Cơ chế `defer recover()` đặt ở lớp ngoài cùng của goroutine làm toàn bộ tiến trình worker / Kafka consumer bị dừng hẳn nếu gặp 1 panic nhất thời.
5. **Truy Vấn Không Giới Hạn (Unbounded Bulk Fetch)**: Các truy vấn quét worker (`FindTimedOutSessions`, `FindSessionsWithCriticalInactivity`) thiếu clause `LIMIT` và preload nạp mảng tọa độ JSONB nặng gây áp lực bộ nhớ RAM/OOM.

---

### 2. Giải Pháp Đề Xuất (Proposed Solution)
1. **Pessimistic Row Locking (`SELECT FOR UPDATE`) & SQL `GREATEST` Upserts**: Thêm `FindByUserIDAndExerciseIDForUpdate` chạy trong 1 Transaction duy nhất per exercise, kết hợp câu lệnh PostgreSQL conditional `GREATEST(personal_records.one_rep_max, EXCLUDED.one_rep_max)` tại persistence layer.
2. **Kiểm Tra Phân Quyền gRPC**: Bổ sung `requireAdminOrCoach(ctx)` ở đầu tất cả các RPC Admin trong `GRPCHandler`.
3. **Commit Trạng Thái Timeout Trước Khi Trả Lỗi**: Xử lý `ErrAnomalousSessionTimeout` trong command handler để lưu trạng thái `ANOMALOUS` và outbox event xuống CSDL trước khi trả lỗi về cho client.
4. **Panic Recovery Theo Ticker & Theo Message**: Bổ sung `defer recover()` bên trong từng tick của Ticker loop và từng bản tin của Kafka consumer loop.
5. **Khống Chế Limit & Tối Ưu Preload**: Bổ sung `Limit(100)` cho các câu SQL quét worker và loại bỏ `.Preload("Sets.Reps")` không cần thiết.

---

### 3. Danh Sách Sửa Đổi & Ảnh Hưởng (Changes & Impact)
- `internal/workout_execution/domain/repository/repositories.go`: Khai báo `FindByUserIDAndExerciseIDForUpdate` trong interface `PersonalRecordRepository`.
- `internal/workout_execution/infrastructure/persistence/postgres_repository.go`: Triển khai row lock (`SELECT FOR UPDATE`), SQL `GREATEST` upserts và giới hạn `Limit(100)`.
- `internal/workout_execution/application/command/process_completed_session_pr.go`: Gộp quy trình đọc PR có lock, tính toán domain và lưu thành 1 transaction duy nhất.
- `internal/workout_execution/application/command/log_workout_set.go`: Commit trạng thái `ANOMALOUS` khi timeout.
- `internal/workout_execution/application/command/complete_workout_session.go`: Commit trạng thái `ANOMALOUS` khi timeout.
- `internal/workout_execution/infrastructure/transport/grpc_handler.go`: Bổ sung phân quyền `requireAdminOrCoach(ctx)` tại các RPC Admin.
- `internal/workout_execution/infrastructure/worker/outbox_worker.go`: Thêm panic recovery per-tick.
- `internal/workout_execution/infrastructure/worker/session_timeout_worker.go`: Thêm panic recovery per-tick.
- `internal/workout_execution/infrastructure/worker/critical_inactivity_worker.go`: Thêm panic recovery per-tick.
- `internal/workout_execution/module.go`: Thêm panic recovery per-message trong Kafka consumer loops.

---

### 4. Kiểm Thử & Xác Nhận (Testing & Verification)
- **Automated Tests**: Đã chạy bộ kiểm thử `go test ./internal/workout_execution/...` -> **PASS 100%** trên toàn bộ các package.
- **Manual Verification**: Kiểm tra phân quyền RPC, logic commit transaction khi timeout, và kiểm thử tính toán PR trong môi trường giả lập.
