### PR TITLE
🔧 chore(db): add outbox_log idempotency index across all modules

### DIFF
--- a/scripts/postgres-init/01-init-schemas.sql
+++ b/scripts/postgres-init/01-init-schemas.sql
@@ -257,4 +257,16 @@ CREATE INDEX IF NOT EXISTS idx_coaching_outbox_claim ON coaching.outbox (publish
 CREATE INDEX IF NOT EXISTS idx_workout_execution_outbox_claim ON workout_execution.outbox (published, status, locked_until, created_at);
 CREATE INDEX IF NOT EXISTS idx_exercise_outbox_claim ON exercise.outbox (published, status, locked_until, created_at);
 
+-- ------------------------------------------
+-- 10. OUTBOX LOG IDEMPOTENCY INDEXES
+-- ------------------------------------------
+CREATE INDEX IF NOT EXISTS idx_auth_outbox_log_event_status ON auth.outbox_log (event_id, status);
+CREATE INDEX IF NOT EXISTS idx_profile_outbox_log_event_status ON profile.outbox_log (event_id, status);
+CREATE INDEX IF NOT EXISTS idx_coaching_outbox_log_event_status ON coaching.outbox_log (event_id, status);
+CREATE INDEX IF NOT EXISTS idx_workout_execution_outbox_log_event_status ON workout_execution.outbox_log (event_id, status);
+CREATE INDEX IF NOT EXISTS idx_nutrition_outbox_log_event_status ON nutrition.outbox_log (event_id, status);
+CREATE INDEX IF NOT EXISTS idx_notification_outbox_log_event_status ON notification.outbox_log (event_id, status);
+CREATE INDEX IF NOT EXISTS idx_audio_outbox_log_event_status ON audio.outbox_log (event_id, status);
+CREATE INDEX IF NOT EXISTS idx_exercise_outbox_log_event_status ON exercise.outbox_log (event_id, status);
+
 

--- a/scripts/postgres-init/02-create-exercise-tables.sql
+++ b/scripts/postgres-init/02-create-exercise-tables.sql
@@ -83,3 +83,5 @@ CREATE TABLE IF NOT EXISTS exercise.motion_specifications (
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE INDEX IF NOT EXISTS idx_exercise_outbox_log_event_status ON exercise.outbox_log (event_id, status);

--- a/scripts/postgres-init/03_init_auth_schema.sql
+++ b/scripts/postgres-init/03_init_auth_schema.sql
@@ -32,4 +32,5 @@ CREATE INDEX IF NOT EXISTS idx_users_google_id ON auth.users (google_id) WHERE g
 CREATE INDEX IF NOT EXISTS idx_users_facebook_id ON auth.users (facebook_id) WHERE facebook_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON auth.sessions (user_id);
 CREATE INDEX IF NOT EXISTS idx_jwk_keys_status ON auth.jwk_keys (status);
+CREATE INDEX IF NOT EXISTS idx_auth_outbox_log_event_status ON auth.outbox_log (event_id, status);
 

--- a/scripts/postgres-init/04-create-workout-execution-tables.sql
+++ b/scripts/postgres-init/04-create-workout-execution-tables.sql
@@ -107,6 +107,8 @@ CREATE TABLE IF NOT EXISTS workout_execution.motion_specifications (
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE INDEX IF NOT EXISTS idx_workout_execution_outbox_log_event_status ON workout_execution.outbox_log (event_id, status);
+
 
 
 

--- a/scripts/postgres-init/05-create-coaching-tables.sql
+++ b/scripts/postgres-init/05-create-coaching-tables.sql
@@ -88,3 +88,5 @@ CREATE INDEX IF NOT EXISTS ix_session_plans_pending
 -- 5. Consumer idempotency (D9): unique event_id on outbox_log
 CREATE UNIQUE INDEX IF NOT EXISTS ux_coaching_outbox_log_event_id
     ON coaching.outbox_log(event_id);
+CREATE INDEX IF NOT EXISTS idx_coaching_outbox_log_event_status
+    ON coaching.outbox_log(event_id, status);

--- a/scripts/postgres-init/05_init_profile_tables.sql
+++ b/scripts/postgres-init/05_init_profile_tables.sql
@@ -51,3 +51,4 @@ CREATE TABLE IF NOT EXISTS profile.injuries (
 );
 
 CREATE INDEX IF NOT EXISTS idx_profile_injuries_user_id ON profile.injuries(user_id);
+CREATE INDEX IF NOT EXISTS idx_profile_outbox_log_event_status ON profile.outbox_log (event_id, status);


### PR DESCRIPTION
### 1. Problem to Solve
- Cần tối ưu hóa tốc độ truy vấn kiểm tra Idempotency trên bảng outbox_log cho tất cả các Bounded Context (modules) khi consumer xử lý CloudEvents.

### 2. Proposed Solution
- Bổ sung composite index (event_id, status) với tên idx_<module>_outbox_log_event_status cho bảng outbox_log của 8 module trong file khởi tạo schema tổng hợp 01-init-schemas.sql.
- Cập nhật đồng bộ các file SQL khởi tạo riêng lẻ của từng module.

### 3. Changes & Impact
- [scripts/postgres-init/01-init-schemas.sql](scripts/postgres-init/01-init-schemas.sql): Bổ sung Section 10 tạo index idx_<module>_outbox_log_event_status cho cả 8 modules.
- [scripts/postgres-init/02-create-exercise-tables.sql](scripts/postgres-init/02-create-exercise-tables.sql): Bổ sung index idempotency cho module exercise.
- [scripts/postgres-init/03_init_auth_schema.sql](scripts/postgres-init/03_init_auth_schema.sql): Bổ sung index idempotency cho module auth.
- [scripts/postgres-init/04-create-workout-execution-tables.sql](scripts/postgres-init/04-create-workout-execution-tables.sql): Bổ sung index idempotency cho module workout_execution.
- [scripts/postgres-init/05-create-coaching-tables.sql](scripts/postgres-init/05-create-coaching-tables.sql): Bổ sung index idempotency cho module coaching.
- [scripts/postgres-init/05_init_profile_tables.sql](scripts/postgres-init/05_init_profile_tables.sql): Bổ sung index idempotency cho module profile.

### 4. Testing & Verification
- Automated Tests: Chạy go test ./internal/... thành công 100%.