### PR TITLE
✅ test(workout-execution): add missing unit tests and refactor MotionSpecificationDTO

### DIFF
--- a/internal/workout_execution/application/command/motion_spec_commands_test.go
+++ b/internal/workout_execution/application/command/motion_spec_commands_test.go
@@ -34,14 +34,14 @@ func (m *mockMotionSpecRepo) Save(ctx context.Context, spec *aggregate.MotionSpe
 func (m *mockMotionSpecRepo) FindByExerciseID(ctx context.Context, exerciseID string) (*aggregate.MotionSpecification, error) {
 	spec, ok := m.specs[exerciseID]
 	if !ok {
-		return nil, derror.ErrNotFound
+		return nil, derror.ErrMotionSpecNotFound
 	}
 	return spec, nil
 }
 
 func (m *mockMotionSpecRepo) Delete(ctx context.Context, exerciseID string) error {
 	if _, ok := m.specs[exerciseID]; !ok {
-		return derror.ErrNotFound
+		return derror.ErrMotionSpecNotFound
 	}
 	delete(m.specs, exerciseID)
 	return nil
@@ -69,7 +69,7 @@ func TestUpdateMotionSpecificationHandler(t *testing.T) {
 
 		_, err := handler.Handle(context.Background(), cmd)
 		if err == nil {
-			t.Fatal("got nil error, want ErrNotFound")
+			t.Fatal("got nil error, want ErrMotionSpecNotFound")
 		}
 	})
 

--- a/internal/workout_execution/application/command/patch_motion_spec_asset.go
+++ b/internal/workout_execution/application/command/patch_motion_spec_asset.go
@@ -85,7 +85,7 @@ func (h *PatchMotionSpecificationAssetHandler) Handle(
 	// 1. Check if MotionSpecification exists in Database
 	spec, err := h.motionRepo.FindByExerciseID(ctx, exerciseID)
 	if err != nil {
-		if errors.Is(err, derror.ErrNotFound) || errors.Is(err, derror.ErrMotionSpecNotFound) {
+		if errors.Is(err, derror.ErrMotionSpecNotFound) {
 			return nil, fmt.Errorf("patch motion asset: %w: exercise_id '%s'", derror.ErrMotionSpecNotFound, exerciseID)
 		}
 		return nil, fmt.Errorf("patch motion asset find spec: %w", err)

--- a/internal/workout_execution/application/command/update_motion_spec.go
+++ b/internal/workout_execution/application/command/update_motion_spec.go
@@ -53,7 +53,7 @@ func (h *UpdateMotionSpecificationHandler) Handle(
 
 	spec, err := h.motionRepo.FindByExerciseID(ctx, cmd.ExerciseID)
 	if err != nil {
-		if errors.Is(err, derror.ErrNotFound) || errors.Is(err, derror.ErrMotionSpecNotFound) {
+		if errors.Is(err, derror.ErrMotionSpecNotFound) {
 			return nil, fmt.Errorf("update motion spec: %w: exercise_id '%s'", derror.ErrMotionSpecNotFound, cmd.ExerciseID)
 		}
 		return nil, fmt.Errorf("update motion spec find: %w", err)

--- a/internal/workout_execution/application/query/queries.go
+++ b/internal/workout_execution/application/query/queries.go
@@ -3,11 +3,25 @@ package query
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/viethung213/gym-companion/internal/workout_execution/domain/aggregate"
 	"github.com/viethung213/gym-companion/internal/workout_execution/domain/derror"
 	"github.com/viethung213/gym-companion/internal/workout_execution/domain/repository"
 )
+
+// MotionSpecificationDTO represents read-only motion specification data for query responses.
+type MotionSpecificationDTO struct {
+	ExerciseID             string    `json:"exerciseId"`
+	OnnxDetectorURL        string    `json:"onnxDetectorUrl"`
+	OnnxSkeletonURL        string    `json:"onnxSkeletonUrl"`
+	LocalRulesURL          string    `json:"localRulesUrl"`
+	DialogueEngineURL      string    `json:"dialogueEngineUrl"`
+	RecommendedCameraAngle string    `json:"recommendedCameraAngle"`
+	IsReady                bool      `json:"isReady"`
+	CreatedAt              time.Time `json:"createdAt"`
+	UpdatedAt              time.Time `json:"updatedAt"`
+}
 
 // GetMotionSpecificationQueryHandler handles fetching motion spec config.
 type GetMotionSpecificationQueryHandler struct {
@@ -22,7 +36,7 @@ func NewGetMotionSpecificationQueryHandler(motionRepo repository.MotionSpecifica
 }
 
 // Handle executes query.
-func (h *GetMotionSpecificationQueryHandler) Handle(ctx context.Context, exerciseID, _ string) (*aggregate.MotionSpecification, error) {
+func (h *GetMotionSpecificationQueryHandler) Handle(ctx context.Context, exerciseID, _ string) (*MotionSpecificationDTO, error) {
 	if exerciseID == "" {
 		return nil, derror.ErrMotionSpecNotFound
 	}
@@ -36,7 +50,17 @@ func (h *GetMotionSpecificationQueryHandler) Handle(ctx context.Context, exercis
 		return nil, derror.ErrMotionSpecNotFound
 	}
 
-	return spec, nil
+	return &MotionSpecificationDTO{
+		ExerciseID:             spec.ExerciseID(),
+		OnnxDetectorURL:        spec.OnnxDetectorURL(),
+		OnnxSkeletonURL:        spec.OnnxSkeletonURL(),
+		LocalRulesURL:          spec.LocalRulesURL(),
+		DialogueEngineURL:      spec.DialogueEngineURL(),
+		RecommendedCameraAngle: spec.RecommendedCameraAngle(),
+		IsReady:                spec.IsReady(),
+		CreatedAt:              spec.CreatedAt(),
+		UpdatedAt:              spec.UpdatedAt(),
+	}, nil
 }
 
 // GetPersonalRecordsQueryHandler handles fetching PR records.

--- a/internal/workout_execution/application/query/queries_test.go
+++ b/internal/workout_execution/application/query/queries_test.go
@@ -236,10 +236,8 @@ func TestGetMotionSpecificationQueryHandler(t *testing.T) {
 
 		}
 
-		if res.ExerciseID() != "ex-1" {
-
-			t.Errorf("got %v, want ex-1", res.ExerciseID())
-
+		if res.ExerciseID != "ex-1" {
+			t.Errorf("got %v, want ex-1", res.ExerciseID)
 		}
 
 	})

--- a/internal/workout_execution/domain/aggregate/motion_specification_test.go
+++ b/internal/workout_execution/domain/aggregate/motion_specification_test.go
@@ -108,3 +108,130 @@ func TestMotionSpecificationUpdateSpecAndEvents(t *testing.T) {
 		t.Error("want 0 events after PopEvents")
 	}
 }
+
+func TestMotionSpecification_UpdateSpec_PartialUpdates(t *testing.T) {
+	spec := aggregate.RestoreMotionSpecification(
+		"ex-4",
+		"http://det1.onnx",
+		"http://skel1.onnx",
+		"http://rules1.json",
+		"http://dialogue1.json",
+		"side",
+		true,
+		time.Now().UTC().Add(-time.Hour),
+		time.Now().UTC().Add(-time.Hour),
+	)
+
+	prevUpdatedAt := spec.UpdatedAt()
+	time.Sleep(2 * time.Millisecond)
+
+	// Partial update: empty strings should not overwrite existing URLs
+	spec.UpdateSpec("", "", "http://rules2.json", "", "")
+
+	if got, want := spec.OnnxDetectorURL(), "http://det1.onnx"; got != want {
+		t.Errorf("got OnnxDetectorURL = %v, want %v", got, want)
+	}
+	if got, want := spec.OnnxSkeletonURL(), "http://skel1.onnx"; got != want {
+		t.Errorf("got OnnxSkeletonURL = %v, want %v", got, want)
+	}
+	if got, want := spec.LocalRulesURL(), "http://rules2.json"; got != want {
+		t.Errorf("got LocalRulesURL = %v, want %v", got, want)
+	}
+	if got, want := spec.DialogueEngineURL(), "http://dialogue1.json"; got != want {
+		t.Errorf("got DialogueEngineURL = %v, want %v", got, want)
+	}
+	if got, want := spec.RecommendedCameraAngle(), "side"; got != want {
+		t.Errorf("got RecommendedCameraAngle = %v, want %v", got, want)
+	}
+
+	if !spec.UpdatedAt().After(prevUpdatedAt) {
+		t.Errorf("got UpdatedAt = %v, want after %v", spec.UpdatedAt(), prevUpdatedAt)
+	}
+}
+
+func TestMotionSpecification_IsComplete(t *testing.T) {
+	tests := []struct {
+		name              string
+		detectorURL       string
+		skeletonURL       string
+		localRulesURL     string
+		dialogueEngineURL string
+		want              bool
+	}{
+		{
+			name:              "all URLs populated",
+			detectorURL:       "http://det.onnx",
+			skeletonURL:       "http://skel.onnx",
+			localRulesURL:     "http://rules.json",
+			dialogueEngineURL: "http://dialogue.json",
+			want:              true,
+		},
+		{
+			name:              "missing detector URL",
+			detectorURL:       "",
+			skeletonURL:       "http://skel.onnx",
+			localRulesURL:     "http://rules.json",
+			dialogueEngineURL: "http://dialogue.json",
+			want:              false,
+		},
+		{
+			name:              "missing skeleton URL",
+			detectorURL:       "http://det.onnx",
+			skeletonURL:       "",
+			localRulesURL:     "http://rules.json",
+			dialogueEngineURL: "http://dialogue.json",
+			want:              false,
+		},
+		{
+			name:              "missing local rules URL",
+			detectorURL:       "http://det.onnx",
+			skeletonURL:       "http://skel.onnx",
+			localRulesURL:     "",
+			dialogueEngineURL: "http://dialogue.json",
+			want:              false,
+		},
+		{
+			name:              "missing dialogue engine URL",
+			detectorURL:       "http://det.onnx",
+			skeletonURL:       "http://skel.onnx",
+			localRulesURL:     "http://rules.json",
+			dialogueEngineURL: "",
+			want:              false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			spec := aggregate.RestoreMotionSpecification(
+				"ex-test",
+				tt.detectorURL,
+				tt.skeletonURL,
+				tt.localRulesURL,
+				tt.dialogueEngineURL,
+				"front",
+				false,
+				time.Now().UTC(),
+				time.Now().UTC(),
+			)
+			if got := spec.IsComplete(); got != tt.want {
+				t.Errorf("IsComplete() got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMotionSpecification_PopEvents(t *testing.T) {
+	spec := aggregate.NewDraftMotionSpecification("ex-pop", "http://det.onnx", "http://skel.onnx")
+	spec.UpdateSpec("http://det2.onnx", "http://skel2.onnx", "http://rules.json", "http://dialogue.json", "front")
+
+	evs1 := spec.PopEvents()
+	if got, want := len(evs1), 1; got != want {
+		t.Fatalf("first PopEvents() count got %d, want %d", got, want)
+	}
+
+	evs2 := spec.PopEvents()
+	if got, want := len(evs2), 0; got != want {
+		t.Errorf("second PopEvents() count got %d, want %d", got, want)
+	}
+}

--- a/internal/workout_execution/domain/aggregate/workout_session_test.go
+++ b/internal/workout_execution/domain/aggregate/workout_session_test.go
@@ -304,3 +304,235 @@ func TestWorkoutSession_NewScheduledAndAbort(t *testing.T) {
 		}
 	})
 }
+
+func TestWorkoutSession_NewScheduledWorkoutSession_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      string
+		userID  string
+		planID  string
+		wantErr bool
+	}{
+		{
+			name:    "empty id returns error",
+			id:      "",
+			userID:  "u1",
+			planID:  "p1",
+			wantErr: true,
+		},
+		{
+			name:    "empty userID returns error",
+			id:      "s1",
+			userID:  "",
+			planID:  "p1",
+			wantErr: true,
+		},
+		{
+			name:    "empty planID returns error",
+			id:      "s1",
+			userID:  "u1",
+			planID:  "",
+			wantErr: true,
+		},
+		{
+			name:    "valid params creates scheduled session",
+			id:      "s1",
+			userID:  "u1",
+			planID:  "p1",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			schedTime := time.Now().UTC()
+			sess, err := aggregate.NewScheduledWorkoutSession(tt.id, tt.userID, tt.planID, schedTime)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewScheduledWorkoutSession() err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				if sess.Status() != aggregate.StatusScheduled {
+					t.Errorf("got status = %v, want SCHEDULED", sess.Status())
+				}
+				if sess.StartedAt() != nil {
+					t.Errorf("got startedAt = %v, want nil for scheduled session", sess.StartedAt())
+				}
+				if sess.ScheduledAt() == nil || !sess.ScheduledAt().Equal(schedTime) {
+					t.Errorf("got scheduledAt = %v, want %v", sess.ScheduledAt(), schedTime)
+				}
+			}
+		})
+	}
+}
+
+func TestWorkoutSession_AbortAndAbortAnomalous_Detailed(t *testing.T) {
+	t.Run("Abort emits non-anomalous event", func(t *testing.T) {
+		sess, _ := aggregate.NewWorkoutSession("s-ab-1", "u1", "p1")
+		sess.PopEvents() // clear start event
+
+		err := sess.Abort("user stopped early")
+		if err != nil {
+			t.Fatalf("Abort() err = %v, want nil", err)
+		}
+		if sess.Status() != aggregate.StatusAborted {
+			t.Errorf("got status = %v, want ABORTED", sess.Status())
+		}
+		if sess.EndedAt() == nil {
+			t.Error("want endedAt non-nil after Abort")
+		}
+
+		events := sess.PopEvents()
+		if len(events) != 1 {
+			t.Fatalf("got %d events, want 1", len(events))
+		}
+		ev, ok := events[0].(*event.WorkoutSessionAborted)
+		if !ok {
+			t.Fatalf("expected *event.WorkoutSessionAborted, got %T", events[0])
+		}
+		if ev.IsAnomalous {
+			t.Error("want IsAnomalous = false for Abort()")
+		}
+		if ev.Reason != "user stopped early" {
+			t.Errorf("got Reason = %q, want 'user stopped early'", ev.Reason)
+		}
+	})
+
+	t.Run("AbortAnomalous emits anomalous event", func(t *testing.T) {
+		sess, _ := aggregate.NewWorkoutSession("s-ab-2", "u1", "p1")
+		sess.PopEvents() // clear start event
+
+		err := sess.AbortAnomalous("critical fall detected")
+		if err != nil {
+			t.Fatalf("AbortAnomalous() err = %v, want nil", err)
+		}
+		if sess.Status() != aggregate.StatusAnomalous {
+			t.Errorf("got status = %v, want ANOMALOUS", sess.Status())
+		}
+		if sess.EndedAt() == nil {
+			t.Error("want endedAt non-nil after AbortAnomalous")
+		}
+
+		events := sess.PopEvents()
+		if len(events) != 1 {
+			t.Fatalf("got %d events, want 1", len(events))
+		}
+		ev, ok := events[0].(*event.WorkoutSessionAborted)
+		if !ok {
+			t.Fatalf("expected *event.WorkoutSessionAborted, got %T", events[0])
+		}
+		if !ev.IsAnomalous {
+			t.Error("want IsAnomalous = true for AbortAnomalous()")
+		}
+		if ev.Reason != "critical fall detected" {
+			t.Errorf("got Reason = %q, want 'critical fall detected'", ev.Reason)
+		}
+	})
+
+	t.Run("Abort and AbortAnomalous on terminated session returns error", func(t *testing.T) {
+		sess, _ := aggregate.NewWorkoutSession("s-ab-3", "u1", "p1")
+		_ = sess.Complete(false, false)
+
+		if err := sess.Abort("reason"); err == nil {
+			t.Error("want error calling Abort on completed session")
+		}
+		if err := sess.AbortAnomalous("reason"); err == nil {
+			t.Error("want error calling AbortAnomalous on completed session")
+		}
+	})
+}
+
+func TestWorkoutSession_RecordBodyMetricUpdate_EdgeCases(t *testing.T) {
+	t.Run("weight > 0 emits BodyMetricUpdated event", func(t *testing.T) {
+		sess, _ := aggregate.NewWorkoutSession("s-bm-edge", "u1", "p1")
+		sess.PopEvents()
+
+		sess.RecordBodyMetricUpdate(82.5)
+		events := sess.PopEvents()
+		if len(events) != 1 {
+			t.Fatalf("got %d events, want 1", len(events))
+		}
+		ev, ok := events[0].(*event.BodyMetricUpdated)
+		if !ok {
+			t.Fatalf("expected *event.BodyMetricUpdated, got %T", events[0])
+		}
+		if ev.UserID != "u1" || ev.WeightKg != 82.5 {
+			t.Errorf("got UserID=%s WeightKg=%v, want u1 82.5", ev.UserID, ev.WeightKg)
+		}
+	})
+
+	t.Run("weight <= 0 emits no event", func(t *testing.T) {
+		sess, _ := aggregate.NewWorkoutSession("s-bm-zero", "u1", "p1")
+		sess.PopEvents()
+
+		sess.RecordBodyMetricUpdate(0)
+		sess.RecordBodyMetricUpdate(-10.0)
+
+		events := sess.PopEvents()
+		if len(events) != 0 {
+			t.Errorf("got %d events, want 0 for weight <= 0", len(events))
+		}
+	})
+}
+
+func TestWorkoutSession_LogSet_DuplicateSetNumberOverwritesExisting(t *testing.T) {
+	sess, _ := aggregate.NewWorkoutSession("s-dup-1", "u1", "p1")
+
+	fs1 := float32(80.0)
+	set1 := aggregate.WorkoutSetLog{
+		ID:         "set-uuid-100",
+		SetNumber:  1,
+		ExerciseID: "ex-bench",
+		TargetReps: 10,
+		ActualReps: 10,
+		Weight:     50.0,
+		FormScore:  &fs1,
+		RPE:        7.0,
+	}
+
+	err := sess.LogSet(set1)
+	if err != nil {
+		t.Fatalf("first LogSet err = %v, want nil", err)
+	}
+
+	if len(sess.Sets()) != 1 {
+		t.Fatalf("got sets count = %d, want 1", len(sess.Sets()))
+	}
+
+	// Ghi đè set trùng set_number và exercise_id với input ID rỗng ("")
+	fs2 := float32(95.0)
+	set1Override := aggregate.WorkoutSetLog{
+		ID:         "", // empty ID should retain existing set ID "set-uuid-100"
+		SetNumber:  1,
+		ExerciseID: "ex-bench",
+		TargetReps: 10,
+		ActualReps: 12,
+		Weight:     55.0,
+		FormScore:  &fs2,
+		RPE:        8.5,
+	}
+
+	err = sess.LogSet(set1Override)
+	if err != nil {
+		t.Fatalf("second LogSet err = %v, want nil", err)
+	}
+
+	sets := sess.Sets()
+	if len(sets) != 1 {
+		t.Fatalf("got sets count after duplicate set_number = %d, want 1 (overwritten)", len(sets))
+	}
+
+	updatedSet := sets[0]
+	if updatedSet.ID != "set-uuid-100" {
+		t.Errorf("got set ID = %q, want 'set-uuid-100' (retained existing ID)", updatedSet.ID)
+	}
+	if updatedSet.Weight != 55.0 {
+		t.Errorf("got Weight = %v, want 55.0", updatedSet.Weight)
+	}
+	if updatedSet.ActualReps != 12 {
+		t.Errorf("got ActualReps = %d, want 12", updatedSet.ActualReps)
+	}
+	if updatedSet.FormScore == nil || *updatedSet.FormScore != 95.0 {
+		t.Errorf("got FormScore = %v, want 95.0", updatedSet.FormScore)
+	}
+}

--- a/internal/workout_execution/domain/derror/errors.go
+++ b/internal/workout_execution/domain/derror/errors.go
@@ -20,4 +20,3 @@ var (
 	ErrOptimisticLocking            = errors.New("concurrent update detected for workout session")
 	ErrForbidden                    = errors.New("forbidden: user does not own this workout session")
 )
-

--- a/internal/workout_execution/domain/derror/errors.go
+++ b/internal/workout_execution/domain/derror/errors.go
@@ -19,5 +19,5 @@ var (
 	ErrInvalidInput                 = errors.New("invalid input parameter")
 	ErrOptimisticLocking            = errors.New("concurrent update detected for workout session")
 	ErrForbidden                    = errors.New("forbidden: user does not own this workout session")
-	ErrNotFound                     = ErrMotionSpecNotFound
 )
+

--- a/internal/workout_execution/domain/policy/critical_posture_policy_test.go
+++ b/internal/workout_execution/domain/policy/critical_posture_policy_test.go
@@ -64,3 +64,11 @@ func TestIsCritical(t *testing.T) {
 		})
 	}
 }
