### PR TITLE
🐛 fix(auth): map empty social IDs to NULL in user model

### DIFF
--- a/internal/auth/infrastructure/persistence/postgres/models.go
+++ b/internal/auth/infrastructure/persistence/postgres/models.go
@@ -13,8 +13,8 @@ import (
 type UserModel struct {
 	ID         string    `gorm:"primaryKey;column:id"`
 	Email      string    `gorm:"column:email;not null;uniqueIndex"`
-	GoogleID   string    `gorm:"column:google_id"`
-	FacebookID string    `gorm:"column:facebook_id"`
+	GoogleID   *string   `gorm:"column:google_id"`
+	FacebookID *string   `gorm:"column:facebook_id"`
 	FullName   string    `gorm:"column:full_name"`
 	Role       string    `gorm:"column:role;not null"`
 	CreatedAt  time.Time `gorm:"column:created_at"`
@@ -26,11 +26,20 @@ func (UserModel) TableName() string {
 }
 
 func toUserModel(u *aggregate.User) *UserModel {
+	var gID, fID *string
+	if u.GoogleID() != "" {
+		val := u.GoogleID()
+		gID = &val
+	}
+	if u.FacebookID() != "" {
+		val := u.FacebookID()
+		fID = &val
+	}
 	return &UserModel{
 		ID:         u.ID(),
 		Email:      u.Email(),
-		GoogleID:   u.GoogleID(),
-		FacebookID: u.FacebookID(),
+		GoogleID:   gID,
+		FacebookID: fID,
 		FullName:   u.FullName(),
 		Role:       u.Role(),
 		CreatedAt:  u.CreatedAt(),
@@ -51,11 +60,18 @@ func (m *UserModel) ToDomain() (*aggregate.User, error) {
 	if err != nil {
 		return nil, err
 	}
+	var gID, fID string
+	if m.GoogleID != nil {
+		gID = *m.GoogleID
+	}
+	if m.FacebookID != nil {
+		fID = *m.FacebookID
+	}
 	return aggregate.NewUser(
 		userID,
 		email,
-		m.GoogleID,
-		m.FacebookID,
+		gID,
+		fID,
 		m.FullName,
 		role,
 		m.CreatedAt,


### PR DESCRIPTION
## 📝 Context & Description
Fixes an issue where unlinked `google_id` and `facebook_id` fields in `UserModel` were inserted into PostgreSQL as empty strings (`""`) rather than SQL `NULL`. This caused `pq: duplicate key value violates unique constraint "users_facebook_id_key" (23505)` errors when registering multiple users without social IDs.

## 🛠️ Changes
- Updated `UserModel` struct fields `GoogleID` and `FacebookID` to `*string` pointers in `internal/auth/infrastructure/persistence/postgres/models.go`.
- Updated `toUserModel()` helper to convert empty strings `""` to `nil` (`NULL` in DB).
- Updated `ToDomain()` helper to safely dereference `*string` pointers back to `""` for domain aggregates.

## ✅ Verification
- Ran `go test ./internal/auth/...` (passed cleanly).
