### PR TITLE
🐛 fix(db): disable GORM prepared statement caching for Neon DB pooler compatibility

### DIFF
--- a/internal/auth/module.go
+++ b/internal/auth/module.go
@@ -61,6 +61,7 @@ func Initialize(ctx context.Context, deps ModuleDeps) (func(), error) {
 	gormDB, err := gorm.Open(gormPostgres.New(gormPostgres.Config{
 		Conn: deps.DB,
 	}), &gorm.Config{
+		PrepareStmt:            false,
 		SkipDefaultTransaction: true,
 	})
 	if err != nil {

--- a/internal/exercise/module.go
+++ b/internal/exercise/module.go
@@ -35,6 +35,7 @@ func Initialize(ctx context.Context, deps ModuleDeps) (func(), error) {
 	gormDB, err := gorm.Open(gormPostgres.New(gormPostgres.Config{
 		Conn: deps.DB,
 	}), &gorm.Config{
+		PrepareStmt:            false,
 		SkipDefaultTransaction: true,
 	})
 	if err != nil {

--- a/internal/workout_execution/module.go
+++ b/internal/workout_execution/module.go
@@ -40,6 +40,7 @@ func Initialize(ctx context.Context, deps ModuleDeps) (func(), error) {
 	gormDB, err := gorm.Open(gormPostgres.New(gormPostgres.Config{
 		Conn: deps.DB,
 	}), &gorm.Config{
+		PrepareStmt:            false,
 		SkipDefaultTransaction: true,
 	})
 	if err != nil {


### PR DESCRIPTION
## Proposed PR Title
🐛 fix(db): disable GORM prepared statement caching for Neon DB pooler compatibility

---

### 1. Problem to Solve
- Khi ứng dụng kết nối tới PostgreSQL trên Cloud (Neon DB / PgBouncer) ở chế độ Transaction Pooling, GORM mặc định sử dụng Prepared Statement cache.
- Khi connection pool luân chuyển kết nối giữa các câu lệnh \PREPARE\ và \EXECUTE\, PostgreSQL trả về lỗi \pq: unnamed prepared statement does not exist (26000)\ (đặc biệt đối với các worker chạy ngầm định kỳ của \workout_execution\).

### 2. Proposed Solution
- Cấu hình rõ ràng \PrepareStmt: false\ trong \gorm.Config\ cho tất cả các module (\uth\, \exercise\, \workout_execution\).
- Ép GORM thực thi các truy vấn SQL trực tiếp thay vì lưu cache prepared statement không tên, tương thích 100% với Neon DB và PgBouncer.

### 3. Changes & Impact
- \internal/auth/module.go\: Thêm \PrepareStmt: false\ vào \gorm.Config\.
- \internal/exercise/module.go\: Thêm \PrepareStmt: false\ vào \gorm.Config\.
- \internal/workout_execution/module.go\: Thêm \PrepareStmt: false\ vào \gorm.Config\.

### 4. Testing & Verification
- **Automated Tests**: Unit tests của cả 3 module đều PASS 100%.
- **Manual Verification**: Kiểm tra biên dịch \go build ./cmd/api\ thành công.