+
+func TestIsCritical_Nil(t *testing.T) {
+	t.Parallel()
+
+	if got := policy.IsCritical(nil); got != false {
+		t.Errorf("IsCritical(nil) = %v, want false", got)
+	}
+}

--- a/internal/workout_execution/infrastructure/kafka/publisher_test.go
+++ b/internal/workout_execution/infrastructure/kafka/publisher_test.go
@@ -2,6 +2,7 @@ package kafka_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/segmentio/kafka-go"
@@ -26,5 +27,32 @@ func TestPublisher_PublishBatch_Empty(t *testing.T) {
 	err = pub.Close()
 	if err != nil {
 		t.Errorf("got err = %v, want nil for Close()", err)
+	}
+}
+
+func TestPublisher_PublishBatch_ErrorHandling(t *testing.T) {
+	writer := &kafka.Writer{
+		Addr: kafka.TCP("127.0.0.1:9092"),
+	}
+	pub := workoutKafka.NewPublisher(writer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel context immediately to force WriteMessages failure
+
+	records := []*port.OutboxRecord{
+		{
+			ID:           "rec-1",
+			EventType:    "contracts.workout_execution.v1.WorkoutSessionStarted",
+			PartitionKey: "user-100",
+			Payload:      []byte(`{"sessionId":"sess-1"}`),
+		},
+	}
+
+	err := pub.PublishBatch(ctx, records)
+	if err == nil {
+		t.Fatal("PublishBatch() got nil error, want error on canceled context")
+	}
+	if !strings.Contains(err.Error(), "write workout_execution kafka batch messages") {
+		t.Errorf("got err = %v, want error wrapped with 'write workout_execution kafka batch messages'", err)
 	}
 }

--- a/internal/workout_execution/infrastructure/persistence/postgres_repository.go
+++ b/internal/workout_execution/infrastructure/persistence/postgres_repository.go
@@ -365,7 +365,7 @@ func (r *PostgresMotionSpecificationRepository) FindByExerciseID(ctx context.Con
 	err := db.First(&model, "exercise_id = ?", exerciseID).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, derror.ErrNotFound
+			return nil, derror.ErrMotionSpecNotFound
 		}
 		return nil, fmt.Errorf("failed to find motion specification: %w", err)
 	}
