### PR TITLE
🔒 fix(coaching): reviewer nhận bản copy, không chạm được giáo án sẽ lưu

### DIFF
--- a/internal/coaching/infrastructure/ai/adk/immutability_test.go
+++ b/internal/coaching/infrastructure/ai/adk/immutability_test.go
@@ -1,0 +1,111 @@
+package adk
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// snapshot renders a plan so two of them can be compared by value.
+func snapshot(t *testing.T, p *GeneratedPlan) string {
+	t.Helper()
+
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal plan: %v", err)
+	}
+	return string(b)
+}
+
+// TestReviewer_CannotInjectAPlanThroughItsVerdict pins the return channel: a
+// reviewer answers with a PlanReview, and that type has no field a plan could
+// travel in. What ships must be exactly what the generator produced.
+func TestReviewer_CannotInjectAPlanThroughItsVerdict(t *testing.T) {
+	v := newPlanValidator(newFakeCatalog("bench-press"))
+
+	generated := validPlan()
+	want := snapshot(t, generated)
+
+	att := alwaysReturns(generated)
+	rev := &recordingReview{verdicts: []*PlanReview{approve(100)}}
+
+	got, err := runWithRetries(context.Background(), v, att.fn, rev.fn)
+	if err != nil {
+		t.Fatalf("runWithRetries: %v", err)
+	}
+
+	if rev.calls != 1 {
+		t.Fatalf("review calls = %d, want 1", rev.calls)
+	}
+	if shipped := snapshot(t, got.Plan); shipped != want {
+		t.Errorf("shipped plan changed after review\n got: %s\nwant: %s", shipped, want)
+	}
+}
+
+// TestReviewer_MutatingThePlanItIsGivenDoesNotChangeWhatShips is the hostile
+// case: the reviewer writes through the plan pointer it was handed. Nothing in
+// the codebase does this, and this test exists so nothing can start.
+func TestReviewer_MutatingThePlanItIsGivenDoesNotChangeWhatShips(t *testing.T) {
+	v := newPlanValidator(newFakeCatalog("bench-press"))
+
+	generated := validPlan()
+	want := snapshot(t, generated)
+
+	att := alwaysReturns(generated)
+
+	var sabotage planReviewFunc = func(_ int, plan *GeneratedPlan, _ ValidationReport) (*PlanReview, error) {
+		// Rewrite everything a reviewer might be tempted to "correct".
+		for i := range plan.Weeks {
+			plan.Weeks[i].Phase = "SABOTAGED"
+			plan.Weeks[i].TargetRPEMax = 99
+			for j := range plan.Weeks[i].Sessions {
+				plan.Weeks[i].Sessions[j].ScheduledDate = "1999-01-01"
+				plan.Weeks[i].Sessions[j].TargetMuscleGroups = []string{"sabotaged"}
+				for k := range plan.Weeks[i].Sessions[j].Prescription.MainExercises {
+					plan.Weeks[i].Sessions[j].Prescription.MainExercises[k].TargetSets = 999
+				}
+			}
+		}
+		return approve(100), nil
+	}
+
+	got, err := runWithRetries(context.Background(), v, att.fn, sabotage)
+	if err != nil {
+		t.Fatalf("runWithRetries: %v", err)
+	}
+
+	if shipped := snapshot(t, got.Plan); shipped != want {
+		t.Errorf("a reviewer changed the shipped plan\n got: %s\nwant: %s", shipped, want)
+	}
+}
+
+// TestPlanReview_HasNoPlanField documents the structural reason the verdict
+// cannot carry a plan: the reviewer's schema declares four properties, and none
+// of them is the plan. Gemini's structured output cannot emit a fifth.
+func TestPlanReview_HasNoPlanField(t *testing.T) {
+	schema := buildPlanReviewSchema()
+
+	for name := range schema.Properties {
+		switch name {
+		case "approved", "score", "confidence", "feedback":
+		default:
+			t.Errorf("reviewer schema declares %q; a reviewer must not return anything but its verdict", name)
+		}
+	}
+
+	b, err := json.Marshal(&PlanReview{Approved: true, Score: 100, Confidence: 1})
+	if err != nil {
+		t.Fatalf("marshal verdict: %v", err)
+	}
+
+	var asMap map[string]any
+	if err := json.Unmarshal(b, &asMap); err != nil {
+		t.Fatalf("unmarshal verdict: %v", err)
+	}
+	if _, hasPlan := asMap["plan"]; hasPlan {
+		t.Error("PlanReview serialises a plan field")
+	}
+	if _, hasWeeks := asMap["weeks"]; hasWeeks {
+		t.Error("PlanReview serialises a weeks field")
+	}
+}

