### PR TITLE
👷 ci(workflow): trigger publish-proto-stubs workflow on PRs targeting main and workflow changes

### DIFF
--- a/.github/workflows/publish-proto-stubs.yml
+++ b/.github/workflows/publish-proto-stubs.yml
@@ -7,6 +7,13 @@ on:
       - main
     paths:
       - 'proto/**'
+      - '.github/workflows/publish-proto-stubs.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'proto/**'
+      - '.github/workflows/publish-proto-stubs.yml'
 
 jobs:
   generate-and-publish:
@@ -32,6 +39,7 @@ jobs:
           make proto-gen
 
       - name: Publish TypeScript ConnectRPC package to GHCR
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
         working-directory: ./gen/es
         run: |
           npm publish --access public || echo "Version already published"


### PR DESCRIPTION
### 1. Problem to Solve
- Workflow \Publish Proto Stubs (ConnectRPC TS)\ (\.github/workflows/publish-proto-stubs.yml\) trước đây chỉ kích hoạt khi push trực tiếp lên \main\ và khi thư mục \proto/**\ thay đổi.
- Khi có Pull Request hướng tới \main\ hoặc khi chỉnh sửa chính file \.github/workflows/publish-proto-stubs.yml\, workflow không hề được kích hoạt để kiểm thử.

### 2. Proposed Changes
- [\.github/workflows/publish-proto-stubs.yml\](.github/workflows/publish-proto-stubs.yml):
  - Thêm trigger \pull_request\ cho nhánh \main\.
  - Thêm đường dẫn \.github/workflows/publish-proto-stubs.yml\ vào danh sách \paths\ cho cả 2 trigger \push\ và \pull_request\.
  - Thêm điều kiện \if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'\ cho bước \Publish TypeScript ConnectRPC package to GHCR\ để bước npm publish chỉ thực hiện khi code đã chính thức merge vào \main\.

### 3. Verification Plan
- Kiểm tra workflow tự động kích hoạt trên Pull Request này.