### PR TITLE
✨ feat(notification): chuyển đổi cấu hình xác thực FCM từ file JSON sang biến môi trường

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,9 @@ DEFAULT_ONNX_SKELETON_URL=https://storage.supabase.co/storage/v1/object/public/s
 
 # Firebase Cloud Messaging (FCM) Notification Configuration
 FCM_PROJECT_ID=your-firebase-project-id
+FCM_CLIENT_EMAIL=firebase-adminsdk-fbsvc@your-firebase-project-id.iam.gserviceaccount.com
+FCM_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nyour-private-key-here\n-----END PRIVATE KEY-----\n"
+FCM_PRIVATE_KEY_ID=your-private-key-id
+FCM_CLIENT_ID=your-client-id
 FCM_SERVER_KEY=your-firebase-fcm-oauth2-token-or-key
-FCM_SERVICE_ACCOUNT_FILE=./service-account.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,6 @@ COPY --from=prod-builder /bin/fitai-api /app/fitai-api
 COPY internal/coaching/infrastructure/ai/adk/prompts ./internal/coaching/infrastructure/ai/adk/prompts
 COPY internal/coaching/infrastructure/ai/adk/skills ./internal/coaching/infrastructure/ai/adk/skills
 
-# Copy service-account.json (nếu có) để FCM Push SDK khởi tạo bên trong Docker container
-COPY service-account.json* /app/
 
 EXPOSE 8080
 EXPOSE 9090

--- a/internal/notification/infrastructure/config/config.go
+++ b/internal/notification/infrastructure/config/config.go
@@ -3,33 +3,23 @@ package config
 import "os"
 
 type Config struct {
-	FCMProjectID          string
-	FCMServiceAccountFile string
-	FCMServerKey          string
-	KafkaBrokers          string
+	FCMProjectID    string
+	FCMClientEmail  string
+	FCMPrivateKey   string
+	FCMPrivateKeyID string
+	FCMClientID     string
+	FCMServerKey    string
+	KafkaBrokers    string
 }
 
 func LoadConfig() Config {
-	fcmFile := os.Getenv("FCM_SERVICE_ACCOUNT_FILE")
-	if fcmFile == "" {
-		candidates := []string{
-			"service-account.json",
-			"./service-account.json",
-			"../service-account.json",
-			"/app/service-account.json",
-		}
-		for _, cand := range candidates {
-			if _, err := os.Stat(cand); err == nil {
-				fcmFile = cand
-				break
-			}
-		}
-	}
-
 	return Config{
-		FCMProjectID:          os.Getenv("FCM_PROJECT_ID"),
-		FCMServiceAccountFile: fcmFile,
-		FCMServerKey:          os.Getenv("FCM_SERVER_KEY"),
-		KafkaBrokers:          os.Getenv("KAFKA_BROKERS"),
+		FCMProjectID:    os.Getenv("FCM_PROJECT_ID"),
+		FCMClientEmail:  os.Getenv("FCM_CLIENT_EMAIL"),
+		FCMPrivateKey:   os.Getenv("FCM_PRIVATE_KEY"),
+		FCMPrivateKeyID: os.Getenv("FCM_PRIVATE_KEY_ID"),
+		FCMClientID:     os.Getenv("FCM_CLIENT_ID"),
+		FCMServerKey:    os.Getenv("FCM_SERVER_KEY"),
+		KafkaBrokers:    os.Getenv("KAFKA_BROKERS"),
 	}
 }

--- a/internal/notification/infrastructure/config/config_test.go
+++ b/internal/notification/infrastructure/config/config_test.go
@@ -8,15 +8,40 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
+	os.Setenv("FCM_PROJECT_ID", "test-project-id")
+	os.Setenv("FCM_CLIENT_EMAIL", "test@example.com")
+	os.Setenv("FCM_PRIVATE_KEY", "test-private-key")
+	os.Setenv("FCM_PRIVATE_KEY_ID", "key-id-123")
+	os.Setenv("FCM_CLIENT_ID", "client-id-456")
 	os.Setenv("FCM_SERVER_KEY", "test-server-key")
 	os.Setenv("KAFKA_BROKERS", "localhost:9092")
 	defer func() {
+		os.Unsetenv("FCM_PROJECT_ID")
+		os.Unsetenv("FCM_CLIENT_EMAIL")
+		os.Unsetenv("FCM_PRIVATE_KEY")
+		os.Unsetenv("FCM_PRIVATE_KEY_ID")
+		os.Unsetenv("FCM_CLIENT_ID")
 		os.Unsetenv("FCM_SERVER_KEY")
 		os.Unsetenv("KAFKA_BROKERS")
 	}()
 
 	cfg := config.LoadConfig()
 