@@ -384,7 +384,7 @@ func (r *PostgresMotionSpecificationRepository) Delete(ctx context.Context, exer
 		return fmt.Errorf("failed to delete motion specification: %w", res.Error)
 	}
 	if res.RowsAffected == 0 {
-		return derror.ErrNotFound
+		return derror.ErrMotionSpecNotFound
 	}
 	return nil
 }

--- a/internal/workout_execution/infrastructure/persistence/postgres_repository_test.go
+++ b/internal/workout_execution/infrastructure/persistence/postgres_repository_test.go
@@ -340,8 +340,8 @@ func TestPostgresMotionSpecificationRepository_Integration(t *testing.T) {
 	}
 
 	missingSpec, err := repo.FindByExerciseID(ctx, "non-existent-ex")
-	if !errors.Is(err, derror.ErrNotFound) || missingSpec != nil {
-		t.Errorf("expected derror.ErrNotFound for missing MotionSpec, got %v, %v", missingSpec, err)
+	if !errors.Is(err, derror.ErrMotionSpecNotFound) || missingSpec != nil {
+		t.Errorf("expected derror.ErrMotionSpecNotFound for missing MotionSpec, got %v, %v", missingSpec, err)
 	}
 }
 

--- a/internal/workout_execution/infrastructure/transport/grpc_handler.go
+++ b/internal/workout_execution/infrastructure/transport/grpc_handler.go
@@ -278,12 +278,12 @@ func (h *GRPCHandler) GetMotionSpecification(ctx context.Context, req *workoutex
 	}
 
 	return &workoutexecutionv1message.GetMotionSpecificationResponse{
-		ExerciseId:             spec.ExerciseID(),
-		OnnxDetectorUrl:        spec.OnnxDetectorURL(),
-		OnnxSkeletonUrl:        spec.OnnxSkeletonURL(),
-		LocalRulesUrl:          spec.LocalRulesURL(),
-		DialogueEngineUrl:      spec.DialogueEngineURL(),
-		RecommendedCameraAngle: spec.RecommendedCameraAngle(),
+		ExerciseId:             spec.ExerciseID,
+		OnnxDetectorUrl:        spec.OnnxDetectorURL,
+		OnnxSkeletonUrl:        spec.OnnxSkeletonURL,
+		LocalRulesUrl:          spec.LocalRulesURL,
+		DialogueEngineUrl:      spec.DialogueEngineURL,
+		RecommendedCameraAngle: spec.RecommendedCameraAngle,
 	}, nil
 }
 
