### PR TITLE
✨ feat(workout-execution): bổ sung PlanID vào Outbox CloudEvent cho WorkoutSessionCompleted và WorkoutSessionAborted

### DIFF
--- a/internal/workout_execution/infrastructure/event/outbox_writer.go
+++ b/internal/workout_execution/infrastructure/event/outbox_writer.go
@@ -217,112 +217,65 @@ func mapToProtoEvent(ev interface{}) proto.Message {
 		return mapWorkoutSessionCompletedToProto(e)
 
 	case domainEvent.WorkoutSessionAborted:
-
 		return &workoutexecutionv1event.WorkoutSessionAborted{
-
 			SessionId: e.SessionID,
-
-			UserId: e.UserID,
-
+			UserId:    e.UserID,
+			PlanId:    e.PlanID,
 			AbortedAt: timestamppb.New(e.AbortedAt),
-
-			Reason: e.Reason,
+			Reason:    e.Reason,
 		}
-
 	case *domainEvent.WorkoutSessionAborted:
-
 		if e == nil {
-
 			return nil
-
 		}
-
 		return &workoutexecutionv1event.WorkoutSessionAborted{
-
 			SessionId: e.SessionID,
-
-			UserId: e.UserID,
-
+			UserId:    e.UserID,
+			PlanId:    e.PlanID,
 			AbortedAt: timestamppb.New(e.AbortedAt),
-
-			Reason: e.Reason,
+			Reason:    e.Reason,
 		}
-
 	case domainEvent.NewPersonalRecordAchieved:
-
 		return &workoutexecutionv1event.NewPersonalRecordAchieved{
-
-			UserId: e.UserID,
-
+			UserId:     e.UserID,
 			ExerciseId: e.ExerciseID,
-
-			OneRepMax: e.OneRepMax,
-
-			Weight: e.Weight,
-
-			Reps: int32(e.Reps),
-
+			OneRepMax:  e.OneRepMax,
+			Weight:     e.Weight,
+			Reps:       int32(e.Reps),
 			AchievedAt: timestamppb.New(e.AchievedAt),
 		}
-
 	case *domainEvent.NewPersonalRecordAchieved:
-
 		if e == nil {
-
 			return nil
-
 		}
-
 		return &workoutexecutionv1event.NewPersonalRecordAchieved{
-
-			UserId: e.UserID,
-
+			UserId:     e.UserID,
 			ExerciseId: e.ExerciseID,
-
-			OneRepMax: e.OneRepMax,
-
-			Weight: e.Weight,
-
-			Reps: int32(e.Reps),
-
+			OneRepMax:  e.OneRepMax,
+			Weight:     e.Weight,
+			Reps:       int32(e.Reps),
 			AchievedAt: timestamppb.New(e.AchievedAt),
 		}
-
 	default:
-
 		return nil
-
 	}
-
 }
 
 func mapWorkoutSessionCompletedToProto(e *domainEvent.WorkoutSessionCompleted) *workoutexecutionv1event.WorkoutSessionCompleted {
-
 	var avgScore *float32
-
 	if e.Summary.AverageFormScore != nil {
-
 		score := float32(*e.Summary.AverageFormScore)
-
 		avgScore = &score
-
 	}
 
 	return &workoutexecutionv1event.WorkoutSessionCompleted{
-
-		SessionId: e.SessionID,
-
-		UserId: e.UserID,
-
-		CompletedAt: timestamppb.New(e.CompletedAt),
-
-		TotalSets: int32(e.Summary.TotalSets),
-
-		TotalVolume: float32(e.Summary.TotalVolume),
-
+		SessionId:        e.SessionID,
+		UserId:           e.UserID,
+		PlanId:           e.PlanID,
+		CompletedAt:      timestamppb.New(e.CompletedAt),
+		TotalSets:        int32(e.Summary.TotalSets),
+		TotalVolume:      float32(e.Summary.TotalVolume),
 		AverageFormScore: avgScore,
-
-		AverageRpe: float32(e.Summary.AverageRPE),
+		AverageRpe:       float32(e.Summary.AverageRPE),
 	}
-
 }

--- a/internal/workout_execution/infrastructure/event/outbox_writer_test.go
+++ b/internal/workout_execution/infrastructure/event/outbox_writer_test.go
@@ -139,7 +139,10 @@ func TestOutboxWriter(t *testing.T) {
 		if err := json.Unmarshal(repo.savedRecord.Payload, &envelope); err != nil {
 			t.Fatalf("failed to unmarshal payload: %v", err)
 		}
-		dataMap := envelope["data"].(map[string]interface{})
+		dataMap, ok := envelope["data"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected data to be map[string]interface{}, got %T", envelope["data"])
+		}
 		if got, want := dataMap["planId"], "plan-2"; got != want {
 			t.Errorf("got data.planId = %v, want %v", got, want)
 		}
@@ -164,7 +167,10 @@ func TestOutboxWriter(t *testing.T) {
 		if err := json.Unmarshal(repo.savedRecord.Payload, &envelope); err != nil {
 			t.Fatalf("failed to unmarshal payload: %v", err)
 		}
-		dataMap := envelope["data"].(map[string]interface{})
+		dataMap, ok := envelope["data"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected data to be map[string]interface{}, got %T", envelope["data"])
+		}
 		if got, want := dataMap["planId"], "plan-3"; got != want {
 			t.Errorf("got data.planId = %v, want %v", got, want)
 		}

--- a/internal/workout_execution/infrastructure/event/outbox_writer_test.go
+++ b/internal/workout_execution/infrastructure/event/outbox_writer_test.go
@@ -114,11 +114,60 @@ func TestOutboxWriter(t *testing.T) {
 		}
 
 		if got, want := dataMap["userId"], "user-1"; got != want {
-
 			t.Errorf("got data.userId = %v, want %v", got, want)
+		}
+		if got, want := dataMap["planId"], "plan-1"; got != want {
+			t.Errorf("got data.planId = %v, want %v", got, want)
+		}
+	})
 