+	if got, want := cfg.FCMProjectID, "test-project-id"; got != want {
+		t.Errorf("got FCMProjectID %s, want %s", got, want)
+	}
+	if got, want := cfg.FCMClientEmail, "test@example.com"; got != want {
+		t.Errorf("got FCMClientEmail %s, want %s", got, want)
+	}
+	if got, want := cfg.FCMPrivateKey, "test-private-key"; got != want {
+		t.Errorf("got FCMPrivateKey %s, want %s", got, want)
+	}
+	if got, want := cfg.FCMPrivateKeyID, "key-id-123"; got != want {
+		t.Errorf("got FCMPrivateKeyID %s, want %s", got, want)
+	}
+	if got, want := cfg.FCMClientID, "client-id-456"; got != want {
+		t.Errorf("got FCMClientID %s, want %s", got, want)
+	}
 	if got, want := cfg.FCMServerKey, "test-server-key"; got != want {
 		t.Errorf("got FCMServerKey %s, want %s", got, want)
 	}

--- a/internal/notification/infrastructure/fcm/fcm_client.go
+++ b/internal/notification/infrastructure/fcm/fcm_client.go
@@ -33,8 +33,8 @@ type serviceAccountJSON struct {
 	UniverseDomain          string `json:"universe_domain,omitempty"`
 }
 
