### PR TITLE
✨ feat(profile): wire and start UserRegisteredConsumer for auth events

### DIFF
--- a/internal/profile/module.go
+++ b/internal/profile/module.go
@@ -19,6 +19,7 @@ import (
 	profileKafka "github.com/viethung213/gym-companion/internal/profile/infrastructure/kafka"
 	"github.com/viethung213/gym-companion/internal/profile/infrastructure/persistence"
 	"github.com/viethung213/gym-companion/internal/profile/infrastructure/worker"
+	profileConsumer "github.com/viethung213/gym-companion/internal/profile/transport/consumer"
 	profileGRPC "github.com/viethung213/gym-companion/internal/profile/transport/grpc"
 	sharedKafka "github.com/viethung213/gym-companion/internal/shared/kafka"
 	gormPostgres "gorm.io/driver/postgres"
@@ -42,6 +43,7 @@ func Initialize(ctx context.Context, deps ModuleDeps) (*profileGRPC.GRPCHandler,
 
 	userRepo := persistence.NewPostgresUserProfileRepository(gormDB)
 	outboxRepo := persistence.NewGormOutboxRepository(gormDB)
+	outboxLogRepo := persistence.NewGormOutboxLogRepository(gormDB)
 	txManager := persistence.NewSQLTransactionManager(gormDB)
 	eventPub := profileEvent.NewOutboxWriter(outboxRepo)
 
@@ -56,6 +58,8 @@ func Initialize(ctx context.Context, deps ModuleDeps) (*profileGRPC.GRPCHandler,
 	getInjuryHistoryHandler := query.NewGetInjuryHistoryHandler(userRepo)
 
 	var kafkaPub *profileKafka.Publisher
+	var userRegisteredConsumer *profileConsumer.UserRegisteredConsumer
+
 	if deps.KafkaRegistry != nil {
 		cfg := profileConfig.LoadConfig()
 		brokers := strings.Split(cfg.KafkaBrokers, ",")
@@ -63,6 +67,11 @@ func Initialize(ctx context.Context, deps ModuleDeps) (*profileGRPC.GRPCHandler,
 		writer, wErr := deps.KafkaRegistry.GetWriter("profile.events", brokers)
 		if wErr == nil && writer != nil {
 			kafkaPub = profileKafka.NewPublisher(writer)
+		}
+
+		reader, rErr := deps.KafkaRegistry.GetReader("profile-user-registered-group", "auth.events", brokers)
+		if rErr == nil && reader != nil {
+			userRegisteredConsumer = profileConsumer.NewUserRegisteredConsumer(reader, userRepo, outboxLogRepo, txManager)
 		}
 	}
 
@@ -75,6 +84,14 @@ func Initialize(ctx context.Context, deps ModuleDeps) (*profileGRPC.GRPCHandler,
 		go func() {
 			defer wg.Done()
 			outboxWorker.Start(workerCtx)
+		}()
+	}
+
+	if userRegisteredConsumer != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			userRegisteredConsumer.Start(workerCtx)
 		}()
 	}
 


### PR DESCRIPTION
## 📝 Context & Description
`UserRegisteredConsumer` was defined in `internal/profile/transport/consumer/user_registered_consumer.go` to listen for user registration events (`contracts.generic.auth.v1.userRegistered`) from the `auth.events` Kafka topic and automatically create initial blank user profiles. However, it was not wired or started in `internal/profile/module.go`.

## 🛠️ Changes
- Updated `internal/profile/module.go` to instantiate `UserRegisteredConsumer` with a Kafka reader subscribed to `auth.events` using consumer group `profile-user-registered-group`.
- Started `userRegisteredConsumer.Start(workerCtx)` inside a background goroutine managed by `sync.WaitGroup`.

## ✅ Event Handling Status
`UserRegisteredConsumer` is now configured and active. It handles:
- `contracts.generic.auth.v1.userRegistered`
- `UserRegistered`

When a new user registers, this consumer automatically creates an initial `UserProfile` with default metrics (`BEGINNER` experience level, 1.0/1.0 height/weight placeholders, and empty goals/injuries).