+	t.Run("WriteEvents with WorkoutSessionCompleted maps planId", func(t *testing.T) {
+		repo := &mockOutboxRepo{}
+		writer := infraEvent.NewOutboxWriter(repo)
+		ev := &event.WorkoutSessionCompleted{
+			SessionID:   "sess-2",
+			UserID:      "user-2",
+			PlanID:      "plan-2",
+			CompletedAt: time.Now().UTC(),
 		}
 
+		if err := writer.WriteEvents(context.Background(), "WorkoutSession", "sess-2", []interface{}{ev}); err != nil {
+			t.Fatalf("got err = %v, want nil", err)
+		}
+
+		var envelope map[string]interface{}
+		if err := json.Unmarshal(repo.savedRecord.Payload, &envelope); err != nil {
+			t.Fatalf("failed to unmarshal payload: %v", err)
+		}
+		dataMap := envelope["data"].(map[string]interface{})
+		if got, want := dataMap["planId"], "plan-2"; got != want {
+			t.Errorf("got data.planId = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("WriteEvents with WorkoutSessionAborted maps planId", func(t *testing.T) {
+		repo := &mockOutboxRepo{}
+		writer := infraEvent.NewOutboxWriter(repo)
+		ev := &event.WorkoutSessionAborted{
+			SessionID: "sess-3",
+			UserID:    "user-3",
+			PlanID:    "plan-3",
+			Reason:    "timeout",
+			AbortedAt: time.Now().UTC(),
+		}
+
+		if err := writer.WriteEvents(context.Background(), "WorkoutSession", "sess-3", []interface{}{ev}); err != nil {
+			t.Fatalf("got err = %v, want nil", err)
+		}
+
+		var envelope map[string]interface{}
+		if err := json.Unmarshal(repo.savedRecord.Payload, &envelope); err != nil {
+			t.Fatalf("failed to unmarshal payload: %v", err)
+		}
+		dataMap := envelope["data"].(map[string]interface{})
+		if got, want := dataMap["planId"], "plan-3"; got != want {
+			t.Errorf("got data.planId = %v, want %v", got, want)
+		}
 	})
 
 	t.Run("WriteEvents with generic struct (unknown event type)", func(t *testing.T) {


### PR DESCRIPTION
## Proposed PR Title
✨ feat(workout-execution): bổ sung PlanID vào Outbox CloudEvent cho WorkoutSessionCompleted và WorkoutSessionAborted

---

### 1. Vấn Đề Cần Giải Quyết (Problem to Solve)
Trong module `workout_execution`, khi chuyển đổi domain event sang proto payload cho Outbox CloudEvent (`outbox_writer.go`):
- Trường `PlanId` chỉ mới được gán cho duy nhất event `WorkoutSessionStarted`.
- Event `WorkoutSessionCompleted` (hàm `mapWorkoutSessionCompletedToProto`) và `WorkoutSessionAborted` (hàm `mapToProtoEvent`) bị bỏ sót không gán `PlanId: e.PlanID`, dẫn đến các dịch vụ tiêu thụ CloudEvent (như analytics/notification service) nhận payload thiếu thông tin `planId`.

---

### 2. Giải Pháp Đề Xuất (Proposed Solution)
- Trong `outbox_writer.go`:
  - Bổ sung `PlanId: e.PlanID` vào hàm `mapWorkoutSessionCompletedToProto` khi tạo proto `WorkoutSessionCompleted`.
  - Bổ sung `PlanId: e.PlanID` vào các case `domainEvent.WorkoutSessionAborted` (cả struct value và pointer value) khi tạo proto `WorkoutSessionAborted`.
- Trong `outbox_writer_test.go`:
  - Bổ sung unit test cases kiểm thử sự xuất hiện của `planId` trong JSON payload của `WorkoutSessionCompleted` và `WorkoutSessionAborted`.

---

### 3. Danh Sách Sửa Đổi & Ảnh Hưởng (Changes & Impact)
- `[internal/workout_execution/infrastructure/event/outbox_writer.go](internal/workout_execution/infrastructure/event/outbox_writer.go)`: Gán `PlanId: e.PlanID` cho `WorkoutSessionCompleted` và `WorkoutSessionAborted`.
- `[internal/workout_execution/infrastructure/event/outbox_writer_test.go](internal/workout_execution/infrastructure/event/outbox_writer_test.go)`: Thêm test case xác minh `planId` trong CloudEvent payload.

---

### 4. Kiểm Thử & Xác Nhận (Testing & Verification)
- **Automated Tests**: Đã chạy `go test -count=1 ./internal/workout_execution/infrastructure/event/...` -> **PASS 100%**.