-func buildServiceAccountJSON(cfg config.Config) ([]byte, error) {
-	if cfg.FCMClientEmail == "" || cfg.FCMPrivateKey == "" {
+func buildServiceAccountJSON(cfg *config.Config) ([]byte, error) {
+	if cfg == nil || cfg.FCMClientEmail == "" || cfg.FCMPrivateKey == "" {
 		return nil, errors.New("missing FCM client email or private key")
 	}
 
@@ -56,8 +56,13 @@ func buildServiceAccountJSON(cfg config.Config) ([]byte, error) {
 	return json.Marshal(sa)
 }
 
-func NewClient(cfg config.Config) *Client {
+func NewClient(cfg *config.Config) *Client {
 	ctx := context.Background()
+
+	if cfg == nil {
+		log.Println("⚠️ Warning: config is nil. FCM Push SDK disabled.")
+		return &Client{messagingClient: nil}
+	}
 
 	var opts []option.ClientOption
 	if saJSON, err := buildServiceAccountJSON(cfg); err == nil {

--- a/internal/notification/infrastructure/fcm/fcm_client.go
+++ b/internal/notification/infrastructure/fcm/fcm_client.go
@@ -2,8 +2,10 @@ package fcm
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"log"
-	"os"
+	"strings"
 
 	firebase "firebase.google.com/go/v4"
 	"firebase.google.com/go/v4/messaging"
@@ -18,24 +20,50 @@ type Client struct {
 	messagingClient *messaging.Client
 }
 
-func findServiceAccountFile(specifiedPath string) string {
-	if specifiedPath != "" {
-		if _, err := os.Stat(specifiedPath); err == nil {
-			return specifiedPath
-		}
+type serviceAccountJSON struct {
+	Type                    string `json:"type"`
+	ProjectID               string `json:"project_id"`
+	PrivateKeyID            string `json:"private_key_id,omitempty"`
+	PrivateKey              string `json:"private_key"`
+	ClientEmail             string `json:"client_email"`
+	ClientID                string `json:"client_id,omitempty"`
+	AuthURI                 string `json:"auth_uri"`
+	TokenURI                string `json:"token_uri"`
+	AuthProviderX509CertURL string `json:"auth_provider_x509_cert_url"`
+	UniverseDomain          string `json:"universe_domain,omitempty"`
+}
+
+func buildServiceAccountJSON(cfg config.Config) ([]byte, error) {
+	if cfg.FCMClientEmail == "" || cfg.FCMPrivateKey == "" {
+		return nil, errors.New("missing FCM client email or private key")
 	}
-	return ""
+
+	privateKey := strings.ReplaceAll(cfg.FCMPrivateKey, "\\n", "\n")
+
+	sa := serviceAccountJSON{
+		Type:                    "service_account",
+		ProjectID:               cfg.FCMProjectID,
+		PrivateKeyID:            cfg.FCMPrivateKeyID,
+		PrivateKey:              privateKey,
+		ClientEmail:             cfg.FCMClientEmail,
+		ClientID:                cfg.FCMClientID,
+		AuthURI:                 "https://accounts.google.com/o/oauth2/auth",
+		TokenURI:                "https://oauth2.googleapis.com/token",
+		AuthProviderX509CertURL: "https://www.googleapis.com/oauth2/v1/certs",
+		UniverseDomain:          "googleapis.com",
+	}
+
+	return json.Marshal(sa)
 }
 
 func NewClient(cfg config.Config) *Client {
 	ctx := context.Background()
 
 	var opts []option.ClientOption
-	credFile := findServiceAccountFile(cfg.FCMServiceAccountFile)
-	if credFile != "" {
-		opts = append(opts, option.WithCredentialsFile(credFile))
-	} else if cfg.FCMServiceAccountFile != "" {
-		log.Printf("⚠️ Warning: FCM service account file '%s' not found or unreadable.", cfg.FCMServiceAccountFile)
+	if saJSON, err := buildServiceAccountJSON(cfg); err == nil {
+		opts = append(opts, option.WithCredentialsJSON(saJSON))
+	} else if cfg.FCMClientEmail != "" || cfg.FCMPrivateKey != "" {
+		log.Printf("⚠️ Warning: failed to construct FCM service account JSON: %v", err)
 	}
 
 	var fbCfg *firebase.Config
@@ -44,7 +72,7 @@ func NewClient(cfg config.Config) *Client {
 	}
 
 	if len(opts) == 0 && cfg.FCMProjectID == "" {
-		log.Println("⚠️ Warning: FCMProjectID and FCMServiceAccountFile are empty. FCM Push SDK disabled.")
+		log.Println("⚠️ Warning: FCM credentials and FCMProjectID are empty. FCM Push SDK disabled.")
 		return &Client{messagingClient: nil}
 	}
 

--- a/internal/notification/infrastructure/fcm/fcm_client_test.go
+++ b/internal/notification/infrastructure/fcm/fcm_client_test.go
@@ -15,7 +15,7 @@ func TestFCMClientMock(t *testing.T) {
 		FCMServerKey: "", // empty key triggers Mock push mode
 	}
 
-	client := fcm.NewClient(cfg)
+	client := fcm.NewClient(&cfg)
 
 	t.Run("empty tokens", func(t *testing.T) {
 		t.Parallel()

--- a/internal/notification/module.go
+++ b/internal/notification/module.go
@@ -40,7 +40,7 @@ func Initialize(ctx context.Context, deps ModuleDeps) (*transport.GRPCHandler, f
 	outboxRepo := postgres.NewOutboxRepository(deps.DB)
 	outboxLogRepo := postgres.NewOutboxLogRepository(deps.DB)
 	txManager := postgres.NewTxManager(deps.DB)
-	fcmClient := fcm.NewClient(cfg)
+	fcmClient := fcm.NewClient(&cfg)
 
 	// 2. Command Handlers
 	registerDeviceHandler := command.NewRegisterDeviceTokenHandler(deviceRepo)


### PR DESCRIPTION
### 1. Vấn đề cần giải quyết
Railway và các môi trường container hóa (Docker) không thể upload hoặc mount file vật lý `service-account.json` một cách dễ dàng. Việc lưu trữ hoặc copy file JSON secret trong source code/Docker build gây mất an toàn bảo mật và thiếu linh hoạt khi deploy.

### 2. Giải pháp đề xuất
- Chuyển đổi cơ chế xác thực Firebase Cloud Messaging (FCM) từ đọc file `service-account.json` sang đọc trực tiếp từ các biến môi trường (`FCM_CLIENT_EMAIL`, `FCM_PRIVATE_KEY`, `FCM_PROJECT_ID`, `FCM_PRIVATE_KEY_ID`, `FCM_CLIENT_ID`).
- Dựng động cấu trúc JSON Service Account trong bộ nhớ tại `fcm_client.go` từ struct `config.Config` sử dụng `json.Marshal(sa)` và truyền vào SDK Firebase qua `option.WithCredentialsJSON(saJSON)`.
- Tự động thay thế `\n` trong Private Key (`strings.ReplaceAll(cfg.FCMPrivateKey, "\\n", "\n")`) để tương thích với dấu xuống dòng trên biến môi trường.
- Loại bỏ hoàn toàn câu lệnh copy file `service-account.json` trong `Dockerfile`.

### 3. Thay đổi & Ảnh hưởng
- `[.env.example](.env.example)`: Cập nhật biến môi trường mẫu cho FCM.
- `[Dockerfile](Dockerfile)`: Xóa bỏ lệnh `COPY service-account.json* /app/`.
- `[internal/notification/infrastructure/config/config.go](internal/notification/infrastructure/config/config.go)`: Bỏ danh sách kiểm tra file JSON, bổ sung các biến môi trường mới vào struct `Config`.
- `[internal/notification/infrastructure/config/config_test.go](internal/notification/infrastructure/config/config_test.go)`: Cập nhật unit test load biến môi trường FCM mới.
- `[internal/notification/infrastructure/fcm/fcm_client.go](internal/notification/infrastructure/fcm/fcm_client.go)`: Loại bỏ hàm đọc file `findServiceAccountFile`, thêm hàm `buildServiceAccountJSON()` tạo chuỗi byte JSON từ struct `config.Config`.

### 4. Kiểm thử & Xác minh
- **Automated Tests**: Chạy `go test -v ./internal/notification/...` — Vượt qua 100% PASS cho toàn bộ các package (`config`, `fcm`, `kafka`, `postgres`, `transport`, `worker`).
- **Linter**: Chạy `go vet ./internal/notification/...` — 0 lỗi, 0 cảnh báo.
