### PR TITLE
👷 ci(workflow): upgrade Node.js version to 22 to clear deprecation warning

### DIFF
--- a/.github/workflows/publish-proto-stubs.yml
+++ b/.github/workflows/publish-proto-stubs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@viethung213'
 

--- a/.github/workflows/publish-proto-stubs.yml
+++ b/.github/workflows/publish-proto-stubs.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Publish TypeScript ConnectRPC package to GHCR
         if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
-        working-directory: ./gen/es
+        working-directory: ./internal/gen/es
         run: |
           npm publish --access public || echo "Version already published"
         env:


### PR DESCRIPTION
### 1. Problem to Solve
- Cảnh báo deprecation của Node 20 trên GitHub Actions runner:
  \Node 20 is being deprecated. This workflow is running with Node 24 by default...\.

### 2. Proposed Changes
- [\.github/workflows/publish-proto-stubs.yml\](.github/workflows/publish-proto-stubs.yml):
  - Cập nhật \
ode-version: '22'\ trong bước \setup-node@v4\.

### 3. Verification Plan
- Kiểm tra CI workflow chạy không còn cảnh báo Node 20.