### PR TITLE
✨ feat(nutrition): add Auto-Healing for food IDs in PlanValidator and mandate exact UUIDs in generator prompt

### DIFF
--- a/internal/nutrition/infrastructure/ai/adk/prompts/generator.txt
+++ b/internal/nutrition/infrastructure/ai/adk/prompts/generator.txt
@@ -3,7 +3,7 @@ Bạn là Chuyên Gia Dinh Dưỡng & Bếp Trưởng Thông Minh AI của GymCo
 ---
 
 ## 🎯 QUY TẮC PHỐI MÓN
-1. Ưu tiên chọn thực phẩm từ danh mục Active CSDL được cung cấp (`available_ingredients`).
+1. PHẢI dùng ĐÚNG CHÍNH XÁC `id` (chuỗi UUID) của từng thực phẩm được cung cấp trong `available_ingredients`. CẤM BỊA RA CÁC ID DẠNG 'PRO_01', 'CARB_01', 'VEG_01'.
 2. Nếu sử dụng thêm các nguyên liệu bổ sung hoặc gia vị MỚI chưa có trong CSDL (ví dụ: Dầu oliu, Sốt chanh dây, Hạt chia...):
    - Bạn PHẢI khai báo thông số dinh dưỡng của nguyên liệu mới đó trong mảng `new_food_catalog_items`.
    - Cung cấp đầy đủ: `name`, `category`, `calories_per_100g`, `protein_per_100g`, `carbs_per_100g`, `fat_per_100g`, `allergen_tags`.

--- a/internal/nutrition/infrastructure/ai/adk/validator.go
+++ b/internal/nutrition/infrastructure/ai/adk/validator.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/viethung213/gym-companion/internal/nutrition/domain/aggregate"
 	"github.com/viethung213/gym-companion/internal/nutrition/domain/repository"
 	"github.com/viethung213/gym-companion/internal/nutrition/domain/vo"
 )
