### PR TITLE
🐛 fix(ci): dynamically generate package.json before npm publish in internal/gen/es

### DIFF
--- a/.github/workflows/publish-proto-stubs.yml
+++ b/.github/workflows/publish-proto-stubs.yml
@@ -42,6 +42,9 @@ jobs:
         if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
         working-directory: ./internal/gen/es
         run: |
+          if [ ! -f "package.json" ]; then
+            echo '{"name":"@viethung213/contracts","version":"1.0.0","description":"TypeScript ConnectRPC stubs for Gym Companion","publishConfig":{"registry":"https://npm.pkg.github.com"},"dependencies":{"@bufbuild/protobuf":"^1.10.0","@connectrpc/connect":"^1.6.0"}}' > package.json
+          fi
           npm publish --access public || echo "Version already published"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### 1. Problem to Solve
- Khi chạy lệnh \
pm publish\ trong thư mục \internal/gen/es\, lệnh bị thất bại do thiếu tệp \package.json\:
  \
pm error enoent Could not read package.json: Error: ENOENT: no such file or directory, open '/home/runner/work/gym-companion/gym-companion/internal/gen/es/package.json'\.

### 2. Proposed Changes
- [\.github/workflows/publish-proto-stubs.yml\](.github/workflows/publish-proto-stubs.yml):
  - Bổ sung bước kiểm tra tự động trước khi \
pm publish\: Nếu \package.json\ chưa tồn tại trong thư mục \internal/gen/es\, script sẽ tự động tạo tệp \package.json\ với tên gói \@viethung213/contracts\ và registry \https://npm.pkg.github.com\.

### 3. Verification Plan
- Thử nghiệm trên CI workflow của Pull Request này.