### PR TITLE
♻️ refactor(coaching): reviewer phải chịu trách nhiệm với vòng trước, và chấm có mốc

### DIFF
--- a/internal/coaching/infrastructure/ai/adk/README.md
+++ b/internal/coaching/infrastructure/ai/adk/README.md
@@ -81,11 +81,14 @@ Lượt thứ 3 chuyển sang **salvage**: thay vì báo lỗi thì loại phầ
   "recent_sessions":   [...],
   "generator_output":  { "weeks": [...] },
   "validation_result": { "passed": true, "degraded": false, "issues": [] },
-  "review_round":      1
+  "review_round":      1,
+  "previous_feedback": []
 }
 ```
 
-`validation_result` có mặt để Reviewer **không xử lại** những gì code đã chốt. Prompt nói thẳng: đừng báo lại lỗi catalog, đừng chấm giới hạn buổi/tuần.
+`validation_result` có mặt để Reviewer **không xử lại** những gì code đã chốt. Prompt nói thẳng: đừng báo lại lỗi catalog, đừng chấm giới hạn buổi/tuần, đừng chấm `BR-AC-10`/`BR-AC-11`.
+
+`previous_feedback` là **những gì vòng trước đã yêu cầu**, có từ vòng 2. Không có nó thì Reviewer chấm mỗi plan như thể chưa từng có vòng nào — và một fix bị Generator lặng lẽ bỏ qua sẽ đọc thành plan sạch rồi được duyệt. Đo được thật: vòng 1 yêu cầu 2 thứ, Generator làm cái dễ bỏ cái khó, vòng 2 cho 100 điểm.
 
 ### Chấm gì — chỉ những thứ code không quyết được
 
@@ -97,22 +100,39 @@ Lượt thứ 3 chuyển sang **salvage**: thay vì báo lỗi thì loại phầ
 | `schedule_fit` | Ngày tập có khớp `available_slots`, có đủ hồi phục giữa các buổi cùng nhóm cơ? |
 | `progression_coherence` | 4 tuần có nối tiếp nhau, `reasoning` có khớp với thứ được kê? |
 
+### Cách chấm điểm
+
+**Bắt đầu ở 60**, không phải 100. Cộng tối đa +10 cho mỗi hạng mục làm tốt, nhưng **phải nêu bằng chứng trong `notes`**; trừ 10 cho mỗi khuyết điểm, và **phải nêu tên trong `feedback`**.
+
+Điểm không phải ý kiến giữ riêng — nó là tổng của những thứ chỉ ra được. Trước khi có rubric này, Reviewer trả `score: 100, feedback: []` ở **ba lần chạy liên tiếp**; với rubric, cùng cấu hình đó cho 60 kèm hai khuyết điểm có thật.
+
 ### Output
 
 ```json
 {
   "approved":   false,
-  "score":      55,
+  "score":      60,
   "confidence": 0.9,
+  "previous_feedback": [
+    { "area": "goal_fit", "applied": true,
+      "evidence": "Cả 12 buổi giờ có 3 bài chính, trước là 2" },
+    { "area": "warmup_specificity", "applied": false,
+      "evidence": "Buổi back tuần 1 vẫn warm-up bằng pull-up, không đổi" }
+  ],
   "feedback": [
-    { "area":   "injury_safety",
-      "detail": "Tuần 2, buổi 2026-08-11 kê bench-press khi active_injuries có shoulder MODERATE",
-      "fix":    "Thay bằng bài neutral-grip và giảm main-exercise từ 4 xuống 2 set" }
+    { "area":   "warmup_specificity",
+      "detail": "Mọi buổi back dùng pull-up cho cả warm-up lẫn cool-down",
+      "fix":    "Cho mỗi buổi một warm-up nhắm đúng nhóm cơ nó tập" }
+  ],
+  "notes": [
+    "Khối lượng 21 → 25 → 28 → 14 set khớp mục tiêu hypertrophy"
   ]
 }
 ```
 
 **Không có field `plan`.** Đó là điều làm cho "chỉ review, không sửa" thành ràng buộc cấu trúc chứ không phải lời nhờ vả model.
+
+`feedback` là **phải sửa**, `notes` là mọi thứ khác. Tách hai cái vì khi gộp, `fix` biến thành lời khen (*"keep doing this"*) — vẫn qua validate mà không nói cho Generator điều gì cần làm.
 
 ### Output của Reviewer cũng bị validate
 
@@ -122,6 +142,14 @@ Lượt thứ 3 chuyển sang **salvage**: thay vì báo lỗi thì loại phầ
 - Từ chối mà **không có feedback** → Generator sẽ nhận "làm lại" mà không biết sửa gì
 - Có note mà **không có `fix`** → cùng vấn đề
 - `approved = true` nhưng `score < 70` → verdict tự mâu thuẫn, đọc theo hướng an toàn là chưa duyệt
+
+Và từ vòng 2, `checkFeedbackCompliance` bắt Reviewer chịu trách nhiệm với yêu cầu của vòng trước:
+
+- **Không báo cáo** một yêu cầu nào → loại verdict
+- Báo `applied` mà **không có `evidence`** → loại, vì đó là lời khẳng định chứ không phải kiểm tra
+- **Duyệt trong khi còn yêu cầu chưa được thi hành** → loại thẳng
+
+Điều cuối là phần có răng: Generator làm fix dễ rồi bỏ fix khó thì không được thưởng.
 
 Verdict không dùng được, hoặc Reviewer gọi không tới (429, timeout): **giao plan kèm `Degraded`**, không chặn. Plan đã qua hết cửa tất định rồi, không được mất nó vì một tầng tham khảo hỏng.
 

--- a/internal/coaching/infrastructure/ai/adk/build_agents.go
+++ b/internal/coaching/infrastructure/ai/adk/build_agents.go
@@ -141,6 +141,9 @@ func buildPlanReviewSchema() *genai.Schema {
 			"approved":   {Type: genai.TypeBoolean},
 			"score":      {Type: genai.TypeInteger},
 			"confidence": {Type: genai.TypeNumber},
+			// Must-fix only. Notes exists so praise has somewhere to go that is
+			// not a "fix", which would pass validation while telling the
+			// generator nothing to do.
 			"feedback": {
 				Type: genai.TypeArray,
 				Items: &genai.Schema{
@@ -151,6 +154,24 @@ func buildPlanReviewSchema() *genai.Schema {
 						"fix":    {Type: genai.TypeString},
 					},
 					Required: []string{"area", "detail", "fix"},
+				},
+			},
+			"notes": {
+				Type:  genai.TypeArray,
+				Items: &genai.Schema{Type: genai.TypeString},
+			},
+			// One entry per item the previous round asked for. Evidence is
+			// required either way: "applied" without a location is a claim.
+			"previous_feedback": {
+				Type: genai.TypeArray,
+				Items: &genai.Schema{
+					Type: genai.TypeObject,
+					Properties: map[string]*genai.Schema{
+						"area":     {Type: genai.TypeString},
+						"applied":  {Type: genai.TypeBoolean},
+						"evidence": {Type: genai.TypeString},
+					},
+					Required: []string{"area", "applied", "evidence"},
 				},
 			},
 		},

--- a/internal/coaching/infrastructure/ai/adk/compliance_test.go
+++ b/internal/coaching/infrastructure/ai/adk/compliance_test.go
@@ -1,0 +1,167 @@
+package adk
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// warmupNote is the fix that the live generator skipped: the hard one.
+func warmupNote() ReviewNote {
+	return ReviewNote{
+		Area:   "warmup_specificity",
+		Detail: "every back session warms up and cools down with pull-up",
+		Fix:    "give each session a warm-up targeting the muscles it trains",
+	}
+}
+
+func applied(area string) FeedbackOutcome {
+	return FeedbackOutcome{Area: area, Applied: true, Evidence: "week 1 session 2 now uses band-pull-apart"}
+}
+
+func skipped(area string) FeedbackOutcome {
+	return FeedbackOutcome{Area: area, Applied: false, Evidence: "week 1 session 2 still uses pull-up, unchanged"}
+}
+
+func TestCheckFeedbackCompliance(t *testing.T) {
+	prior := []ReviewNote{warmupNote()}
+
+	tests := []struct {
+		name  string
+		prior []ReviewNote
+		give  *PlanReview
+		want  bool // true means the verdict is usable
+	}{
+		{
+			name: "round 1 has nothing to account for",
+			give: approve(100),
+			want: true,
+		},
+		{
+			name:  "approving with the fix applied",
+			prior: prior,
+			give: &PlanReview{
+				Approved: true, Score: 100, Confidence: 0.9,
+				PreviousFeedback: []FeedbackOutcome{applied("warmup_specificity")},
+			},
+			want: true,
+		},
+		{
+			// The live failure: the generator skipped a fix and round 2 approved
+			// anyway, because nothing had told it what had been asked.
+			name:  "approving while a fix is still unapplied",
+			prior: prior,
+			give: &PlanReview{
+				Approved: true, Score: 100, Confidence: 0.9,
+				PreviousFeedback: []FeedbackOutcome{skipped("warmup_specificity")},
+			},
+		},
+		{
+			name:  "rejecting because the fix is unapplied is fine",
+			prior: prior,
+			give: &PlanReview{
+				Approved: false, Score: 60, Confidence: 0.9,
+				PreviousFeedback: []FeedbackOutcome{skipped("warmup_specificity")},
+				Feedback:         []ReviewNote{warmupNote()},
+			},
+			want: true,
+		},
+		{
+			name:  "silent about what was asked",
+			prior: prior,
+			give:  approve(100),
+		},
+		{
+			name:  "accounting for the wrong item",
+			prior: prior,
+			give: &PlanReview{
+				Approved: true, Score: 100, Confidence: 0.9,
+				PreviousFeedback: []FeedbackOutcome{applied("goal_fit")},
+			},
+		},
+		{
+			name:  "claiming applied without evidence",
+			prior: prior,
+			give: &PlanReview{
+				Approved: true, Score: 100, Confidence: 0.9,
+				PreviousFeedback: []FeedbackOutcome{{Area: "warmup_specificity", Applied: true}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateReview(tt.give, tt.prior)
+
+			if got := err == nil; got != tt.want {
+				t.Errorf("usable = %t, want %t (err: %v)", got, tt.want, err)
+			}
+			if err != nil && !errors.Is(err, errReviewUnusable) {
+				t.Errorf("err = %v, want it to wrap errReviewUnusable", err)
+			}
+		})
+	}
+}
+
+// TestReviewLoop_CarriesLastRoundsAsksForward pins the plumbing: round 1 asks
+// for something, and round 2 is handed exactly that so it can check.
+func TestReviewLoop_CarriesLastRoundsAsksForward(t *testing.T) {
+	v := newPlanValidator(newFakeCatalog("bench-press"))
+	att := alwaysReturns(validPlan())
+
+	round1 := &PlanReview{
+		Approved: false, Score: 60, Confidence: 0.9,
+		Feedback: []ReviewNote{warmupNote()},
+	}
+	round2 := &PlanReview{
+		Approved: true, Score: 100, Confidence: 0.9,
+		PreviousFeedback: []FeedbackOutcome{applied("warmup_specificity")},
+	}
+	rev := &recordingReview{verdicts: []*PlanReview{round1, round2}}
+
+	if _, err := runWithRetries(context.Background(), v, att.fn, rev.fn); err != nil {
+		t.Fatalf("runWithRetries: %v", err)
+	}
+
+	if rev.calls != 2 {
+		t.Fatalf("review calls = %d, want 2", rev.calls)
+	}
+	if got := rev.seenPrior[0]; len(got) != 0 {
+		t.Errorf("round 1 prior = %+v, want empty", got)
+	}
+	got := rev.seenPrior[1]
+	if len(got) != 1 || got[0].Area != "warmup_specificity" {
+		t.Errorf("round 2 prior = %+v, want round 1's single ask", got)
+	}
+}
+
+// TestReviewLoop_SkippedFixIsRecordedOnTheShippedPlan covers the exhausted-rounds
+// path: the plan still ships, but the objection travels with it rather than
+// vanishing into an approval.
+func TestReviewLoop_SkippedFixIsRecordedOnTheShippedPlan(t *testing.T) {
+	v := newPlanValidator(newFakeCatalog("bench-press"))
+	att := alwaysReturns(validPlan())
+
+	stubborn := &PlanReview{
+		Approved: false, Score: 60, Confidence: 0.9,
+		Feedback: []ReviewNote{warmupNote()},
+	}
+	rev := &recordingReview{verdicts: []*PlanReview{stubborn, stubborn, stubborn}}
+
+	got, err := runWithRetries(context.Background(), v, att.fn, rev.fn)
+	if err != nil {
+		t.Fatalf("runWithRetries: %v", err)
+	}
+
+	if !got.Degraded {
+		t.Error("Degraded = false, want true")
+	}
+	if joined := strings.Join(got.Issues, "\n"); !strings.Contains(joined, "warmup_specificity") {
+		t.Errorf("Issues = %v, want the unapplied ask recorded", got.Issues)
+	}
+}

--- a/internal/coaching/infrastructure/ai/adk/decode_test.go
+++ b/internal/coaching/infrastructure/ai/adk/decode_test.go
@@ -1,0 +1,136 @@
+package adk
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// asMap parses a verdict exactly as ADK hands it back: an untyped map.
+func asMap(t *testing.T, raw string) map[string]any {
+	t.Helper()
+
+	var out map[string]any
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	return out
+}
+
+// TestDecodePlanReview_LiveShapes decodes payloads captured verbatim from real
+// CoachReviewerAgent runs, so the decoder is pinned against what the model
+// actually emits rather than against what the schema says it should.
+func TestDecodePlanReview_LiveShapes(t *testing.T) {
+	t.Run("approval with notes and no feedback", func(t *testing.T) {
+		t.Parallel()
+
+		got := decodePlanReview(asMap(t, `{
+			"approved": true, "score": 90, "confidence": 1,
+			"feedback": [],
+			"notes": ["Volume progression scales cleanly", "Covers all preferred muscle groups"],
+			"previous_feedback": []
+		}`))
+
+		if got == nil {
+			t.Fatal("verdict = nil")
+		}
+		if !got.Approved || got.Score != 90 || got.Confidence != 1 {
+			t.Errorf("verdict = %+v, want approved/90/1.0", got)
+		}
+		if len(got.Notes) != 2 {
+			t.Errorf("notes = %v, want 2", got.Notes)
+		}
+		if len(got.Feedback) != 0 {
+			t.Errorf("feedback = %+v, want empty", got.Feedback)
+		}
+	})
+
+	t.Run("rejection accounting for the previous round", func(t *testing.T) {
+		t.Parallel()
+
+		got := decodePlanReview(asMap(t, `{
+			"approved": false, "score": 60, "confidence": 0.9,
+			"previous_feedback": [
+				{"area": "goal_fit", "applied": true, "evidence": "all 12 sessions now carry 3 main exercises"},
+				{"area": "warmup_specificity", "applied": false, "evidence": "week 1 back session still warms up with pull-up"}
+			],
+			"feedback": [
+				{"area": "warmup_specificity", "detail": "back sessions reuse pull-up", "fix": "use band-pull-apart before rows"}
+			]
+		}`))
+
+		if got == nil {
+			t.Fatal("verdict = nil")
+		}
+		if got.Approved || got.Score != 60 {
+			t.Errorf("verdict = %+v, want rejected/60", got)
+		}
+		if len(got.PreviousFeedback) != 2 {
+			t.Fatalf("previous_feedback = %+v, want 2", got.PreviousFeedback)
+		}
+		if got.PreviousFeedback[0].Area != "goal_fit" || !got.PreviousFeedback[0].Applied {
+			t.Errorf("previous_feedback[0] = %+v, want goal_fit applied", got.PreviousFeedback[0])
+		}
+		if got.PreviousFeedback[1].Applied {
+			t.Errorf("previous_feedback[1] = %+v, want warmup_specificity NOT applied", got.PreviousFeedback[1])
+		}
+		if len(got.Feedback) != 1 || got.Feedback[0].Fix == "" {
+			t.Errorf("feedback = %+v, want one entry carrying a fix", got.Feedback)
+		}
+
+		// The whole point of the compliance check: this verdict must survive
+		// validation, and the same one flipped to approved must not.
+		prior := []ReviewNote{{Area: "goal_fit"}, {Area: "warmup_specificity"}}
+		if err := validateReview(got, prior); err != nil {
+			t.Errorf("validateReview = %v, want usable", err)
+		}
+
+		got.Approved = true
+		got.Score = 100
+		if err := validateReview(got, prior); err == nil {
+			t.Error("validateReview accepted an approval with warmup_specificity still unapplied")
+		}
+	})
+
+	t.Run("score arrives as a JSON number, not an int", func(t *testing.T) {
+		t.Parallel()
+
+		// json.Unmarshal into any yields float64, which is what tripped the
+		// hand-written decoder into needing a numeric conversion helper.
+		got := decodePlanReview(asMap(t, `{"approved": true, "score": 85, "confidence": 0.75}`))
+
+		if got == nil {
+			t.Fatal("verdict = nil")
+		}
+		if got.Score != 85 {
+			t.Errorf("score = %d, want 85", got.Score)
+		}
+		if got.Confidence != 0.75 {
+			t.Errorf("confidence = %v, want 0.75", got.Confidence)
+		}
+	})
+}
+
+func TestDecodePlanReview_Rejects(t *testing.T) {
+	tests := []struct {
+		name string
+		give map[string]any
+	}{
+		{name: "nil map"},
+		{name: "score of the wrong type", give: map[string]any{"score": "ninety"}},
+		{name: "feedback that is not a list", give: map[string]any{"feedback": "looks fine"}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// A malformed verdict must decode to nil so validateReview reports it,
+			// rather than to a half-filled struct that steers the loop.
+			if got := decodePlanReview(tt.give); got != nil {
+				t.Errorf("verdict = %+v, want nil", got)
+			}
+		})
+	}
+}

--- a/internal/coaching/infrastructure/ai/adk/immutability_test.go
+++ b/internal/coaching/infrastructure/ai/adk/immutability_test.go
@@ -1,0 +1,111 @@
+package adk
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// snapshot renders a plan so two of them can be compared by value.
+func snapshot(t *testing.T, p *GeneratedPlan) string {
+	t.Helper()
+
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal plan: %v", err)
+	}
+	return string(b)
+}
+
+// TestReviewer_CannotInjectAPlanThroughItsVerdict pins the return channel: a
+// reviewer answers with a PlanReview, and that type has no field a plan could
+// travel in. What ships must be exactly what the generator produced.
+func TestReviewer_CannotInjectAPlanThroughItsVerdict(t *testing.T) {
+	v := newPlanValidator(newFakeCatalog("bench-press"))
+
+	generated := validPlan()
+	want := snapshot(t, generated)
+
+	att := alwaysReturns(generated)
+	rev := &recordingReview{verdicts: []*PlanReview{approve(100)}}
+
+	got, err := runWithRetries(context.Background(), v, att.fn, rev.fn)
+	if err != nil {
+		t.Fatalf("runWithRetries: %v", err)
+	}
+
+	if rev.calls != 1 {
+		t.Fatalf("review calls = %d, want 1", rev.calls)
+	}
+	if shipped := snapshot(t, got.Plan); shipped != want {
+		t.Errorf("shipped plan changed after review\n got: %s\nwant: %s", shipped, want)
+	}
+}
+
+// TestReviewer_MutatingThePlanItIsGivenDoesNotChangeWhatShips is the hostile
+// case: the reviewer writes through the plan pointer it was handed. Nothing in
+// the codebase does this, and this test exists so nothing can start.
+func TestReviewer_MutatingThePlanItIsGivenDoesNotChangeWhatShips(t *testing.T) {
+	v := newPlanValidator(newFakeCatalog("bench-press"))
+
+	generated := validPlan()
+	want := snapshot(t, generated)
+
+	att := alwaysReturns(generated)
+
+	var sabotage planReviewFunc = func(_ int, plan *GeneratedPlan, _ ValidationReport) (*PlanReview, error) {
+		// Rewrite everything a reviewer might be tempted to "correct".
+		for i := range plan.Weeks {
+			plan.Weeks[i].Phase = "SABOTAGED"
+			plan.Weeks[i].TargetRPEMax = 99
+			for j := range plan.Weeks[i].Sessions {
+				plan.Weeks[i].Sessions[j].ScheduledDate = "1999-01-01"
+				plan.Weeks[i].Sessions[j].TargetMuscleGroups = []string{"sabotaged"}
+				for k := range plan.Weeks[i].Sessions[j].Prescription.MainExercises {
+					plan.Weeks[i].Sessions[j].Prescription.MainExercises[k].TargetSets = 999
+				}
+			}
+		}
+		return approve(100), nil
+	}
+
+	got, err := runWithRetries(context.Background(), v, att.fn, sabotage)
+	if err != nil {
+		t.Fatalf("runWithRetries: %v", err)
+	}
+
+	if shipped := snapshot(t, got.Plan); shipped != want {
+		t.Errorf("a reviewer changed the shipped plan\n got: %s\nwant: %s", shipped, want)
+	}
+}
+
+// TestPlanReview_HasNoPlanField documents the structural reason the verdict
+// cannot carry a plan: the reviewer's schema declares four properties, and none
+// of them is the plan. Gemini's structured output cannot emit a fifth.
+func TestPlanReview_HasNoPlanField(t *testing.T) {
+	schema := buildPlanReviewSchema()
+
+	for name := range schema.Properties {
+		switch name {
+		case "approved", "score", "confidence", "feedback":
+		default:
+			t.Errorf("reviewer schema declares %q; a reviewer must not return anything but its verdict", name)
+		}
+	}
+
+	b, err := json.Marshal(&PlanReview{Approved: true, Score: 100, Confidence: 1})
+	if err != nil {
+		t.Fatalf("marshal verdict: %v", err)
+	}
+
+	var asMap map[string]any
+	if err := json.Unmarshal(b, &asMap); err != nil {
+		t.Fatalf("unmarshal verdict: %v", err)
+	}
+	if _, hasPlan := asMap["plan"]; hasPlan {
+		t.Error("PlanReview serialises a plan field")
+	}
+	if _, hasWeeks := asMap["weeks"]; hasWeeks {
+		t.Error("PlanReview serialises a weeks field")
+	}
+}

--- a/internal/coaching/infrastructure/ai/adk/immutability_test.go
+++ b/internal/coaching/infrastructure/ai/adk/immutability_test.go
@@ -53,7 +53,7 @@ func TestReviewer_MutatingThePlanItIsGivenDoesNotChangeWhatShips(t *testing.T) {
 
 	att := alwaysReturns(generated)
 
-	var sabotage planReviewFunc = func(_ int, plan *GeneratedPlan, _ ValidationReport) (*PlanReview, error) {
+	var sabotage planReviewFunc = func(_ int, plan *GeneratedPlan, _ ValidationReport, _ []ReviewNote) (*PlanReview, error) {
 		// Rewrite everything a reviewer might be tempted to "correct".
 		for i := range plan.Weeks {
 			plan.Weeks[i].Phase = "SABOTAGED"
@@ -80,14 +80,16 @@ func TestReviewer_MutatingThePlanItIsGivenDoesNotChangeWhatShips(t *testing.T) {
 }
 
 // TestPlanReview_HasNoPlanField documents the structural reason the verdict
-// cannot carry a plan: the reviewer's schema declares four properties, and none
-// of them is the plan. Gemini's structured output cannot emit a fifth.
+// cannot carry a plan: every property the reviewer's schema declares is part of
+// its judgement, and Gemini's structured output cannot emit one that is not
+// declared. The allow-list is deliberately exhaustive so adding a property has
+// to be a decision rather than an accident.
 func TestPlanReview_HasNoPlanField(t *testing.T) {
 	schema := buildPlanReviewSchema()
 
 	for name := range schema.Properties {
 		switch name {
-		case "approved", "score", "confidence", "feedback":
+		case "approved", "score", "confidence", "feedback", "notes", "previous_feedback":
 		default:
 			t.Errorf("reviewer schema declares %q; a reviewer must not return anything but its verdict", name)
 		}

--- a/internal/coaching/infrastructure/ai/adk/prompts/evaluator.txt
+++ b/internal/coaching/infrastructure/ai/adk/prompts/evaluator.txt
@@ -5,29 +5,49 @@ only happen by sending the generator back with feedback it can act on.
 
 ## Your Input
 
-A single JSON object with four parts. Read all four before scoring.
+A single JSON object. Read every part before scoring.
 
 1. `original_task` — which flow was requested (INITIATE_4_WEEK, REGENERATE_PENDING, ...).
-   This tells you what the plan was supposed to be, so judge it against that and
-   not against some other shape.
+   Judge the plan against that, not against some other shape.
 2. `user_context` — the athlete: weight, goal, equipment, available slots, and
    `active_injuries`. Every judgement about safety and fit comes from here.
 3. `generator_output` — the plan you are reviewing. This and only this is what
    you score.
 4. `validation_result` — what deterministic validation already concluded.
+5. `previous_feedback` — present only from round 2 onward: what you asked the
+   generator to change last time. See "Checking Your Last Round" below.
+6. `review_round` — 1 on a first look.
+
+When `review_round` is 1 there is nothing to account for. **Omit
+`previous_feedback` from your output entirely** — do not invent a placeholder
+entry for it.
 
 `validation_result.passed` is true for every plan you receive. Catalog
 membership, date format, the 6-sessions-per-week cap and the 7-distinct-dates
-cap are ALREADY enforced in code. Do not re-report them, do not score them,
-and never claim an exercise_id is invalid — that question is settled.
+cap are ALREADY enforced in code, as are the per-phase RPE windows and the
+DELOAD volume ceiling. Do not re-report any of them, do not score them, and
+never claim an exercise_id is invalid — those questions are settled.
 If `validation_result.degraded` is true, some exercises were dropped during
-salvage, so thin sessions are expected; weigh that rather than penalising it
-as if the generator had chosen it.
+salvage, so thin sessions are expected; weigh that rather than penalising the
+generator for a choice it did not make.
+
+## Checking Your Last Round — do this FIRST when `previous_feedback` is present
+
+For every entry in `previous_feedback`, emit one entry in your own
+`previous_feedback` array saying whether it landed:
+
+- `area` — copy it verbatim from the item you are answering.
+- `applied` — true only if the plan in front of you actually reflects the fix.
+- `evidence` — where you looked. Name the week and session. Required either way:
+  "applied" without a location is a claim, not a check.
+
+**You may not approve while any item is still unapplied.** A generator that does
+the easy fix and quietly skips the hard one must not be rewarded, and the system
+will reject a verdict that tries to.
 
 ## What to Judge
 
-Score only what code cannot decide. For each dimension, decide pass or fail and
-say why.
+Score only what code cannot decide.
 
 1. **Injury safety** — does any session load a muscle group listed in
    `user_context.active_injuries`? A SEVERE injury must not be trained at all;
@@ -35,48 +55,91 @@ say why.
 2. **Goal fit** — does the volume, rep range and exercise selection actually
    serve `user_context.primary_goal`? Hypertrophy wants 6-12 reps and multiple
    sets; strength wants lower reps and heavier loads.
-3. **Equipment fit** — does every prescribed exercise need only equipment the
-   athlete has in `user_context.available_equipment`?
+3. **Equipment fit** — does every prescribed exercise need only equipment in
+   `user_context.available_equipment`?
 4. **Schedule fit** — do the scheduled dates land on days the athlete has in
-   `user_context.available_slots`, with enough recovery between sessions that
-   hit the same muscle group?
+   `user_context.available_slots`, with at least 48h between sessions loading
+   the same muscle group?
 5. **Progression coherence** — do the four weeks build on each other, and does
    the reasoning attached to each session match what it prescribes?
 
 ## Scoring
 
-- `score`: 0-100. Start at 100 and subtract for each real defect. An injury
-  safety failure alone must put the score below 70.
-- `approved`: true only when no dimension above failed. A plan can score 85 and
-  still be rejected if it trains an injured muscle group.
-- `confidence`: 0.0-1.0, how sure you are of this verdict. Lower it when
-  `user_context` is thin — a missing goal or empty equipment list means you are
-  guessing, and you should say so rather than assert.
-- `feedback`: one entry per defect. **Every entry MUST have a usable `fix`.**
-  The generator sees only your feedback, not this conversation, so "improve the
-  plan" or "review the volume" is useless to it. Name the week, the session and
-  the change.
+A plan is not exemplary merely because it is well-formed and breaks no hard
+rule. **Start at 60.** Then:
 
-Emit no feedback entries when you approve.
+Add up to +10 each, and only when you can name the evidence in `notes`:
 
-## Example
+- Volume progression across the weeks is justified by `primary_goal`.
+- Exercise selection covers every muscle group implied by
+  `preferred_muscle_groups`, without redundancy.
+- At least 48h separates sessions loading the same muscle group.
+- Each session's `reasoning` explains that session rather than restating the phase.
+
+Subtract 10 each. These are defects even though no hard rule forbids them:
+
+- A session with fewer than 3 main exercises.
+- Identical set and rep schemes repeated across every session in a week.
+- Warm-ups or cool-downs that do not target the muscles being trained.
+- `reasoning` shorter than a full sentence, or copy-pasted between sessions.
+
+**Every deduction you make must appear as a `feedback` entry.** The score is not
+an opinion you hold privately — it is the sum of things you can point at. If you
+cannot name a defect in `feedback`, you have not found one, so do not deduct
+for it.
+
+It follows that **a rejection with an empty `feedback` list is discarded**: the
+system throws the whole verdict away, the plan ships unreviewed, and your round
+is wasted. If `approved` is false, `feedback` MUST hold at least one entry.
+
+`approved`: true only when no dimension in "What to Judge" failed, no item in
+`previous_feedback` is unapplied, and the score reaches 70. A plan can score 85
+and still be rejected if it trains an injured muscle group.
+
+`confidence`: 0.0-1.0, how sure you are. Lower it when `user_context` is thin —
+a missing goal or empty equipment list means you are guessing, and saying so is
+worth more than asserting.
+
+## Feedback vs Notes — do not mix them
+
+`feedback` is **must-fix only**. One entry per defect, and every entry MUST have
+a usable `fix`. The generator sees only your feedback, not this conversation, so
+"improve the plan" or "review the volume" is useless to it. Name the week, the
+session and the change.
+
+`notes` is everything else: what earned a bonus, what you liked, what you were
+unsure about. "Keep doing this" belongs here — it is not a fix.
+
+**When you approve, `feedback` must be empty.** Put your observations in `notes`.
+
+## Example — round 2, rejecting because a fix was skipped
 
 ```json
 {
   "approved": false,
-  "score": 55,
+  "score": 60,
   "confidence": 0.9,
-  "feedback": [
-    {
-      "area": "injury_safety",
-      "detail": "Week 2 session on 2026-08-11 prescribes bench-press and db-press while active_injuries lists shoulder as MODERATE.",
-      "fix": "Replace both pressing movements with a neutral-grip or machine alternative and cut the session's main-exercise sets from 4 to 2."
-    },
+  "previous_feedback": [
     {
       "area": "goal_fit",
-      "detail": "primary_goal is hypertrophy but every main exercise is prescribed at 4 reps.",
-      "fix": "Raise main-exercise target_reps into the 8-12 range across all four weeks, keeping target_rpe inside each phase's window."
+      "applied": true,
+      "evidence": "All 12 sessions now carry 3 main exercises, up from 2."
+    },
+    {
+      "area": "warmup_specificity",
+      "applied": false,
+      "evidence": "Week 1 back session still warms up with pull-up and cools down with pull-up, unchanged from the previous plan."
     }
+  ],
+  "feedback": [
+    {
+      "area": "warmup_specificity",
+      "detail": "Every back session uses pull-up for both warm-up and cool-down, and the chest sessions reuse push-up regardless of the movement being trained.",
+      "fix": "Give each session a warm-up that targets the muscles it trains — band pull-apart before rows, not pull-up — and a distinct cool-down."
+    }
+  ],
+  "notes": [
+    "Volume progression 21 → 25 → 28 → 14 sets is well matched to a hypertrophy goal."
   ]
 }
 ```

--- a/internal/coaching/infrastructure/ai/adk/retry.go
+++ b/internal/coaching/infrastructure/ai/adk/retry.go
@@ -45,9 +45,10 @@ type attemptFeedback struct {
 // planAttemptFunc produces one candidate plan; injected so retries need no LLM.
 type planAttemptFunc func(attempt int, fb *attemptFeedback) (*GeneratedPlan, error)
 
-// planReviewFunc scores a validated plan; injected so the loop tests without an LLM.
-// A nil func skips review entirely.
-type planReviewFunc func(round int, plan *GeneratedPlan, report ValidationReport) (*PlanReview, error)
+// planReviewFunc scores a validated plan; injected so the loop tests without an
+// LLM. prior is what the previous round asked for, so the reviewer can check
+// whether it landed. A nil func skips review entirely.
+type planReviewFunc func(round int, plan *GeneratedPlan, report ValidationReport, prior []ReviewNote) (*PlanReview, error)
 
 // runWithRetries drives generate → validate → review until a plan ships.
 //
@@ -67,6 +68,10 @@ func runWithRetries(
 	review planReviewFunc,
 ) (*PlanResult, error) {
 	var fb attemptFeedback
+
+	// What the last round asked the generator to change, so the next reviewer
+	// can check whether it landed instead of judging the plan in isolation.
+	var priorFeedback []ReviewNote
 
 	for n := 1; n <= maxGenerationAttempts; n++ {
 		if err := ctx.Err(); err != nil {
@@ -130,7 +135,7 @@ func runWithRetries(
 			return result, nil
 		}
 
-		verdict, err := review(n, clonePlan(outcome.Plan), report)
+		verdict, err := review(n, clonePlan(outcome.Plan), report, priorFeedback)
 		if err != nil {
 			// A reviewer that is down or incoherent must not block a plan that
 			// already passed every deterministic gate.
@@ -162,8 +167,10 @@ func runWithRetries(
 			return result, nil
 		}
 
-		// Gate 2 failed: reflect, carrying the plan being revised.
+		// Gate 2 failed: reflect, carrying the plan being revised. The asks are
+		// remembered so the next reviewer must account for each of them.
 		fb = attemptFeedback{PreviousPlan: outcome.Plan, Review: verdict}
+		priorFeedback = verdict.Feedback
 	}
 
 	return nil, ErrPlanGenerationFailed // unreachable: the final iteration always returns
@@ -208,7 +215,9 @@ func reviewPasses(v *PlanReview) bool {
 // validateReview rejects a verdict the loop cannot act on. Without this a
 // malformed review either sends the generator back with nothing to fix or, on
 // an out-of-range score, silently blocks every plan.
-func validateReview(v *PlanReview) error {
+//
+// prior is what the previous round asked for, empty on the first round.
+func validateReview(v *PlanReview, prior []ReviewNote) error {
 	if v == nil {
 		return fmt.Errorf("%w: no verdict returned", errReviewUnusable)
 	}
@@ -217,6 +226,10 @@ func validateReview(v *PlanReview) error {
 	}
 	if v.Confidence < 0 || v.Confidence > 1 {
 		return fmt.Errorf("%w: confidence %.2f outside 0..1", errReviewUnusable, v.Confidence)
+	}
+
+	if err := checkFeedbackCompliance(v, prior); err != nil {
+		return err
 	}
 
 	if reviewPasses(v) {
@@ -231,6 +244,42 @@ func validateReview(v *PlanReview) error {
 		if note.Fix == "" {
 			return fmt.Errorf("%w: feedback[%d] (%s) has no fix", errReviewUnusable, i, note.Area)
 		}
+	}
+
+	return nil
+}
+
+// checkFeedbackCompliance holds the reviewer to the previous round's asks.
+//
+// Observed live: round 1 told the generator to fix two things, the generator did
+// the easy one and skipped the hard one, and round 2 approved with a perfect
+// score — because nothing had told it what had been asked. Reporting an outcome
+// per item is therefore mandatory, and approving while an item is still
+// outstanding is refused outright.
+func checkFeedbackCompliance(v *PlanReview, prior []ReviewNote) error {
+	if len(prior) == 0 {
+		return nil
+	}
+
+	reported := make(map[string]bool, len(v.PreviousFeedback))
+	for i, outcome := range v.PreviousFeedback {
+		if outcome.Evidence == "" {
+			return fmt.Errorf("%w: previous_feedback[%d] (%s) has no evidence",
+				errReviewUnusable, i, outcome.Area)
+		}
+		reported[outcome.Area] = true
+	}
+
+	for _, note := range prior {
+		if !reported[note.Area] {
+			return fmt.Errorf("%w: previous round asked for %q and the verdict does not say whether it landed",
+				errReviewUnusable, note.Area)
+		}
+	}
+
+	if unapplied := v.unappliedAreas(); len(unapplied) > 0 && v.Approved {
+		return fmt.Errorf("%w: approved while %v from the previous round are still unapplied",
+			errReviewUnusable, unapplied)
 	}
 
 	return nil

--- a/internal/coaching/infrastructure/ai/adk/retry.go
+++ b/internal/coaching/infrastructure/ai/adk/retry.go
@@ -2,6 +2,7 @@ package adk
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -129,7 +130,7 @@ func runWithRetries(
 			return result, nil
 		}
 
-		verdict, err := review(n, outcome.Plan, report)
+		verdict, err := review(n, clonePlan(outcome.Plan), report)
 		if err != nil {
 			// A reviewer that is down or incoherent must not block a plan that
 			// already passed every deterministic gate.
@@ -166,6 +167,35 @@ func runWithRetries(
 	}
 
 	return nil, ErrPlanGenerationFailed // unreachable: the final iteration always returns
+}
+
+// clonePlan returns a deep copy, so a reviewer handed the plan cannot reach
+// what ships. Its verdict type carries no plan and nothing reassigns
+// result.Plan, and this closes the one remaining path: a write through the
+// pointer it was given.
+//
+// A JSON round-trip rather than a hand-written copy: GeneratedPlan is already
+// defined by its JSON shape, so this cannot silently miss a slice field added
+// later — which is the exact bug it exists to prevent. Marshalling a struct of
+// scalars and slices cannot fail, so the error path is unreachable; it returns
+// the original rather than nil so a hypothetical failure degrades to today's
+// behaviour instead of a panic.
+func clonePlan(p *GeneratedPlan) *GeneratedPlan {
+	if p == nil {
+		return nil
+	}
+
+	encoded, err := json.Marshal(p)
+	if err != nil {
+		return p
+	}
+
+	var out GeneratedPlan
+	if err := json.Unmarshal(encoded, &out); err != nil {
+		return p
+	}
+
+	return &out
 }
 
 // reviewPasses reports whether a verdict clears both gates. Approval and score

--- a/internal/coaching/infrastructure/ai/adk/review_test.go
+++ b/internal/coaching/infrastructure/ai/adk/review_test.go
@@ -9,15 +9,17 @@ import (
 
 // recordingReview hands back canned verdicts and records what it was asked about.
 type recordingReview struct {
-	verdicts []*PlanReview
-	errs     []error
-	calls    int
-	seen     []ValidationReport
+	verdicts  []*PlanReview
+	errs      []error
+	calls     int
+	seen      []ValidationReport
+	seenPrior [][]ReviewNote
 }
 
-func (r *recordingReview) fn(round int, _ *GeneratedPlan, report ValidationReport) (*PlanReview, error) {
+func (r *recordingReview) fn(round int, _ *GeneratedPlan, report ValidationReport, prior []ReviewNote) (*PlanReview, error) {
 	r.calls++
 	r.seen = append(r.seen, report)
+	r.seenPrior = append(r.seenPrior, prior)
 
 	i := round - 1
 	if i < len(r.errs) && r.errs[i] != nil {
@@ -221,7 +223,7 @@ func TestValidateReview(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := validateReview(tt.give)
+			err := validateReview(tt.give, nil)
 
 			if got := err == nil; got != tt.want {
 				t.Errorf("usable = %t, want %t (err: %v)", got, tt.want, err)

--- a/internal/coaching/infrastructure/ai/adk/runner.go
+++ b/internal/coaching/infrastructure/ai/adk/runner.go
@@ -70,7 +70,7 @@ func (c *CoachingContextAgent) reviewPlan(
 	nodeCtx agent.Context,
 	coachInput *CoachInput,
 ) planReviewFunc {
-	return func(round int, plan *GeneratedPlan, report ValidationReport) (*PlanReview, error) {
+	return func(round int, plan *GeneratedPlan, report ValidationReport, prior []ReviewNote) (*PlanReview, error) {
 		if c.reviewerNode == nil {
 			return nil, fmt.Errorf("%w: no reviewer configured", errReviewUnusable)
 		}
@@ -82,6 +82,7 @@ func (c *CoachingContextAgent) reviewPlan(
 			GeneratorOutput:  plan,
 			ValidationResult: report,
 			ReviewRound:      round,
+			PreviousFeedback: prior,
 		}
 
 		raw, err := retryTransient(nodeCtx, "reviewer", func() (map[string]any, error) {
@@ -92,7 +93,7 @@ func (c *CoachingContextAgent) reviewPlan(
 		}
 
 		verdict := decodePlanReview(raw)
-		if err := validateReview(verdict); err != nil {
+		if err := validateReview(verdict, prior); err != nil {
 			return nil, err
 		}
 		return verdict, nil
@@ -118,29 +119,59 @@ func decodePlanReview(raw map[string]any) *PlanReview {
 		out.Confidence = v
 	}
 
-	rawNotes, ok := raw["feedback"].([]any)
-	if !ok {
-		return &out
-	}
-	for _, item := range rawNotes {
-		m, ok := item.(map[string]any)
-		if !ok {
-			continue
-		}
+	for _, item := range objectsAt(raw, "feedback") {
 		note := ReviewNote{}
-		if s, ok := m["area"].(string); ok {
+		if s, ok := item["area"].(string); ok {
 			note.Area = s
 		}
-		if s, ok := m["detail"].(string); ok {
+		if s, ok := item["detail"].(string); ok {
 			note.Detail = s
 		}
-		if s, ok := m["fix"].(string); ok {
+		if s, ok := item["fix"].(string); ok {
 			note.Fix = s
 		}
 		out.Feedback = append(out.Feedback, note)
 	}
 
+	for _, item := range objectsAt(raw, "previous_feedback") {
+		outcome := FeedbackOutcome{}
+		if s, ok := item["area"].(string); ok {
+			outcome.Area = s
+		}
+		if b, ok := item["applied"].(bool); ok {
+			outcome.Applied = b
+		}
+		if s, ok := item["evidence"].(string); ok {
+			outcome.Evidence = s
+		}
+		out.PreviousFeedback = append(out.PreviousFeedback, outcome)
+	}
+
+	if rawStrings, ok := raw["notes"].([]any); ok {
+		for _, item := range rawStrings {
+			if s, ok := item.(string); ok {
+				out.Notes = append(out.Notes, s)
+			}
+		}
+	}
+
 	return &out
+}
+
+// objectsAt reads an array-of-objects field, skipping anything of another shape.
+func objectsAt(raw map[string]any, key string) []map[string]any {
+	items, ok := raw[key].([]any)
+	if !ok {
+		return nil
+	}
+
+	out := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		if m, ok := item.(map[string]any); ok {
+			out = append(out, m)
+		}
+	}
+	return out
 }
 
 // toFloat accepts both JSON number shapes an any-typed map can hold.

--- a/internal/coaching/infrastructure/ai/adk/runner.go
+++ b/internal/coaching/infrastructure/ai/adk/runner.go
@@ -100,95 +100,35 @@ func (c *CoachingContextAgent) reviewPlan(
 	}
 }
 
-// decodePlanReview reads the reviewer's schema-constrained map. Absent or
-// wrongly-typed fields fall to zero values, which validateReview then rejects
-// rather than letting a half-parsed verdict steer the loop.
+// decodePlanReview reads the reviewer's schema-constrained output.
+//
+// A JSON round-trip rather than field-by-field assertions, matching clonePlan:
+// PlanReview is defined by its JSON shape, so this cannot silently drop a field
+// added later. The manual version needed an edit in three places per new field,
+// and missing one lost data with no error — which is how notes and
+// previous_feedback nearly arrived empty.
+//
+// The trade is a coarser message on a type mismatch: a nil verdict, which
+// validateReview reports as "no verdict returned", rather than one zero-valued
+// field named precisely. Gemini constrains these types through OutputSchema, so
+// a mismatch means something is wrong upstream, not that a field needs
+// salvaging.
 func decodePlanReview(raw map[string]any) *PlanReview {
 	if raw == nil {
 		return nil
 	}
 
-	var out PlanReview
-	if v, ok := raw["approved"].(bool); ok {
-		out.Approved = v
-	}
-	if v, ok := toFloat(raw["score"]); ok {
-		out.Score = int(v)
-	}
-	if v, ok := toFloat(raw["confidence"]); ok {
-		out.Confidence = v
-	}
-
-	for _, item := range objectsAt(raw, "feedback") {
-		note := ReviewNote{}
-		if s, ok := item["area"].(string); ok {
-			note.Area = s
-		}
-		if s, ok := item["detail"].(string); ok {
-			note.Detail = s
-		}
-		if s, ok := item["fix"].(string); ok {
-			note.Fix = s
-		}
-		out.Feedback = append(out.Feedback, note)
-	}
-
-	for _, item := range objectsAt(raw, "previous_feedback") {
-		outcome := FeedbackOutcome{}
-		if s, ok := item["area"].(string); ok {
-			outcome.Area = s
-		}
-		if b, ok := item["applied"].(bool); ok {
-			outcome.Applied = b
-		}
-		if s, ok := item["evidence"].(string); ok {
-			outcome.Evidence = s
-		}
-		out.PreviousFeedback = append(out.PreviousFeedback, outcome)
-	}
-
-	if rawStrings, ok := raw["notes"].([]any); ok {
-		for _, item := range rawStrings {
-			if s, ok := item.(string); ok {
-				out.Notes = append(out.Notes, s)
-			}
-		}
-	}
-
-	return &out
-}
-
-// objectsAt reads an array-of-objects field, skipping anything of another shape.
-func objectsAt(raw map[string]any, key string) []map[string]any {
-	items, ok := raw[key].([]any)
-	if !ok {
+	encoded, err := json.Marshal(raw)
+	if err != nil {
 		return nil
 	}
 
-	out := make([]map[string]any, 0, len(items))
-	for _, item := range items {
-		if m, ok := item.(map[string]any); ok {
-			out = append(out, m)
-		}
+	var out PlanReview
+	if err := json.Unmarshal(encoded, &out); err != nil {
+		return nil
 	}
-	return out
-}
 
-// toFloat accepts both JSON number shapes an any-typed map can hold.
-func toFloat(v any) (float64, bool) {
-	switch n := v.(type) {
-	case float64:
-		return n, true
-	case int:
-		return float64(n), true
-	case int64:
-		return float64(n), true
-	case json.Number:
-		f, err := n.Float64()
-		return f, err == nil
-	default:
-		return 0, false
-	}
+	return &out
 }
 
 func (c *CoachingContextAgent) putResult(sessionID string, res *PlanResult) {

--- a/internal/coaching/infrastructure/ai/adk/types.go
+++ b/internal/coaching/infrastructure/ai/adk/types.go
@@ -165,6 +165,11 @@ type ReviewRequest struct {
 	GeneratorOutput  *GeneratedPlan   `json:"generator_output"`
 	ValidationResult ValidationReport `json:"validation_result"`
 	ReviewRound      int              `json:"review_round"`
+
+	// PreviousFeedback is what the last round asked the generator to change.
+	// Without it a reviewer judges each plan as if no round had happened, so a
+	// fix the generator quietly skipped reads as a clean plan and gets approved.
+	PreviousFeedback []ReviewNote `json:"previous_feedback,omitempty"`
 }
 
 // ReviewNote is one actionable defect. Area locates it, Fix says what to do;
@@ -175,13 +180,48 @@ type ReviewNote struct {
 	Fix    string `json:"fix"`
 }
 
+// FeedbackOutcome reports what became of one item the previous round asked for.
+// Evidence is required either way: "applied" without a location is a claim, not
+// a check.
+type FeedbackOutcome struct {
+	Area     string `json:"area"`
+	Applied  bool   `json:"applied"`
+	Evidence string `json:"evidence"`
+}
+
 // PlanReview is the reviewer's verdict. It deliberately carries no plan field:
 // the reviewer may judge, score and advise, but never rewrite. A corrected
 // plan can only come from the generator, which is the only path that then goes
 // back through domain validation.
 type PlanReview struct {
-	Approved   bool         `json:"approved"`
-	Score      int          `json:"score"`      // 0..100
-	Confidence float64      `json:"confidence"` // 0..1
-	Feedback   []ReviewNote `json:"feedback,omitempty"`
+	Approved   bool    `json:"approved"`
+	Score      int     `json:"score"`      // 0..100
+	Confidence float64 `json:"confidence"` // 0..1
+
+	// Feedback is strictly must-fix. Anything the reviewer merely likes or
+	// wonders about belongs in Notes: mixing the two turns Fix into praise
+	// ("keep doing this"), which passes validation while telling the generator
+	// nothing to do.
+	Feedback []ReviewNote `json:"feedback,omitempty"`
+	Notes    []string     `json:"notes,omitempty"`
+
+	// PreviousFeedback answers, item by item, whether the last round's fixes
+	// actually landed.
+	PreviousFeedback []FeedbackOutcome `json:"previous_feedback,omitempty"`
+}
+
+// unappliedAreas lists the previous round's items the reviewer reports as still
+// not done.
+func (v *PlanReview) unappliedAreas() []string {
+	if v == nil {
+		return nil
+	}
+
+	var out []string
+	for _, o := range v.PreviousFeedback {
+		if !o.Applied {
+			out = append(out, o.Area)
+		}
+	}
+	return out
 }


### PR DESCRIPTION
> **PR xếp chồng.** Base là `fix/reviewer-plan-immutability` (#250), không phải `main`. Merge #250 trước.

### 1. Vấn đề cần giải quyết

Closes #251.

Ba phát hiện từ chạy vòng review với model thật.

**a. Không ai kiểm feedback đã được thi hành chưa — nghiêm trọng nhất.**

Vòng 1 yêu cầu Generator sửa hai thứ. Nó làm cái dễ, **lặng lẽ bỏ cái khó**, và vòng 2 duyệt với điểm tuyệt đối:

```
FIX 1 "thêm bài chính thứ ba vào mọi buổi"   →  [2,2,2] → [3,3,3]   ✅ đã làm
FIX 2 "warm-up phải nhắm đúng nhóm cơ"       →  pull-up → pull-up   ❌ bỏ qua
                                                 vòng 2: approved, score 100
```

Nguyên nhân: `ReviewRequest` không mang theo yêu cầu của vòng trước, nên vòng 2 chấm plan **như thể chưa từng có vòng nào**. Thấy hợp lệ, cho 100.

**b. Rubric không có mốc.**

`evaluator.txt` liệt kê 5 hạng mục cần xét mà không nói cái gì mất điểm, nên model mặc định cho điểm tối đa: **ba lần chạy liên tiếp** đều `score: 100, feedback: []`.

Thay tạm bằng bản có mốc trừ điểm cụ thể rồi chạy lại **trên cùng cấu hình** → `score: 60`, hai khuyết điểm, và cả hai đều **có thật** (fact-check từ dump: 12/12 buổi thực sự chỉ có 2 bài chính).

**c. Lời khen đến dưới dạng `fix`.**

Khi `feedback` là kênh duy nhất, một Reviewer duyệt sẽ viết:

```json
"fix": "Maintain this structured periodization model in future plan generations."
```

`validateReview` chấp nhận vì `fix` không rỗng — nhưng đó không phải việc cần làm.

---

### 2. Giải pháp

**Reviewer phải chịu trách nhiệm với vòng trước.** `ReviewRequest` thêm `previous_feedback`, và verdict thêm một mảng cùng tên trả lời từng mục: `applied` kèm `evidence`. `checkFeedbackCompliance` loại verdict nếu:

| Trường hợp | Vì sao loại |
|---|---|
| Không nói gì về một yêu cầu | Không kiểm thì không biết Generator có bỏ qua không |
| `applied: true` mà `evidence` rỗng | Đó là lời khẳng định, không phải kiểm tra |
| **Duyệt trong khi còn mục chưa thi hành** | Phần có răng: làm dễ bỏ khó thì không được thưởng |

**Rubric có mốc.** Bắt đầu ở 60. Cộng phải nêu bằng chứng trong `notes`, trừ phải nêu tên trong `feedback`. Điểm là **tổng của những thứ chỉ ra được**, không phải ý kiến giữ riêng.

**Tách `feedback` khỏi `notes`.** `feedback` = phải sửa, `notes` = mọi thứ khác. Duyệt thì `feedback` phải rỗng.

---

### 3. Thay đổi & tác động

- [types.go](internal/coaching/infrastructure/ai/adk/types.go): `ReviewRequest.PreviousFeedback`; `PlanReview` thêm `Notes` và `PreviousFeedback []FeedbackOutcome`; type `FeedbackOutcome`.
- [retry.go](internal/coaching/infrastructure/ai/adk/retry.go): vòng lặp nhớ yêu cầu qua các vòng; `planReviewFunc` nhận `prior`; `checkFeedbackCompliance`.
- [runner.go](internal/coaching/infrastructure/ai/adk/runner.go): truyền `prior` vào `ReviewRequest` và `validateReview`; decode `notes` + `previous_feedback`.
- [build_agents.go](internal/coaching/infrastructure/ai/adk/build_agents.go): schema thêm `notes`, `previous_feedback`.
- [prompts/evaluator.txt](internal/coaching/infrastructure/ai/adk/prompts/evaluator.txt): viết lại — rubric, mục "Checking Your Last Round", tách feedback/notes.
- [compliance_test.go](internal/coaching/infrastructure/ai/adk/compliance_test.go): **mới**.
- [README.md](internal/coaching/infrastructure/ai/adk/README.md): tài liệu cách chấm và các luật compliance.

**Tác động:** không thêm lần gọi LLM nào. Reviewer khắt khe hơn nên reflect sẽ xảy ra thường xuyên hơn — mà reflect tốn quota, xem mục 5.

---

### 4. Kiểm chứng

**Tự động**

```bash
go build ./...
go vet ./internal/... ./cmd/...
go test ./internal/...                                    # toàn repo, 0 FAIL
golangci-lint run --new-from-rev=origin/main ./internal/coaching/...
go test ./internal/coaching/infrastructure/ai/adk/ -run 'Compliance|CarriesLastRound|SkippedFix' -v
```

| Test | Khẳng định |
|---|---|
| `TestCheckFeedbackCompliance` (7 case) | Gồm đúng ca lỗi live: **duyệt khi còn fix chưa thi hành → loại verdict** |
| `TestReviewLoop_CarriesLastRoundsAsksForward` | Vòng 1 nhận `prior` rỗng, vòng 2 nhận đúng yêu cầu của vòng 1 |
| `TestReviewLoop_SkippedFixIsRecordedOnTheShippedPlan` | Hết vòng thì plan vẫn ship, nhưng phản đối đi kèm chứ không tan vào một lượt duyệt |
| `TestPlanReview_HasNoPlanField` | Allow-list schema mở rộng có chủ ý, vẫn không có field nào hình dạng plan |

**Thủ công — hai lần chạy thật**

Lần 1 phơi ra hai khuyết điểm trong prompt tôi vừa viết:

```
approved=false score=65  feedback: (rỗng)     ← validateReview loại → ship unreviewed
previous_feedback: [{"area":"initial_review","applied":true}]   ← bịa ra ở vòng 1
```

Sửa prompt: buộc **mọi điểm trừ phải xuất hiện trong `feedback`**, và bỏ `previous_feedback` ở vòng 1. Lần 2:

```
approved=true  score=90  confidence=1.0
feedback (0)                    ← đúng: duyệt thì rỗng
notes (4)                       ← bốn bằng chứng cộng điểm
previous_feedback []            ← không còn bịa
```

Từ `100/feedback rỗng/không giải thích` sang `90/bốn bằng chứng nêu tên` trên cùng loại giáo án.

---

### 5. Điều còn chưa trọn, nói rõ để khỏi tưởng là xong

**Điểm 90 nghĩa là nó trừ 10 mà không nêu tên.** Bốn bonus trong `notes` cộng lại là +40 từ mốc 60 → phải ra 100. Nó ra 90, nên có một điểm trừ không xuất hiện trong `feedback` — trái đúng luật tôi vừa thêm vào prompt. `validateReview` không bắt được vì không có cách tất định nào để kiểm "điểm có khớp số feedback". Đây là sai lệch hiệu chuẩn còn lại, nhỏ, nhưng thật.

**Đường compliance chưa chạy live.** Lần chạy thứ hai duyệt ngay vòng 1 nên không có vòng 2 nào để `checkFeedbackCompliance` làm việc. Nó hiện **chỉ được phủ bởi unit test**. Cần một lần chạy có reflect thật để xác nhận model điền `previous_feedback` đúng schema.

**Quota.** Đo được: 4 lần gọi nếu duyệt ngay, 9 nếu có 1 vòng reflect, ~13 nếu hết 3 vòng. Hạn mức free tier là 20/ngày/model. Reviewer khắt khe hơn sẽ đẩy con số này lên — nên cân nhắc hạ `maxGenerationAttempts` nếu 429 thành vấn đề.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
