### PR TITLE
🐛 fix(nutrition): add AI rate limit cooldown and quiet GORM record not found logs

### DIFF
--- a/internal/nutrition/infrastructure/ai/adk/fallback_llm.go
+++ b/internal/nutrition/infrastructure/ai/adk/fallback_llm.go
@@ -7,6 +7,7 @@ import (
 	"iter"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/viethung213/gym-companion/internal/nutrition/infrastructure/config"
 	"google.golang.org/adk/v2/model"
@@ -23,7 +24,10 @@ type FallbackLLM struct {
 // NewFallbackLLMFromEnv tạo FallbackLLM đọc danh sách model từ cấu hình module Nutrition.
 func NewFallbackLLMFromEnv(ctx context.Context) (model.LLM, error) {
 	cfg := config.LoadConfig()
+	defaultModels := []string{"gemini-2.5-flash", "gemini-2.0-flash", "gemini-2.5-flash-lite", "gemini-1.5-flash", "gemini-1.5-pro"}
 	rawNames := append([]string{cfg.GeminiModel}, strings.Split(cfg.GeminiFallbackModels, ",")...)
+	rawNames = append(rawNames, defaultModels...)
+
 	modelNames := make([]string, 0, len(rawNames))
 	seen := make(map[string]bool)
 
@@ -103,11 +107,31 @@ func (f *FallbackLLM) GenerateContent(ctx context.Context, req *model.LLMRequest
 			}
 
 			// Kiểm tra nếu lỗi do Quota / Rate limit (429) và còn model dự phòng
-			if isQuotaOrRateLimitErr(lastErr) && idx < len(f.models)-1 {
-				nextModel := f.models[idx+1]
-				log.Printf("[FallbackLLM] Model %s hit quota/rate limit error (%v). Auto-falling back to %s...",
-					m.Name(), lastErr, nextModel.Name())
-				continue
+			if isQuotaOrRateLimitErr(lastErr) {
+				if idx < len(f.models)-1 {
+					nextModel := f.models[idx+1]
+					log.Printf("[FallbackLLM] Model %s hit quota/rate limit error (%v). Auto-falling back to %s after 1s...",
+						m.Name(), lastErr, nextModel.Name())
+					time.Sleep(1 * time.Second)
+					continue
+				}
+
+				// Nếu là model cuối cùng mà bị 429, chờ 2s rồi thử lại 1 lần cuối
+				log.Printf("[FallbackLLM] Model %s hit rate limit (429). Retrying after 2s cooldown...", m.Name())
+				time.Sleep(2 * time.Second)
+				var retryErr error
+				for resp, err := range m.GenerateContent(ctx, req, stream) {
+					if err != nil {
+						retryErr = err
+						break
+					}
+					if !yield(resp, nil) {
+						return
+					}
+				}
+				if retryErr == nil {
+					return
+				}
 			}
 
 			// Nếu không phải lỗi 429 hoặc đã hết model dự phòng, trả về lỗi

--- a/internal/workout_execution/module.go
+++ b/internal/workout_execution/module.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -27,6 +28,7 @@ import (
 	workoutGRPC "github.com/viethung213/gym-companion/internal/workout_execution/transport/grpc"
 	gormPostgres "gorm.io/driver/postgres"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 // ModuleDeps contains external dependencies required to boot the Workout Execution module.
@@ -38,9 +40,20 @@ type ModuleDeps struct {
 // Initialize wires dependencies, registers gRPC services, and starts background workers.
 func Initialize(ctx context.Context, deps ModuleDeps) (*workoutGRPC.GRPCHandler, func(), error) {
 
+	gormLogger := logger.New(
+		log.New(os.Stdout, "\r\n", log.LstdFlags),
+		logger.Config{
+			SlowThreshold:             200 * time.Millisecond,
+			LogLevel:                  logger.Warn,
+			IgnoreRecordNotFoundError: true,
+			Colorful:                  false,
+		},
+	)
+
 	gormDB, err := gorm.Open(gormPostgres.New(gormPostgres.Config{
 		Conn: deps.DB,
 	}), &gorm.Config{
+		Logger:                 gormLogger,
 		PrepareStmt:            false,
 		SkipDefaultTransaction: true,
 	})


### PR DESCRIPTION
## 1. Problem to Solve
- Khắc phục lỗi \RESOURCE_EXHAUSTED / 429 Rate Limit\ khi gọi Gemini AI Free Tier (15 RPM) bằng cách thêm thời gian nghỉ cooldown và chuỗi 5 model dự phòng mặc định.
- Tắt các dòng log rác \ecord not found\ từ GORM logger khi khởi tạo seed data bài tập để tránh dính lỗi Railway Log Rate Limit (\Messages dropped: 83\).

## 2. Proposed Solution
- \[internal/nutrition/infrastructure/ai/adk/fallback_llm.go](internal/nutrition/infrastructure/ai/adk/fallback_llm.go)\: Tự động bổ sung 5 model fallback (\gemini-2.5-flash\, \gemini-2.0-flash\, \gemini-2.5-flash-lite\, \gemini-1.5-flash\, \gemini-1.5-pro\) và thêm thời gian nghỉ \1s\/\2s\ khi bị rate limit.
- \[internal/workout_execution/module.go](internal/workout_execution/module.go)\: Cấu hình \gormLogger\ với \IgnoreRecordNotFoundError: true\.

## 3. Testing & Verification
- \go test -v ./internal/nutrition/infrastructure/ai/adk/... ./internal/workout_execution/...\: PASS 100%.
- \golangci-lint\: PASS 100%.