@@ -629,8 +629,7 @@ func toGRPCError(msg string, err error) error {
 	// 404 Not Found
 	case errors.Is(err, derror.ErrWorkoutSessionNotFound),
 		errors.Is(err, derror.ErrMotionSpecNotFound),
-		errors.Is(err, derror.ErrPersonalRecordNotFound),
-		errors.Is(err, derror.ErrNotFound):
+		errors.Is(err, derror.ErrPersonalRecordNotFound):
 		return status.Errorf(codes.NotFound, "%s: %v", msg, err)
 
 	// 400 Bad Request / Invalid Argument

--- a/internal/workout_execution/infrastructure/worker/exercise_created_consumer.go
+++ b/internal/workout_execution/infrastructure/worker/exercise_created_consumer.go
@@ -117,7 +117,7 @@ func (c *ExerciseCreatedConsumer) OnExerciseCreated(ctx context.Context, exercis
 		log.Printf("[WorkoutExecution] Draft MotionSpecification already exists for exercise_id: %s, skipping", exerciseID)
 		return nil
 	}
-	if err != nil && !errors.Is(err, derror.ErrNotFound) {
+	if err != nil && !errors.Is(err, derror.ErrMotionSpecNotFound) {
 		return fmt.Errorf("exercise created consumer check existing: %w", err)
 	}
 

--- a/internal/workout_execution/infrastructure/worker/exercise_created_consumer_test.go
+++ b/internal/workout_execution/infrastructure/worker/exercise_created_consumer_test.go
@@ -31,7 +31,7 @@ func (m *mockMotionRepo) Save(ctx context.Context, spec *aggregate.MotionSpecifi
 func (m *mockMotionRepo) FindByExerciseID(ctx context.Context, exerciseID string) (*aggregate.MotionSpecification, error) {
 	spec, ok := m.specs[exerciseID]
 	if !ok {
-		return nil, derror.ErrNotFound
+		return nil, derror.ErrMotionSpecNotFound
 	}
 	return spec, nil
 }


### PR DESCRIPTION
### 1. Problem to Solve
- Bổ sung các test case còn thiếu trong context \workout_execution\: \MotionSpecification\ (UpdateSpec, IsComplete, PopEvents), \WorkoutSession\ (NewScheduledWorkoutSession, Abort, AbortAnomalous, RecordBodyMetricUpdate, ghi đè set trùng set_number), \CriticalPosturePolicy\ (IsCritical(nil)), và \Kafka Publisher\ (PublishBatch error handling & Close).
- Khắc phục vi phạm quy tắc tầng Application Query khi nhúng/trả về trực tiếp Aggregate Domain struct thay vì DTO.
- Loại bỏ error alias dư thừa \ErrNotFound = ErrMotionSpecNotFound\ gây nhầm lẫn.

### 2. Proposed Solution
- Viết unit test dạng table-driven kiểm tra tất cả các hàm và edge cases trong Domain & Infrastructure.
- Khai báo DTO \MotionSpecificationDTO\ tại \pplication/query/queries.go\ và cập nhật \GetMotionSpecificationQueryHandler.Handle\ trả về \(*MotionSpecificationDTO, error)\.
- Cập nhật gRPC handler và query tests để sử dụng các trường thuộc tính từ \MotionSpecificationDTO\.
- Xóa dòng alias \ErrNotFound\ và thay thế toàn bộ tham chiếu sang \derror.ErrMotionSpecNotFound\.

### 3. Changes & Impact
- \internal/workout_execution/domain/aggregate/motion_specification_test.go\: Bổ sung unit test UpdateSpec, IsComplete, PopEvents.
- \internal/workout_execution/domain/aggregate/workout_session_test.go\: Bổ sung unit test NewScheduledWorkoutSession, Abort, AbortAnomalous, RecordBodyMetricUpdate, duplicate set_number.
- \internal/workout_execution/domain/policy/critical_posture_policy_test.go\: Bổ sung edge case IsCritical(nil).
- \internal/workout_execution/infrastructure/kafka/publisher_test.go\: Bổ sung test PublishBatch error handling & Close.
- \internal/workout_execution/application/query/queries.go\: Định nghĩa MotionSpecificationDTO và trả về DTO từ GetMotionSpecificationQueryHandler.
- \internal/workout_execution/domain/derror/errors.go\: Xóa alias ErrNotFound = ErrMotionSpecNotFound.

### 4. Testing & Verification
- **Automated Tests**: Chạy \go test ./internal/...\ toàn bộ pass 100%.
- **Manual Verification**: Kiểm tra code vet bằng \go vet ./internal/workout_execution/...\.