--- a/internal/coaching/infrastructure/ai/adk/retry.go
+++ b/internal/coaching/infrastructure/ai/adk/retry.go
@@ -2,6 +2,7 @@ package adk
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -129,7 +130,7 @@ func runWithRetries(
 			return result, nil
 		}
 
-		verdict, err := review(n, outcome.Plan, report)
+		verdict, err := review(n, clonePlan(outcome.Plan), report)
 		if err != nil {
 			// A reviewer that is down or incoherent must not block a plan that
 			// already passed every deterministic gate.
@@ -166,6 +167,35 @@ func runWithRetries(
 	}
 
 	return nil, ErrPlanGenerationFailed // unreachable: the final iteration always returns
+}
+
+// clonePlan returns a deep copy, so a reviewer handed the plan cannot reach
+// what ships. Its verdict type carries no plan and nothing reassigns
+// result.Plan, and this closes the one remaining path: a write through the
+// pointer it was given.
+//
+// A JSON round-trip rather than a hand-written copy: GeneratedPlan is already
+// defined by its JSON shape, so this cannot silently miss a slice field added
+// later — which is the exact bug it exists to prevent. Marshalling a struct of
+// scalars and slices cannot fail, so the error path is unreachable; it returns
+// the original rather than nil so a hypothetical failure degrades to today's
+// behaviour instead of a panic.
+func clonePlan(p *GeneratedPlan) *GeneratedPlan {
+	if p == nil {
+		return nil
+	}
+
+	encoded, err := json.Marshal(p)
+	if err != nil {
+		return p
+	}
+
+	var out GeneratedPlan
+	if err := json.Unmarshal(encoded, &out); err != nil {
+		return p
+	}
+
+	return &out
 }
 
 // reviewPasses reports whether a verdict clears both gates. Approval and score


### PR DESCRIPTION
### 1. Vấn đề cần giải quyết

