### PR TITLE
👷 ci(workflow): enable docker push to GHCR packages for production image

### DIFF
--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -11,7 +11,7 @@ on:
 
 permissions:
   contents: read
-  packages: read
+  packages: write
 
 jobs:
   detect-changes:
@@ -176,7 +176,7 @@ jobs:
             if [ $STATUS -ne 0 ] || [ $FAILED -gt 0 ]; then exit 1; fi'
 
   build-production-image:
-    name: Build Production Image
+    name: Build & Push Production Image
     needs: [detect-changes, run-module-tests]
     if: ${{ needs.detect-changes.outputs.has_modules == 'true' }}
     runs-on: ubuntu-latest
@@ -194,5 +194,11 @@ jobs:
       - name: Generate Protobuf Stubs
         run: make proto-gen
 
-      - name: Build Production Image
-        run: make build-prod
+      - name: Build & Push Production Image to GHCR
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository }}
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          
+          docker build --target prod -t $IMAGE_ID:latest -t $IMAGE_ID:${{ github.sha }} .
+          docker push $IMAGE_ID:latest
+          docker push $IMAGE_ID:${{ github.sha }}


### PR DESCRIPTION
### 1. Problem to Solve
- Trước đó job `build-production-image` chỉ mới chạy `docker build` cục bộ trên GitHub Runner mà chưa có lệnh `docker push` lên GitHub Container Registry (GHCR), dẫn đến chưa thấy Docker Image xuất hiện trong danh sách **Packages** của GitHub Repository.

### 2. Proposed Solution
- Phân quyền `packages: write` cho workflow [`.github/workflows/module-tests.yml`](.github/workflows/module-tests.yml).
- Bổ sung lệnh `docker push` đăng tải Production Image lên GHCR (`ghcr.io/viethung213/gym-companion:latest` và `ghcr.io/viethung213/gym-companion:<commit_sha>`).

### 3. Changes & Impact
- [`.github/workflows/module-tests.yml`](.github/workflows/module-tests.yml): Cập nhật quyền ghi packages và lệnh push Docker Production Image lên GHCR Packages.

### 4. Testing & Verification
- CI workflow tự động kiểm thử và đẩy Docker image lên GHCRPackages khi hợp nhất vào `main`.
