### PR TITLE
🐛 fix(ci): update working directory for TypeScript stubs publish to internal/gen/es

### DIFF
--- a/.github/workflows/publish-proto-stubs.yml
+++ b/.github/workflows/publish-proto-stubs.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Publish TypeScript ConnectRPC package to GHCR
         if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
-        working-directory: ./gen/es
+        working-directory: ./internal/gen/es
         run: |
           npm publish --access public || echo "Version already published"
         env:


### PR DESCRIPTION
### 1. Problem to Solve
- Trong file workflow \.github/workflows/publish-proto-stubs.yml\, đường dẫn \working-directory\ ở bước publish bị ghi nhầm thành \./gen/es\.
- Theo cấu hình nguồn duy nhất trong \proto/buf.gen.yaml\ (các plugin \protoc-gen-es\ và \protoc-gen-connect-es\), thư mục đích sinh mã TypeScript stubs thực sự là \internal/gen/es\.
- Điều này dẫn đến lỗi runner trong GitHub Actions:
  \Error: An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/gym-companion/gym-companion/./gen/es'. No such file or directory\.

### 2. Proposed Changes
- [\.github/workflows/publish-proto-stubs.yml\](.github/workflows/publish-proto-stubs.yml):
  - Cập nhật \working-directory: ./internal/gen/es\ đúng chính xác theo đầu ra sinh mã trong \proto/buf.gen.yaml\.

### 3. Verification Plan
- Chạy thử CI workflow trên Pull Request này.