`CoachReviewerAgent` (thêm ở #248) chỉ được phép **chấm điểm, không được sửa** giáo án. Có ba đường nó có thể phá vỡ ràng buộc đó. Hai đường đã kín, đường thứ ba thì không:

| Đường | Trạng thái trước PR này |
|---|---|
| Trả plan qua verdict | ✅ Bất khả thi — `PlanReview` không có field nào chứa plan; `buildPlanReviewSchema` chỉ khai 4 property nên Gemini structured output không emit được cái thứ 5 |
| Gán lại `result.Plan` | ✅ Không tồn tại — gán đúng một lần tại `retry.go`, từ đầu ra của validator, không có `.Plan = ` nào khác trong package |
| **Ghi qua con trỏ được truyền** | ❌ **Mở** |

`review(n, outcome.Plan, report)` truyền **chính con trỏ** sẽ được `mapToDomainRoadmap` chuyển sang domain rồi `repo.Save` ghi vào PostgreSQL. Một lệnh ghi qua con trỏ đó sẽ đáp thẳng vào database.

Hiện không có dòng code nào làm vậy — nhưng đó là "an toàn vì chưa ai làm", không phải bảo đảm. Một test dựng reviewer cố tình ghi đè đã **fail**, sửa được `phase`, `scheduled_date` và `target_sets` của giáo án được lưu:

```
got:  "phase":"SABOTAGED"    "scheduled_date":"1999-01-01"   "target_sets":999
want: "phase":"ACCUMULATION"  "scheduled_date":"2026-08-03"   "target_sets":3
```

---

### 2. Giải pháp

Reviewer nhận một **bản deep copy**, không phải giáo án sẽ được lưu. Một dòng tại điểm gọi:

```go
verdict, err := review(n, clonePlan(outcome.Plan), report)
```

`clonePlan` dùng **JSON round-trip** thay vì clone viết tay. Lý do: `GeneratedPlan` vốn được định nghĩa bằng hình dạng JSON của nó (mọi field đều có tag), nên bản copy không thể âm thầm bỏ sót một slice field thêm về sau — mà đó đúng là loại bug nó tồn tại để chặn. Clone viết tay thì chỉ cần ai thêm một slice mà quên sửa hàm copy là lỗ hổng mở lại, im lặng.

`json.Marshal` trên một struct chỉ gồm scalar và slice không thể lỗi, nên nhánh error là không tới được; nó trả về bản gốc chứ không trả `nil` để một lỗi giả định suy giảm về đúng hành vi hôm nay thay vì panic.

---

### 3. Thay đổi & tác động

- [internal/coaching/infrastructure/ai/adk/retry.go](internal/coaching/infrastructure/ai/adk/retry.go): thêm `clonePlan` và dùng nó tại điểm gọi reviewer.
- [internal/coaching/infrastructure/ai/adk/immutability_test.go](internal/coaching/infrastructure/ai/adk/immutability_test.go): **mới**, ba test ghim cả ba đường.

**Tác động runtime:** một deep copy mỗi vòng review — nhiều nhất 3 lần cho một giáo án 4 tuần (~8.5 KB JSON). Không đổi hành vi nào khác.

---

### 4. Kiểm chứng

**Tự động**

```bash
go build ./...
go vet ./internal/... ./cmd/...
go test ./internal/...                                    # toàn repo, 0 FAIL
golangci-lint run --new-from-rev=origin/main ./internal/coaching/... ./cmd/...
go test ./internal/coaching/infrastructure/ai/adk/ -run 'Reviewer_|PlanReview_HasNo' -v
```

```
--- PASS: TestReviewer_CannotInjectAPlanThroughItsVerdict
--- PASS: TestReviewer_MutatingThePlanItIsGivenDoesNotChangeWhatShips     ← trước PR này FAIL
--- PASS: TestPlanReview_HasNoPlanField
```

| Test | Khẳng định |
|---|---|
| `CannotInjectAPlanThroughItsVerdict` | Sau một lượt review bình thường, giáo án ship ra **byte-identical** với cái generator sinh |
| `MutatingThePlanItIsGivenDoesNotChangeWhatShips` | Reviewer ghi đè `phase`, `target_rpe_max`, `scheduled_date`, `target_muscle_groups` và `target_sets` trên **mọi** tuần/buổi/bài nó nhận được → giáo án ship ra không đổi một byte |
| `PlanReview_HasNoPlanField` | Schema reviewer chỉ khai `approved`, `score`, `confidence`, `feedback`; `PlanReview` không serialise ra `plan` hay `weeks` |

**Thủ công — chạy thật `init_roadmap_wf` end-to-end**

Rủi ro thật của việc thêm clone là nó sót field: khi đó reviewer sẽ chấm một giáo án khác với giáo án được lưu, sai còn tệ hơn lỗ hổng ban đầu. Đã đối chiếu từng field giữa plan generator sinh ra và plan reviewer nhận được (qua dump `COACH_PROMPT_DUMP_DIR`):

```
Plan generator sinh : 8574 chars, 4 tuần
Plan reviewer nhận  : 8574 chars, 4 tuần

✅ 0 field lệch — gồm cả warm_ups, cool_downs, reasoning,
   target_muscle_groups và toàn bộ prescription của 12 buổi
```

Reviewer vẫn nhận đủ 4 phần input (`original_task`, `user_context`, `generator_output`, `validation_result`) và trả verdict hợp lệ qua `validateReview`:

```json
{ "approved": true, "score": 100, "confidence": 1.0, "feedback": [] }
```

Giáo án thu được đúng chu kỳ periodization, thoả `BR-AC-10` và `BR-AC-11`:

```
Week 1 ACCUMULATION  18 set  RPE 6.5
Week 2 OVERLOAD      21 set  RPE 7.5
Week 3 PEAK          21 set  RPE 8.5
Week 4 DELOAD        12 set  RPE 5.0     ← 12 ≤ 70% × 21 = 14.7
```

---

### 5. Ngoài phạm vi PR này

Reviewer đã trả `score: 100, confidence: 1.0, feedback: []` ở **ba lần chạy liên tiếp**. Điều đó có thể vì giáo án thật sự hợp lệ, hoặc vì nó chỉ đóng dấu — dữ liệu hiện có **không phân biệt được hai khả năng**.

Cách kiểm rẻ: cho `MockUserProfileReader` trả `active_injuries: [{shoulder, SEVERE}]` rồi xem reviewer có bắt các buổi đẩy vai không. Nếu vẫn 100/approved thì vòng review là trang trí và cần sửa prompt hoặc đổi cách chấm. Nên tách issue riêng.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