@@ -42,40 +43,73 @@ func (v *planValidator) validate(ctx context.Context, plan *GeneratedMealPlan, r
 		opt := &plan.Options[idx]
 		optIssues := make([]string, 0)
 
-		// 1. Verify Protein Food in DB Catalog
+		// 1. Verify & Auto-Heal Protein Food
+		var proteinItem *aggregate.FoodItem
 		if opt.ProteinFoodID != "" {
 			item, err := v.foodRepo.FindByID(ctx, opt.ProteinFoodID)
-			if err != nil || item == nil {
-				optIssues = append(optIssues, fmt.Sprintf("option %d: protein_food_id '%s' not found in active catalog", idx+1, opt.ProteinFoodID))
-			} else {
-				for _, tag := range item.AllergenTags() {
-					if restrictionMap[strings.ToUpper(strings.TrimSpace(tag))] {
-						optIssues = append(optIssues, fmt.Sprintf("option %d: protein_food '%s' contains restricted allergen '%s'", idx+1, item.Name(), tag))
-					}
+			if err == nil && item != nil {
+				proteinItem = item
+			}
+		}
+		if proteinItem == nil && opt.ProteinFoodName != "" {
+			item, err := v.foodRepo.FindByName(ctx, opt.ProteinFoodName)
+			if err == nil && item != nil {
+				proteinItem = item
+				opt.ProteinFoodID = item.ID()
+			}
+		}
+		if proteinItem == nil && (opt.ProteinFoodID != "" || opt.ProteinFoodName != "") {
+			optIssues = append(optIssues, fmt.Sprintf("option %d: protein_food_id '%s' not found in active catalog", idx+1, opt.ProteinFoodID))
+		} else if proteinItem != nil {
+			for _, tag := range proteinItem.AllergenTags() {
+				if restrictionMap[strings.ToUpper(strings.TrimSpace(tag))] {
+					optIssues = append(optIssues, fmt.Sprintf("option %d: protein_food '%s' contains restricted allergen '%s'", idx+1, proteinItem.Name(), tag))
 				}
 			}
 		}
 
-		// 2. Verify Carb Food in DB Catalog
+		// 2. Verify & Auto-Heal Carb Food
+		var carbItem *aggregate.FoodItem
 		if opt.CarbFoodID != "" {
 			item, err := v.foodRepo.FindByID(ctx, opt.CarbFoodID)
-			if err != nil || item == nil {
-				optIssues = append(optIssues, fmt.Sprintf("option %d: carb_food_id '%s' not found in active catalog", idx+1, opt.CarbFoodID))
-			} else {
-				for _, tag := range item.AllergenTags() {
-					if restrictionMap[strings.ToUpper(strings.TrimSpace(tag))] {
-						optIssues = append(optIssues, fmt.Sprintf("option %d: carb_food '%s' contains restricted allergen '%s'", idx+1, item.Name(), tag))
-					}
+			if err == nil && item != nil {
+				carbItem = item
+			}
+		}
+		if carbItem == nil && opt.CarbFoodName != "" {
+			item, err := v.foodRepo.FindByName(ctx, opt.CarbFoodName)
+			if err == nil && item != nil {
+				carbItem = item
+				opt.CarbFoodID = item.ID()
+			}
+		}
+		if carbItem == nil && (opt.CarbFoodID != "" || opt.CarbFoodName != "") {
+			optIssues = append(optIssues, fmt.Sprintf("option %d: carb_food_id '%s' not found in active catalog", idx+1, opt.CarbFoodID))
+		} else if carbItem != nil {
+			for _, tag := range carbItem.AllergenTags() {
+				if restrictionMap[strings.ToUpper(strings.TrimSpace(tag))] {
+					optIssues = append(optIssues, fmt.Sprintf("option %d: carb_food '%s' contains restricted allergen '%s'", idx+1, carbItem.Name(), tag))
 				}
 			}
 		}
 
-		// 3. Verify Veggie Food in DB Catalog
+		// 3. Verify & Auto-Heal Veggie Food
+		var veggieItem *aggregate.FoodItem
 		if opt.VeggieFoodID != "" {
 			item, err := v.foodRepo.FindByID(ctx, opt.VeggieFoodID)
-			if err != nil || item == nil {
-				optIssues = append(optIssues, fmt.Sprintf("option %d: veggie_food_id '%s' not found in active catalog", idx+1, opt.VeggieFoodID))
+			if err == nil && item != nil {
+				veggieItem = item
 			}
+		}
+		if veggieItem == nil && opt.VeggieFoodName != "" {
+			item, err := v.foodRepo.FindByName(ctx, opt.VeggieFoodName)
+			if err == nil && item != nil {
+				veggieItem = item
+				opt.VeggieFoodID = item.ID()
+			}
+		}
+		if veggieItem == nil && (opt.VeggieFoodID != "" || opt.VeggieFoodName != "") {
+			optIssues = append(optIssues, fmt.Sprintf("option %d: veggie_food_id '%s' not found in active catalog", idx+1, opt.VeggieFoodID))
 		}
 
 		// 4. Verify Lockout Rules

--- a/internal/nutrition/infrastructure/ai/adk/validator_test.go
+++ b/internal/nutrition/infrastructure/ai/adk/validator_test.go
@@ -16,7 +16,12 @@ type mockFoodRepoForValidator struct {
 func (m *mockFoodRepoForValidator) FindByID(_ context.Context, id string) (*aggregate.FoodItem, error) {
 	return m.items[id], nil
 }
-func (m *mockFoodRepoForValidator) FindByName(_ context.Context, _ string) (*aggregate.FoodItem, error) {
+func (m *mockFoodRepoForValidator) FindByName(_ context.Context, name string) (*aggregate.FoodItem, error) {
+	for _, item := range m.items {
+		if item.Name() == name {
+			return item, nil
+		}
+	}
 	return nil, nil
 }
 func (m *mockFoodRepoForValidator) FindActiveCatalog(_ context.Context) ([]vo.FoodNutrient, error) {
@@ -55,5 +60,35 @@ func TestPlanValidator_Validate(t *testing.T) {
 
 	if len(outcome.Issues) == 0 {
 		t.Fatalf("expected validation issues for allergen and missing carb_food_id")
+	}
+}
+
+func TestPlanValidator_AutoHealing(t *testing.T) {
+	t.Parallel()
+
+	foodChicken := aggregate.NewFoodItem("real-uuid-chicken", "Ức gà tươi", "PROTEIN", 165, 31, 0, 3.6, nil, "CHICKEN", "", false)
+	repo := &mockFoodRepoForValidator{items: map[string]*aggregate.FoodItem{"real-uuid-chicken": foodChicken}}
+	validator := newPlanValidator(repo, vo.NewLockoutRegistry(nil))
+
+	plan := &GeneratedMealPlan{
+		Options: []GeneratedMealOption{
+			{
+				ProteinFoodID:   "PRO_01", // Dummy hallucinated ID
+				ProteinFoodName: "Ức gà tươi",
+			},
+		},
+	}
+
+	outcome, err := validator.validate(context.Background(), plan, nil, false)
+	if err != nil {
+		t.Fatalf("unexpected error validating: %v", err)
+	}
+
+	if len(outcome.Issues) > 0 {
+		t.Fatalf("expected 0 issues due to auto-healing, got: %v", outcome.Issues)
+	}
+
+	if plan.Options[0].ProteinFoodID != "real-uuid-chicken" {
+		t.Fatalf("expected ProteinFoodID to be healed to 'real-uuid-chicken', got '%s'", plan.Options[0].ProteinFoodID)
 	}
 }

--- a/internal/shared/database/migrations/09-seed-food-items.sql
+++ b/internal/shared/database/migrations/09-seed-food-items.sql
@@ -27,7 +27,7 @@ VALUES
     ('Cá hồi phi lê tươi', 'PROTEIN', 208.0, 20.0, 0.0, 13.0, '["FISH"]'::jsonb, 'FISH', NULL, FALSE, 'Active'),
     ('Cá ngừ đại dương tươi', 'PROTEIN', 130.0, 28.0, 0.0, 1.0, '["FISH"]'::jsonb, 'FISH', NULL, FALSE, 'Active'),
     ('Cá ngừ ngâm nước khoáng (Hộp)', 'PROTEIN', 116.0, 26.0, 0.0, 1.0, '["FISH"]'::jsonb, 'FISH', NULL, FALSE, 'Active'),
-    ('Cá thu tươi', 'PROTEIN蛋白质', 205.0, 19.0, 0.0, 13.9, '["FISH"]'::jsonb, 'FISH', NULL, FALSE, 'Active'),
+    ('Cá thu tươi', 'PROTEIN', 205.0, 19.0, 0.0, 13.9, '["FISH"]'::jsonb, 'FISH', NULL, FALSE, 'Active'),
     ('Cá bass (Cá chẽm)', 'PROTEIN', 124.0, 23.0, 0.0, 3.0, '["FISH"]'::jsonb, 'FISH', NULL, FALSE, 'Active'),
     ('Cá lóc đồng', 'PROTEIN', 97.0, 18.2, 0.0, 2.7, '["FISH"]'::jsonb, 'FISH', NULL, FALSE, 'Active'),
     ('Cá chép tươi', 'PROTEIN', 127.0, 16.0, 0.0, 5.6, '["FISH"]'::jsonb, 'FISH', NULL, FALSE, 'Active'),


### PR DESCRIPTION
## 1. Problem to Solve
- Khắc phục lỗi AI Gemini tự tưởng tượng ra các ID giả lập (\PRO_01\, \CARB_01\, \VEG_01\) làm \PlanValidator\ từ chối thực đơn với lỗi \ood_id not found in active catalog\.

## 2. Proposed Solution
- **Chỉ thị Prompt Cứng**: Cập nhật [\prompts/generator.txt\](internal/nutrition/infrastructure/ai/adk/prompts/generator.txt) ép buộc AI dùng ĐÚNG CHÍNH XÁC \id\ (chuỗi UUID) từ danh mục \vailable_ingredients\, cấm tự bịa ID \PRO_01\.
- **Cơ chế Tự Sửa Lỗi (Auto-Healing)**: Trong [\alidator.go\](internal/nutrition/infrastructure/ai/adk/validator.go), nếu AI trả về ID không tồn tại nhưng tên thực phẩm đúng, \planValidator\ tự động tra cứu DB theo tên \FindByName\ và tự phục hồi \opt.FoodID\ về đúng UUID chính xác.

## 3. Testing & Verification
- Unit test mới \TestPlanValidator_AutoHealing\ trong [\alidator_test.go\](internal/nutrition/infrastructure/ai/adk/validator_test.go) $\rightarrow$ PASS 100%.
- Full ADK Test Suite: PASS 100%.
- \golangci-lint\: PASS 100%.