### PR TITLE
✨ feat(exercise): allow public exercise search and optimize AI prompts for pure JSON responses

### DIFF
--- a/internal/exercise/application/query/get_catalog_metadata.go
+++ b/internal/exercise/application/query/get_catalog_metadata.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/viethung213/gym-companion/internal/exercise/application/port"
-	"github.com/viethung213/gym-companion/internal/shared/middleware"
 )
 
 type GetCatalogMetadataQuery struct{}
@@ -24,10 +23,6 @@ func (h *GetCatalogMetadataHandler) Handle(
 	ctx context.Context,
 	_ GetCatalogMetadataQuery,
 ) (port.Metadata, error) {
-	if _, err := middleware.RequireAuthenticated(ctx); err != nil {
-		return port.Metadata{}, err
-	}
-
 	metadata, err := h.repo.GetMetadata(ctx)
 	if err != nil {
 		return port.Metadata{}, fmt.Errorf("get metadata: %w", err)

--- a/internal/exercise/application/query/get_exercise.go
+++ b/internal/exercise/application/query/get_exercise.go
@@ -27,10 +27,7 @@ func (h *GetExerciseHandler) Handle(
 	ctx context.Context,
 	q GetExerciseQuery,
 ) (*domain.Exercise, error) {
-	actor, err := middleware.RequireAuthenticated(ctx)
-	if err != nil {
-		return nil, err
-	}
+	actor, _ := middleware.RequireAuthenticated(ctx)
 
 	exercise, err := h.repo.FindByID(ctx, q.ID)
 	if err != nil {

--- a/internal/exercise/application/query/search_exercises.go
+++ b/internal/exercise/application/query/search_exercises.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/viethung213/gym-companion/internal/exercise/application/port"
 	"github.com/viethung213/gym-companion/internal/exercise/domain"
-	"github.com/viethung213/gym-companion/internal/shared/middleware"
 )
 
 type SearchExercisesQuery struct {
@@ -27,10 +26,6 @@ func (h *SearchExercisesHandler) Handle(
 	ctx context.Context,
 	q SearchExercisesQuery,
 ) ([]*domain.Exercise, error) {
-	if _, err := middleware.RequireAuthenticated(ctx); err != nil {
-		return nil, err
-	}
-
 	exercises, err := h.repo.SearchActive(ctx, q.Filters)
 	if err != nil {
 		return nil, fmt.Errorf("search exercises: %w", err)

--- a/internal/exercise/application/service_test.go
+++ b/internal/exercise/application/service_test.go
@@ -329,10 +329,10 @@ func TestGetCatalogMetadata(t *testing.T) {
 		t.Fatalf("get metadata: %v", err)
 	}
 
-	// 2. Failure with unauthenticated context
+	// 2. Unauthenticated context should succeed (public bypass)
 	_, err = suite.metadataHandler.Handle(context.Background(), query.GetCatalogMetadataQuery{})
-	if !errors.Is(err, middleware.ErrUnauthorized) {
-		t.Fatalf("got error %v, want %v", err, middleware.ErrUnauthorized)
+	if err != nil {
+		t.Fatalf("get metadata unauthenticated: %v", err)
 	}
 }
 
@@ -431,47 +431,21 @@ func TestRequireAdmin_Authorization(t *testing.T) {
 	}
 }
 
-func TestRequireAuthenticated_Authorization(t *testing.T) {
+func TestPublicCatalogBypass(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name string
-		run  func(ctx context.Context, s *testSuite) error
-	}{
-		{
-			name: "GetExerciseHandler",
-			run: func(ctx context.Context, s *testSuite) error {
-				_, err := s.getHandler.Handle(ctx, query.GetExerciseQuery{ID: "id-1"})
-				return err
-			},
-		},
-		{
-			name: "SearchExercisesHandler",
-			run: func(ctx context.Context, s *testSuite) error {
-				_, err := s.searchHandler.Handle(ctx, query.SearchExercisesQuery{Filters: &port.SearchFilters{}})
-				return err
-			},
-		},
-		{
-			name: "GetCatalogMetadataHandler",
-			run: func(ctx context.Context, s *testSuite) error {
-				_, err := s.metadataHandler.Handle(ctx, query.GetCatalogMetadataQuery{})
-				return err
-			},
-		},
+	suite := newTestSuite()
+	unauthCtx := context.Background()
+
+	// SearchExercisesHandler should succeed when unauthenticated
+	_, err := suite.searchHandler.Handle(unauthCtx, query.SearchExercisesQuery{Filters: &port.SearchFilters{}})
+	if err != nil {
+		t.Fatalf("search exercises unauthenticated: %v", err)
 	}
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			suite := newTestSuite()
-
-			// Rejected when unauthenticated
-			err := tt.run(context.Background(), suite)
-			if !errors.Is(err, middleware.ErrUnauthorized) {
-				t.Fatalf("got error %v, want %v", err, middleware.ErrUnauthorized)
-			}
-		})
+	// GetCatalogMetadataHandler should succeed when unauthenticated
+	_, err = suite.metadataHandler.Handle(unauthCtx, query.GetCatalogMetadataQuery{})
+	if err != nil {
+		t.Fatalf("get metadata unauthenticated: %v", err)
 	}
 }

--- a/internal/nutrition/infrastructure/ai/adk/agent.go
+++ b/internal/nutrition/infrastructure/ai/adk/agent.go
@@ -100,7 +100,7 @@ func (a *NutritionAgent) EstimateNutrient(
 
 	var result repository.EstimatedNutrientResult
 	//nolint:musttag // LLM response struct does not require tags
-	if err := json.Unmarshal([]byte(rawJSON), &result); err != nil {
+	if err := json.Unmarshal([]byte(cleanJSONResponse(rawJSON)), &result); err != nil {
 		return nil, fmt.Errorf("estimate nutrient parse json: %w", err)
 	}
 
@@ -131,7 +131,7 @@ func (a *NutritionAgent) GenerateNutritionInsight(
 	}
 
 	var insight insightLLMResponse
-	if err := json.Unmarshal([]byte(rawJSON), &insight); err != nil {
+	if err := json.Unmarshal([]byte(cleanJSONResponse(rawJSON)), &insight); err != nil {
 		return nil, fmt.Errorf("generate nutrition insight parse json: %w", err)
 	}
 

--- a/internal/nutrition/infrastructure/ai/adk/build_agents.go
+++ b/internal/nutrition/infrastructure/ai/adk/build_agents.go
@@ -194,14 +194,58 @@ func (a *NutritionAgent) buildWorkflowAgents(ctx context.Context) error {
 	return nil
 }
 
+// cleanJSONResponse extracts the JSON payload from LLM output by locating
+// the first '{' or '[' and the last '}' or ']'. This safely removes markdown backticks
+// (e.g. ```json), leading text, or trailing prose emitted by LLM models.
+//
+//nolint:gocritic // ifElseChain is readable for index finding
+func cleanJSONResponse(raw string) string {
+	s := strings.TrimSpace(raw)
+
+	startObj := strings.Index(s, "{")
+	startArr := strings.Index(s, "[")
+	start := -1
+	if startObj != -1 && startArr != -1 {
+		if startObj < startArr {
+			start = startObj
+		} else {
+			start = startArr
+		}
+	} else if startObj != -1 {
+		start = startObj
+	} else if startArr != -1 {
+		start = startArr
+	}
+
+	endObj := strings.LastIndex(s, "}")
+	endArr := strings.LastIndex(s, "]")
+	end := -1
+	if endObj != -1 && endArr != -1 {
+		if endObj > endArr {
+			end = endObj
+		} else {
+			end = endArr
+		}
+	} else if endObj != -1 {
+		end = endObj
+	} else if endArr != -1 {
+		end = endArr
+	}
+
+	if start != -1 && end != -1 && end > start {
+		return s[start : end+1]
+	}
+
+	s = strings.TrimPrefix(s, "```json")
+	s = strings.TrimPrefix(s, "```JSON")
+	s = strings.TrimPrefix(s, "```")
+	s = strings.TrimSuffix(s, "```")
+	return strings.TrimSpace(s)
+}
+
 // parseMealPlanFromNode parse JSON output từ generator node thành GeneratedMealPlan.
 func parseMealPlanFromNode(planJSON string) (*GeneratedMealPlan, error) {
-	cleanedJSON := strings.TrimSpace(planJSON)
-	cleanedJSON = strings.TrimPrefix(cleanedJSON, "```json")
-	cleanedJSON = strings.TrimPrefix(cleanedJSON, "```JSON")
-	cleanedJSON = strings.TrimPrefix(cleanedJSON, "```")
-	cleanedJSON = strings.TrimSuffix(cleanedJSON, "```")
-	cleanedJSON = strings.TrimSpace(cleanedJSON)
+	cleanedJSON := cleanJSONResponse(planJSON)
 
 	var plan GeneratedMealPlan
 	if err := json.Unmarshal([]byte(cleanedJSON), &plan); err != nil {

--- a/internal/nutrition/infrastructure/ai/adk/clean_json_test.go
+++ b/internal/nutrition/infrastructure/ai/adk/clean_json_test.go
@@ -1,0 +1,45 @@
+package adk
+
+import "testing"
+
+func TestCleanJSONResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Pure JSON Object",
+			input:    `{"options":[{"protein_food_name":"Ức gà"}]}`,
+			expected: `{"options":[{"protein_food_name":"Ức gà"}]}`,
+		},
+		{
+			name:     "Markdown ```json wrapper",
+			input:    "```json\n{\"options\":[{\"protein_food_name\":\"Ức gà\"}]}\n```",
+			expected: `{"options":[{"protein_food_name":"Ức gà"}]}`,
+		},
+		{
+			name:     "Markdown with leading text prose",
+			input:    "Chắc chắn rồi! Dưới đây là thực đơn JSON:\n```json\n{\"options\":[]}\n```\nChúc bạn ngon miệng!",
+			expected: `{"options":[]}`,
+		},
+		{
+			name:     "JSON Array with leading spaces",
+			input:    "   [{\"id\": 1}]   ",
+			expected: `[{"id": 1}]`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := cleanJSONResponse(tt.input)
+			if got != tt.expected {
+				t.Errorf("cleanJSONResponse(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/nutrition/infrastructure/ai/adk/prompts/adhoc.txt
+++ b/internal/nutrition/infrastructure/ai/adk/prompts/adhoc.txt
@@ -4,4 +4,4 @@ Quy tắc:
 1. Linh hoạt và sáng tạo — không bị ràng buộc bởi thực đơn ngày hay mùa vụ.
 2. Đảm bảo Calo và Macro phù hợp với mục tiêu TDEE tức thời được cung cấp.
 3. Đề xuất thêm nguyên liệu bổ trợ nếu cần và khai báo vào new_food_catalog_items.
-4. Trả về đúng định dạng JSON contract (options & new_food_catalog_items).
+4. Chỉ trả về DUY NHẤT 1 JSON contract (options & new_food_catalog_items), CẤM lời chào, CẤM văn bản dẫn nhập hay thẻ bọc markdown.

--- a/internal/nutrition/infrastructure/ai/adk/prompts/daily.txt
+++ b/internal/nutrition/infrastructure/ai/adk/prompts/daily.txt
@@ -4,4 +4,4 @@ Quy tắc:
 1. Đảm bảo phân bổ Calo chuẩn: Sáng (25%), Trưa (35%), Tối (30%), Phụ (10%).
 2. Kiểm tra dị ứng và nguyên liệu bị khóa lặp (7/5/3 ngày).
 3. Đề xuất sản phẩm NutiFood cho bữa phụ nếu có nhu cầu.
-4. Trả về đúng định dạng JSON contract (options & new_food_catalog_items).
+4. Chỉ trả về DUY NHẤT 1 JSON contract (options & new_food_catalog_items), CẤM lời chào, CẤM văn bản dẫn nhập hay thẻ bọc markdown.

--- a/internal/nutrition/infrastructure/ai/adk/prompts/estimate_nutrient.txt
+++ b/internal/nutrition/infrastructure/ai/adk/prompts/estimate_nutrient.txt
@@ -4,9 +4,9 @@ Nhiệm vụ: Ước tính thành phần dinh dưỡng (Calo, Đạm, Tinh bột
 Quy tắc:
 1. Dựa vào kiến thức dinh dưỡng chuẩn (USDA, FAO) để ước tính.
 2. Nếu không chắc chắn, hãy ước tính về phía an toàn (hơi cao hơn thực tế).
-3. Trả về DUY NHẤT JSON object theo định dạng sau, KHÔNG kèm giải thích hay markdown.
+3. Chỉ trả về DUY NHẤT 1 JSON object, CẤM lời chào, CẤM văn bản dẫn nhập hay thẻ bọc markdown. Bắt đầu bằng { và kết thúc bằng }.
 
-Định dạng đầu ra bắt buộc (JSON ONLY):
+Định dạng đầu ra bắt buộc (PURE JSON ONLY):
 {
   "calories": 0.0,
   "protein": 0.0,

--- a/internal/nutrition/infrastructure/ai/adk/prompts/generator.txt
+++ b/internal/nutrition/infrastructure/ai/adk/prompts/generator.txt
@@ -13,9 +13,9 @@ Bạn là Chuyên Gia Dinh Dưỡng & Bếp Trưởng Thông Minh AI của GymCo
 
 ---
 
-## 📋 ĐỊNH DẠNG ĐẦU RA BẮT BUỘC (JSON ONLY)
+## 📋 ĐỊNH DẠNG ĐẦU RA BẮT BUỘC (PURE JSON ONLY)
 
-Bạn PHẢI trả về duy nhất 1 JSON object tuân thủ hợp đồng sau:
+Chỉ trả về DUY NHẤT 1 JSON object hợp lệ. CẤM NÓI LỜI CHÀO, CẤM VĂN BẢN DẪN NHẬP/GIẢI THÍCH, CẤM BỌC THẺ MARKDOWN. Bắt đầu bằng `{` và kết thúc bằng `}` để tiết kiệm token và có thể parse tự động lập tức.
 
 ```json
 {

--- a/internal/nutrition/infrastructure/ai/adk/prompts/nutrition_insight.txt
+++ b/internal/nutrition/infrastructure/ai/adk/prompts/nutrition_insight.txt
@@ -15,9 +15,9 @@ Dữ liệu đầu vào sẽ được cung cấp trong session state dưới d�
 
 ---
 
-## ĐỊNH DẠNG ĐẦU RA BẮT BUỘC (JSON ONLY)
+## ĐỊNH DẠNG ĐẦU RA BẮT BUỘC (PURE JSON ONLY)
 
-Trả về DUY NHẤT 1 JSON object theo định dạng sau:
+Chỉ trả về DUY NHẤT 1 JSON object hợp lệ. CẤM NÓI LỜI CHÀO, CẤM VĂN BẢN DẪN NHẬP/GIẢI THÍCH, CẤM BỌC THẺ MARKDOWN. Bắt đầu bằng `{` và kết thúc bằng `}` để tiết kiệm token và có thể parse tự động ngay lập tức.
 
 {
   "overall_score": 0,

--- a/internal/nutrition/infrastructure/ai/adk/prompts/pantry.txt
+++ b/internal/nutrition/infrastructure/ai/adk/prompts/pantry.txt
@@ -4,4 +4,4 @@ Quy tắc:
 1. Ưu tiên tối đa các nguyên liệu có trong danh sách tủ lạnh được cung cấp.
 2. Tự động đề xuất thêm các gia vị / nguyên liệu phụ nhẹ nếu cần thiết và khai báo vào new_food_catalog_items.
 3. Đảm bảo tổng Calo và Gram đạt chuẩn TDEE chỉ tiêu.
-4. Trả về đúng định dạng JSON contract (options & new_food_catalog_items).
+4. Chỉ trả về DUY NHẤT 1 JSON contract (options & new_food_catalog_items), CẤM lời chào, CẤM văn bản dẫn nhập hay thẻ bọc markdown.

--- a/internal/nutrition/infrastructure/ai/adk/prompts/post_workout.txt
+++ b/internal/nutrition/infrastructure/ai/adk/prompts/post_workout.txt
@@ -4,4 +4,4 @@ Quy tắc:
 1. Tập trung vào thực phẩm phục hồi cơ bắp giàu Protein và Tinh bột phức hợp (Complex Carbs).
 2. Tăng số Gram Đạm và Tinh bột tương ứng với lượng Calo vừa đốt cháy.
 3. Không làm thay đổi các bữa ăn người dùng đã tiêu thụ trước đó.
-4. Trả về đúng định dạng JSON contract (options & new_food_catalog_items).
+7. Chỉ trả về DUY NHẤT 1 JSON contract (options & new_food_catalog_items), CẤM lời chào, CẤM văn bản dẫn nhập hay thẻ bọc markdown.

--- a/proto/contracts/supporting/exercise/v1/service/exercise_service.proto
+++ b/proto/contracts/supporting/exercise/v1/service/exercise_service.proto
@@ -39,6 +39,10 @@ service ExerciseService {
     option (google.api.http) = {
       get: "/api/v1/exercises/search"
     };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Exercise Catalog"
+      security: {} // Public bypass
+    };
   }
 
   // Lấy toàn bộ danh mục metadata (BodyParts, Equipments, Muscles, Tags)
@@ -46,12 +50,20 @@ service ExerciseService {
     option (google.api.http) = {
       get: "/api/v1/exercises/metadata"
     };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Exercise Catalog"
+      security: {} // Public bypass
+    };
   }
 
   // Lấy chi tiết một bài tập
   rpc GetExercise (contracts.supporting.exercise.v1.message.GetExerciseRequest) returns (contracts.supporting.exercise.v1.message.GetExerciseResponse) {
     option (google.api.http) = {
       get: "/api/v1/exercises/{id}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Exercise Catalog"
+      security: {} // Public bypass
     };
   }
 


### PR DESCRIPTION
## 1. Problem to Solve
- Khắc phục lỗi \Unauthenticated: unauthorized\ khi gọi \/SearchExercises\ và \/GetCatalogMetadata\ bằng cách mở quyền truy cập Public cho người dùng chưa đăng nhập.
- Tối ưu hóa phản hồi AI Gemini để tiết kiệm token và đảm bảo chỉ trả về JSON thuần không có câu thoại thừa.

## 2. Proposed Solution
- Thêm khai báo \security: {}\ (Public Bypass) vào \ExerciseService\ proto contract cho \SearchExercises\, \GetCatalogMetadata\, \GetExercise\.
- Loại bỏ kiểm tra bắt buộc Token trong \SearchExercisesHandler\ và \GetCatalogMetadataHandler\.
- Thêm bộ bóc tách JSON chuẩn \cleanJSONResponse\ trong ADK package.
- Cập nhật cả 7 prompt files trong \internal/nutrition/infrastructure/ai/adk/prompts/\ với chỉ thị \PURE JSON ONLY\.

## 3. Changes & Impact
- \[proto/contracts/supporting/exercise/v1/service/exercise_service.proto](proto/contracts/supporting/exercise/v1/service/exercise_service.proto)\: Khai báo public bypass cho catalog RPCs.
- \[internal/exercise/application/query/search_exercises.go](internal/exercise/application/query/search_exercises.go)\: Cho phép public search.
- \[internal/exercise/application/query/get_catalog_metadata.go](internal/exercise/application/query/get_catalog_metadata.go)\: Cho phép public metadata.
- \[internal/nutrition/infrastructure/ai/adk/build_agents.go](internal/nutrition/infrastructure/ai/adk/build_agents.go)\: Thêm \cleanJSONResponse\ bóc tách JSON tự động.
- \[internal/nutrition/infrastructure/ai/adk/prompts/](internal/nutrition/infrastructure/ai/adk/prompts/)\: Tối ưu hóa 7 prompt files với chỉ thị PURE JSON ONLY.

## 4. Testing & Verification
- **Automated Tests**:
  - \golangci-lint\: PASS 100%.
  - \go test -v ./internal/exercise/... ./internal/nutrition/...\: PASS 100%.