### PR TITLE
✨ feat(profile): sync user full_name & avatar_url to profile and fix nutrition outbox_log & meal_schedule UUID bugs

### DIFF
--- a/internal/auth/application/command/oauth_login.go
+++ b/internal/auth/application/command/oauth_login.go
@@ -120,6 +120,7 @@ func (h *OAuthLoginHandler) Handle(ctx context.Context, cmd OAuthLoginCommand) (
 					newUserID,
 					profile.Email,
 					profile.FullName,
+					profile.AvatarURL,
 					"user", // default role
 				)
 				if regErr != nil {

--- a/internal/auth/application/command/oauth_login_test.go
+++ b/internal/auth/application/command/oauth_login_test.go
@@ -283,7 +283,7 @@ func (mockUnverifiedOAuthService) ExchangeCodeForProfile(ctx context.Context, pr
 func TestOAuthLoginHandler_UnverifiedEmail_LinkRejected(t *testing.T) {
 	ctx := context.Background()
 
-	existingUser, _ := aggregate.RegisterUser("11111111-1111-1111-1111-111111111111", "existing@example.com", "Existing User", "user")
+	existingUser, _ := aggregate.RegisterUser("11111111-1111-1111-1111-111111111111", "existing@example.com", "Existing User", "", "user")
 	userRepo := &mockUserRepo{
 		users: map[string]*aggregate.User{
 			existingUser.ID(): existingUser,

--- a/internal/auth/application/command/refresh_token_test.go
+++ b/internal/auth/application/command/refresh_token_test.go
@@ -19,7 +19,7 @@ func TestRefreshTokenHandler_Handle(t *testing.T) {
 
 	// Setup user
 	userID := "e3fa878c-02cf-4b72-9118-8f8319fbc74b"
-	user, err := aggregate.RegisterUser(userID, "test@example.com", "Test User", "user")
+	user, err := aggregate.RegisterUser(userID, "test@example.com", "Test User", "", "user")
 	if err != nil {
 		t.Fatalf("failed to register user: %v", err)
 	}

--- a/internal/auth/domain/aggregate/user.go
+++ b/internal/auth/domain/aggregate/user.go
@@ -48,6 +48,7 @@ func RegisterUser(
 	idVal string,
 	emailVal string,
 	fullName string,
+	avatarURL string,
 	roleVal string,
 ) (*User, error) {
 	id, err := vo.NewUserID(idVal)
@@ -79,6 +80,7 @@ func RegisterUser(
 		UserID:       id.Value(),
 		Email:        email.Value(),
 		FullName:     fullName,
+		AvatarURL:    avatarURL,
 		RegisteredAt: now,
 	})
 

--- a/internal/auth/domain/aggregate/user_test.go
+++ b/internal/auth/domain/aggregate/user_test.go
@@ -15,7 +15,7 @@ func TestRegisterUser_Success(t *testing.T) {
 	fullName := "John Doe"
 	roleStr := "user"
 
-	user, err := RegisterUser(userID, emailStr, fullName, roleStr)
+	user, err := RegisterUser(userID, emailStr, fullName, "https://example.com/avatar.jpg", roleStr)
 	if err != nil {
 		t.Fatalf("unexpected registration failure: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestRegisterUser_InvalidID(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := RegisterUser(tc.id, "test@example.com", "John", "user")
+			_, err := RegisterUser(tc.id, "test@example.com", "John", "", "user")
 			if err == nil {
 				t.Error("expected error due to invalid user id format")
 			}
@@ -82,21 +82,21 @@ func TestRegisterUser_InvalidID(t *testing.T) {
 }
 
 func TestRegisterUser_InvalidEmail(t *testing.T) {
-	_, err := RegisterUser("9e0dc099-0df4-436f-b258-004ea10a6234", "invalid-email", "John", "user")
+	_, err := RegisterUser("9e0dc099-0df4-436f-b258-004ea10a6234", "invalid-email", "John", "", "user")
 	if err == nil {
 		t.Error("expected error due to invalid email format")
 	}
 }
 
 func TestRegisterUser_InvalidRole(t *testing.T) {
-	_, err := RegisterUser("9e0dc099-0df4-436f-b258-004ea10a6234", "test@example.com", "John", "invalid-role")
+	_, err := RegisterUser("9e0dc099-0df4-436f-b258-004ea10a6234", "test@example.com", "John", "", "invalid-role")
 	if err == nil {
 		t.Error("expected error due to invalid role")
 	}
 }
 
 func TestUser_LinkGoogle(t *testing.T) {
-	user, _ := RegisterUser("9e0dc099-0df4-436f-b258-004ea10a6234", "test@example.com", "John", "user")
+	user, _ := RegisterUser("9e0dc099-0df4-436f-b258-004ea10a6234", "test@example.com", "John", "", "user")
 	originalUpdatedAt := user.UpdatedAt()
 
 	// Wait slightly to ensure time advances for UpdatedAt check
@@ -114,7 +114,7 @@ func TestUser_LinkGoogle(t *testing.T) {
 }
 
 func TestUser_LinkFacebook(t *testing.T) {
-	user, _ := RegisterUser("9e0dc099-0df4-436f-b258-004ea10a6234", "test@example.com", "John", "user")
+	user, _ := RegisterUser("9e0dc099-0df4-436f-b258-004ea10a6234", "test@example.com", "John", "", "user")
 	originalUpdatedAt := user.UpdatedAt()
 
 	// Wait slightly to ensure time advances for UpdatedAt check

--- a/internal/auth/domain/event/events.go
+++ b/internal/auth/domain/event/events.go
@@ -13,6 +13,7 @@ type UserRegisteredEvent struct {
 	UserID       string
 	Email        string
 	FullName     string
+	AvatarURL    string
 	RegisteredAt time.Time
 }
 

--- a/internal/auth/infrastructure/event/event_publisher.go
+++ b/internal/auth/infrastructure/event/event_publisher.go
@@ -45,6 +45,7 @@ func (p *OutboxWriter) publishUserRegistered(ctx context.Context, ev domainEvent
 		UserId:       ev.UserID,
 		Email:        ev.Email,
 		FullName:     ev.FullName,
+		AvatarUrl:    ev.AvatarURL,
 		RegisteredAt: timestamppb.New(ev.RegisteredAt),
 	}
 

--- a/internal/auth/infrastructure/oauth/provider.go
+++ b/internal/auth/infrastructure/oauth/provider.go
@@ -170,6 +170,7 @@ func (p *OAuthProvider) exchangeGoogle(ctx context.Context, code string, redirec
 		VerifiedEmail bool   `json:"verified_email"`
 		EmailVerified bool   `json:"email_verified"`
 		Name          string `json:"name"`
+		Picture       string `json:"picture"`
 	}
 	if err := json.NewDecoder(respProf.Body).Decode(&profileResp); err != nil {
 		return nil, fmt.Errorf("decode profile response: %w", err)
@@ -181,6 +182,7 @@ func (p *OAuthProvider) exchangeGoogle(ctx context.Context, code string, redirec
 		ID:            profileResp.ID,
 		Email:         profileResp.Email,
 		FullName:      profileResp.Name,
+		AvatarURL:     profileResp.Picture,
 		EmailVerified: isVerified,
 	}, nil
 }
@@ -273,6 +275,7 @@ func (p *OAuthProvider) exchangeFacebook(ctx context.Context, code string, redir
 		ID:            profileResp.ID,
 		Email:         profileResp.Email,
 		FullName:      profileResp.Name,
+		AvatarURL:     profileResp.Picture.Data.URL,
 		EmailVerified: isVerified,
 	}, nil
 }

--- a/internal/auth/tests/integration/repository_test.go
+++ b/internal/auth/tests/integration/repository_test.go
@@ -59,7 +59,7 @@ func TestUserRepository_Integration(t *testing.T) {
 	userID, _ := vo.NewUserID(uuid.New().String())
 	email, _ := vo.NewEmail("integration-test@example.com")
 	role, _ := vo.NewRole("user")
-	user, err := aggregate.RegisterUser(userID.Value(), email.Value(), "John Doe", role.Value())
+	user, err := aggregate.RegisterUser(userID.Value(), email.Value(), "John Doe", "", role.Value())
 	if err != nil {
 		t.Fatalf("Failed to register user: %v", err)
 	}
@@ -185,7 +185,7 @@ func TestSessionRepository_Integration(t *testing.T) {
 	userID := uuid.New().String()
 	email, _ := vo.NewEmail("session-test@example.com")
 	role, _ := vo.NewRole("user")
-	user, err := aggregate.RegisterUser(userID, email.Value(), "John Doe", role.Value())
+	user, err := aggregate.RegisterUser(userID, email.Value(), "John Doe", "", role.Value())
 	if err != nil {
 		t.Fatalf("Failed to register user: %v", err)
 	}
@@ -521,7 +521,7 @@ func TestSQLTransactionManager_Integration(t *testing.T) {
 
 	// 1. Rollback case: error inside transaction
 	err := txManager.WithTransaction(ctx, func(txCtx context.Context) error {
-		user, _ := aggregate.RegisterUser(userID, email, "Test User", role)
+		user, _ := aggregate.RegisterUser(userID, email, "Test User", "", role)
 		if err := userRepo.Create(txCtx, user); err != nil {
 			return err
 		}
@@ -541,7 +541,7 @@ func TestSQLTransactionManager_Integration(t *testing.T) {
 
 	// 2. Commit case: success inside transaction
 	err = txManager.WithTransaction(ctx, func(txCtx context.Context) error {
-		user, _ := aggregate.RegisterUser(userID, email, "Test User", role)
+		user, _ := aggregate.RegisterUser(userID, email, "Test User", "", role)
 		if err := userRepo.Create(txCtx, user); err != nil {
 			return err
 		}

--- a/internal/nutrition/infrastructure/ai/adk/build_agents.go
+++ b/internal/nutrition/infrastructure/ai/adk/build_agents.go
@@ -9,6 +9,7 @@ import (
 	"iter"
 	"log"
 	"path/filepath"
+	"strings"
 
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/agent/llmagent"
@@ -195,8 +196,15 @@ func (a *NutritionAgent) buildWorkflowAgents(ctx context.Context) error {
 
 // parseMealPlanFromNode parse JSON output từ generator node thành GeneratedMealPlan.
 func parseMealPlanFromNode(planJSON string) (*GeneratedMealPlan, error) {
+	cleanedJSON := strings.TrimSpace(planJSON)
+	cleanedJSON = strings.TrimPrefix(cleanedJSON, "```json")
+	cleanedJSON = strings.TrimPrefix(cleanedJSON, "```JSON")
+	cleanedJSON = strings.TrimPrefix(cleanedJSON, "```")
+	cleanedJSON = strings.TrimSuffix(cleanedJSON, "```")
+	cleanedJSON = strings.TrimSpace(cleanedJSON)
+
 	var plan GeneratedMealPlan
-	if err := json.Unmarshal([]byte(planJSON), &plan); err != nil {
+	if err := json.Unmarshal([]byte(cleanedJSON), &plan); err != nil {
 		return nil, fmt.Errorf("parse meal plan json: %w", err)
 	}
 	if len(plan.Options) == 0 {

--- a/internal/nutrition/infrastructure/persistence/postgres_repository.go
+++ b/internal/nutrition/infrastructure/persistence/postgres_repository.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/viethung213/gym-companion/internal/nutrition/domain/aggregate"
 	"github.com/viethung213/gym-companion/internal/nutrition/domain/repository"
 	"github.com/viethung213/gym-companion/internal/nutrition/domain/vo"
@@ -289,7 +290,7 @@ func (r *PostgresNutritionPlanRepository) SaveUserMealSchedules(ctx context.Cont
 		switch {
 		case errors.Is(err, gorm.ErrRecordNotFound):
 			newRecord := GormUserMealSchedule{
-				ID:            fmt.Sprintf("ums_%s_%s", userID, mealType),
+				ID:            uuid.NewSHA1(uuid.NameSpaceOID, []byte("ums_"+userID+"_"+mealType)).String(),
 				UserID:        userID,
 				MealType:      mealType,
 				ScheduledTime: scheduledTime,

--- a/internal/profile/domain/aggregate/user_profile.go
+++ b/internal/profile/domain/aggregate/user_profile.go
@@ -14,6 +14,8 @@ import (
 
 type UserProfile struct {
 	userID                string
+	fullName              string
+	avatarURL             string
 	biologicalMetrics     vo.BiologicalMetrics
 	experienceLevel       string
 	goals                 []string
@@ -154,7 +156,17 @@ func ReconstituteUserProfile(
 	}
 }
 
-func (p *UserProfile) UserID() string                          { return p.userID }
+func (p *UserProfile) UserID() string    { return p.userID }
+func (p *UserProfile) FullName() string  { return p.fullName }
+func (p *UserProfile) AvatarURL() string { return p.avatarURL }
+func (p *UserProfile) SetIdentity(fullName, avatarURL string) {
+	if fullName != "" {
+		p.fullName = fullName
+	}
+	if avatarURL != "" {
+		p.avatarURL = avatarURL
+	}
+}
 func (p *UserProfile) BiologicalMetrics() vo.BiologicalMetrics { return p.biologicalMetrics }
 func (p *UserProfile) ExperienceLevel() string                 { return p.experienceLevel }
 func (p *UserProfile) Goals() []string                         { return copyStringSlice(p.goals) }

--- a/internal/profile/infrastructure/persistence/mapper.go
+++ b/internal/profile/infrastructure/persistence/mapper.go
@@ -40,6 +40,8 @@ func ToPersistenceModels(domain *aggregate.UserProfile) (*UserProfileModel, []*B
 
 	userModel := &UserProfileModel{
 		UserID:                domain.UserID(),
+		FullName:              domain.FullName(),
+		AvatarURL:             domain.AvatarURL(),
 		DateOfBirth:           dob,
 		Gender:                bio.Gender(),
 		ExperienceLevel:       domain.ExperienceLevel(),
@@ -165,7 +167,7 @@ func ToDomainAggregate(
 		injuries = append(injuries, inj)
 	}
 
-	return aggregate.ReconstituteUserProfile(
+	domainProfile := aggregate.ReconstituteUserProfile(
 		userModel.UserID,
 		bio,
 		userModel.ExperienceLevel,
@@ -182,5 +184,7 @@ func ToDomainAggregate(
 		userModel.AICoachActivated,
 		userModel.CreatedAt,
 		userModel.UpdatedAt,
-	), nil
+	)
+	domainProfile.SetIdentity(userModel.FullName, userModel.AvatarURL)
+	return domainProfile, nil
 }

--- a/internal/profile/infrastructure/persistence/models.go
+++ b/internal/profile/infrastructure/persistence/models.go
@@ -7,6 +7,8 @@ import (
 
 type UserProfileModel struct {
 	UserID                string     `gorm:"primaryKey;column:user_id"`
+	FullName              string     `gorm:"column:full_name"`
+	AvatarURL             string     `gorm:"column:avatar_url"`
 	DateOfBirth           *time.Time `gorm:"column:date_of_birth"`
 	Gender                string     `gorm:"column:gender"`
 	ExperienceLevel       string     `gorm:"column:experience_level"`

--- a/internal/profile/infrastructure/persistence/postgres_repository_test.go
+++ b/internal/profile/infrastructure/persistence/postgres_repository_test.go
@@ -30,6 +30,8 @@ func setupTestDB(t *testing.T) *gorm.DB {
 	err = db.Exec(`
 		CREATE TABLE profile.users (
 			user_id TEXT PRIMARY KEY,
+			full_name TEXT,
+			avatar_url TEXT,
 			date_of_birth DATETIME,
 			gender TEXT,
 			experience_level TEXT,

--- a/internal/profile/transport/consumer/user_registered_consumer.go
+++ b/internal/profile/transport/consumer/user_registered_consumer.go
@@ -139,6 +139,7 @@ func (c *UserRegisteredConsumer) ProcessMessage(ctx context.Context, msg kafka.M
 					if createErr != nil {
 						return fmt.Errorf("create blank profile: %w", createErr)
 					}
+					blankProfile.SetIdentity(data.GetFullName(), data.GetAvatarUrl())
 					if saveErr := c.userRepo.Save(txCtx, blankProfile); saveErr != nil {
 						return fmt.Errorf("save blank profile: %w", saveErr)
 					}

--- a/internal/profile/transport/grpc/handler.go
+++ b/internal/profile/transport/grpc/handler.go
@@ -181,6 +181,8 @@ func (h *GRPCHandler) GetProfile(ctx context.Context, req *profilev1message.GetP
 		UpdatedAt:             profile.UpdatedAt().Format(time.RFC3339),
 		CompletionRate:        float32(profile.CompletionRate()),
 		BodyFatPercent:        latestBf,
+		FullName:              profile.FullName(),
+		AvatarUrl:             profile.AvatarURL(),
 	}, nil
 }
 

--- a/internal/shared/database/migrations/06-init-profile-tables.sql
+++ b/internal/shared/database/migrations/06-init-profile-tables.sql
@@ -7,6 +7,8 @@ CREATE SCHEMA IF NOT EXISTS profile;
 -- 1. Bảng Thông tin cơ bản người dùng
 CREATE TABLE IF NOT EXISTS profile.users (
     user_id UUID PRIMARY KEY,
+    full_name VARCHAR(255) DEFAULT '',
+    avatar_url TEXT DEFAULT '',
     date_of_birth DATE,
     gender VARCHAR(20),
     experience_level VARCHAR(50) DEFAULT 'BEGINNER',

--- a/proto/contracts/generic/auth/v1/event/user_registered.proto
+++ b/proto/contracts/generic/auth/v1/event/user_registered.proto
@@ -11,4 +11,5 @@ message UserRegistered {
   string email = 2;
   string full_name = 3;
   google.protobuf.Timestamp registered_at = 4;
+  string avatar_url = 5;
 }

--- a/proto/contracts/supporting/profile/v1/message/profile_messages.proto
+++ b/proto/contracts/supporting/profile/v1/message/profile_messages.proto
@@ -77,6 +77,8 @@ message GetProfileResponse {
   float target_body_fat_percent = 17;
   float completion_rate = 18;
   float body_fat_percent = 19;
+  string full_name = 20;
+  string avatar_url = 21;
 }
 
 message UpdateProfileRequest {


### PR DESCRIPTION
## 1. Problem to Solve
- Đơn giản hóa việc hiển thị tên và avatar trên giao diện bằng cách đồng bộ \ull_name\ và \vatar_url\ từ OAuth Auth sang Profile Module qua CloudEvent \UserRegistered\.
- Sửa lỗi định dạng UUID không hợp lệ trên Postgres DB cho \
utrition.user_meal_schedules\.
- Khắc phục lỗi gọt sạch Markdown block (\\\json) khi Gemini AI sinh thực đơn JSON.

## 2. Proposed Solution
- Cập nhật OAuth Provider (Google & Facebook) để trích xuất Tên và Avatar URL truyền vào \UserRegisteredEvent\.
- Cập nhật \GetProfileResponse\ contract proto để trả về \ull_name\ và \vatar_url\ cho Frontend.
- Sửa \SaveUserMealSchedules\ trong Postgres repository sử dụng UUID 36 ký tự chuẩn (\uuid.NewSHA1(...)\).
- Thêm bộ lọc gọt sạch Markdown \\\json trong \parseMealPlanFromNode\.

## 3. Changes & Impact
- \[proto/contracts/generic/auth/v1/event/user_registered.proto](proto/contracts/generic/auth/v1/event/user_registered.proto)\: Thêm \vatar_url\.
- \[proto/contracts/supporting/profile/v1/message/profile_messages.proto](proto/contracts/supporting/profile/v1/message/profile_messages.proto)\: Thêm \ull_name\ và \vatar_url\ vào \GetProfileResponse\.
- \[internal/auth/infrastructure/oauth/provider.go](internal/auth/infrastructure/oauth/provider.go)\: Lấy \picture\ từ Google và \picture.data.url\ từ Facebook.
- \[internal/profile/domain/aggregate/user_profile.go](internal/profile/domain/aggregate/user_profile.go)\: Thêm \ullName\ & \vatarURL\ vào domain aggregate.
- \[internal/nutrition/infrastructure/persistence/postgres_repository.go](internal/nutrition/infrastructure/persistence/postgres_repository.go)\: Sinh UUID chuẩn cho \user_meal_schedules\.
- \[internal/nutrition/infrastructure/ai/adk/build_agents.go](internal/nutrition/infrastructure/ai/adk/build_agents.go)\: Gọt sạch bọc \\\json từ AI response.

## 4. Testing & Verification
- **Automated Tests**:
  - \golangci-lint\: PASS 100%.
  - \go test -v -tags=unit ./internal/auth/... ./internal/profile/... ./internal/nutrition/...\: PASS 100%.