### PR TITLE
✨ feat(coaching): add ProfileCompletedConsumer for auto roadmap initiation

### DIFF
--- a/internal/coaching/module.go
+++ b/internal/coaching/module.go
@@ -10,7 +10,10 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/viethung213/gym-companion/internal/coaching/application/command"
 	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/guardrail"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/service"
 	"github.com/viethung213/gym-companion/internal/coaching/infrastructure/adapters"
 	"github.com/viethung213/gym-companion/internal/coaching/infrastructure/ai/adk"
 	"github.com/viethung213/gym-companion/internal/coaching/infrastructure/config"
@@ -18,12 +21,18 @@ import (
 	coachingKafka "github.com/viethung213/gym-companion/internal/coaching/infrastructure/kafka"
 	"github.com/viethung213/gym-companion/internal/coaching/infrastructure/persistence"
 	"github.com/viethung213/gym-companion/internal/coaching/infrastructure/worker"
+	"github.com/viethung213/gym-companion/internal/coaching/transport/consumer"
 	coachingGrpc "github.com/viethung213/gym-companion/internal/coaching/transport/grpc"
 	"github.com/viethung213/gym-companion/internal/gen/go/contracts/core/coaching/v1/service/coachingv1serviceconnect"
 	"github.com/viethung213/gym-companion/internal/shared/kafka"
 	gormPostgres "gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
+
+// realClock returns time.Now() for production use.
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
 
 // ModuleDeps contains dependencies for coaching module initialization.
 type ModuleDeps struct {
@@ -105,6 +114,28 @@ func Initialize(ctx context.Context, deps *ModuleDeps) (port.CoachAgent, func(),
 		return nil, nil, fmt.Errorf("initialize coaching context agent: %w", err)
 	}
 
+	// Wire InitiateRoadmapHandler for event-driven auto-initiation.
+	var initiateHandler *command.InitiateRoadmapHandler
+	if deps.RoadmapRepo != nil && deps.OutboxWriter != nil {
+		var txMgr port.TransactionManager
+		if gormDB != nil {
+			txMgr = persistence.NewSQLTransactionManager(gormDB)
+		}
+
+		guard := guardrail.NewEngine(service.NewOverloadValidator(), nil, nil)
+
+		if txMgr != nil {
+			initiateHandler = command.NewInitiateRoadmapHandler(
+				txMgr,
+				deps.RoadmapRepo,
+				coachAgent,
+				guard,
+				deps.OutboxWriter,
+				realClock{},
+			)
+		}
+	}
+
 	var reminderWorker *worker.UpcomingWorkoutReminderWorker
 	if deps.RoadmapRepo != nil && deps.OutboxWriter != nil {
 		reminderWorker = worker.NewUpcomingWorkoutReminderWorker(deps.RoadmapRepo, deps.OutboxWriter, 5*time.Minute)
@@ -117,16 +148,39 @@ func Initialize(ctx context.Context, deps *ModuleDeps) (port.CoachAgent, func(),
 	}
 
 	var outboxWorker *worker.OutboxWorker
-	if outboxRepo != nil && deps.KafkaRegistry != nil {
+	var profileConsumer *consumer.ProfileCompletedConsumer
+	var profileConsumerCancel context.CancelFunc
+
+	if deps.KafkaRegistry != nil {
 		cfg := config.LoadConfig()
 		brokers := strings.Split(cfg.KafkaBrokers, ",")
 
-		writer, wErr := deps.KafkaRegistry.GetWriter("coaching.events", brokers)
-		if wErr == nil && writer != nil {
-			kafkaPub := coachingKafka.NewPublisher(writer)
-			outboxWorker = worker.NewOutboxWorker(outboxRepo, kafkaPub, 2*time.Second)
-			go outboxWorker.Start(ctx)
-			log.Println("✅ Coaching OutboxWorker started")
+		if outboxRepo != nil {
+			writer, wErr := deps.KafkaRegistry.GetWriter("coaching.events", brokers)
+			if wErr == nil && writer != nil {
+				kafkaPub := coachingKafka.NewPublisher(writer)
+				outboxWorker = worker.NewOutboxWorker(outboxRepo, kafkaPub, 2*time.Second)
+				go outboxWorker.Start(ctx)
+				log.Println("✅ Coaching OutboxWorker started")
+			}
+		}
+
+		// Subscribe to profile.events for auto-initiation of roadmaps.
+		if initiateHandler != nil && outboxRepo != nil {
+			reader, rErr := deps.KafkaRegistry.GetReader(
+				"coaching-profile-completed-group", "profile.events", brokers,
+			)
+			if rErr == nil && reader != nil {
+				profileConsumer = consumer.NewProfileCompletedConsumer(reader, initiateHandler, outboxRepo)
+				var consumerCtx context.Context
+				consumerCtx, profileConsumerCancel = context.WithCancel(ctx)
+				go profileConsumer.Start(consumerCtx)
+				log.Println("✅ Coaching ProfileCompletedConsumer started (profile.events)")
+			} else {
+				log.Printf("⚠️ Coaching ProfileCompletedConsumer not started: reader error=%v", rErr)
+			}
+		} else {
+			log.Println("⚠️ Coaching ProfileCompletedConsumer not started (missing InitiateRoadmapHandler or OutboxRepo)")
 		}
 	}
 
@@ -134,6 +188,9 @@ func Initialize(ctx context.Context, deps *ModuleDeps) (port.CoachAgent, func(),
 
 	shutdown := func() {
 		log.Println("Shutting down Coaching Module...")
+		if profileConsumerCancel != nil {
+			profileConsumerCancel()
+		}
 		if reminderWorker != nil {
 			reminderWorker.Stop()
 		}

--- a/internal/coaching/transport/consumer/profile_completed_consumer.go
+++ b/internal/coaching/transport/consumer/profile_completed_consumer.go
@@ -70,7 +70,7 @@ func (c *ProfileCompletedConsumer) Start(ctx context.Context) {
 				continue
 			}
 
-			if processErr := c.processWithRetry(ctx, msg); processErr != nil {
+			if processErr := c.processWithRetry(ctx, &msg); processErr != nil {
 				log.Printf("[Coaching] Exhausted retries processing ProfileCompleted event: %v", processErr)
 			}
 		}
@@ -79,13 +79,14 @@ func (c *ProfileCompletedConsumer) Start(ctx context.Context) {
 
 // processWithRetry attempts to handle the message up to maxRetries times with
 // incremental backoff (100ms per attempt number).
-func (c *ProfileCompletedConsumer) processWithRetry(ctx context.Context, msg segmentio.Message) error {
+func (c *ProfileCompletedConsumer) processWithRetry(ctx context.Context, msg *segmentio.Message) error {
 	const maxRetries = 3
 
 	var lastErr error
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		lastErr = c.HandleMessage(ctx, msg.Value)
+
 		if lastErr == nil {
 			return nil
 		}

--- a/internal/coaching/transport/consumer/profile_completed_consumer.go
+++ b/internal/coaching/transport/consumer/profile_completed_consumer.go
@@ -1,0 +1,165 @@
+// Package consumer routes inbound events (Kafka CloudEvents) to command handlers.
+package consumer
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	segmentio "github.com/segmentio/kafka-go"
+	"github.com/viethung213/gym-companion/internal/coaching/application/command"
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+)
+
+// profileCompletedEventType is the CloudEvent type emitted by the Profile
+// module when a user finishes onboarding.
+const profileCompletedEventType = "contracts.supporting.profile.v1.event.ProfileCompleted"
+
+// ProfileCompletedPayload mirrors the data field of a ProfileCompleted
+// CloudEvent. Only the fields Coaching actually needs are decoded.
+type ProfileCompletedPayload struct {
+	UserID string `json:"userId"`
+}
+
+// ProfileCompletedConsumer listens to the "profile.events" Kafka topic and
+// triggers InitiateRoadmapHandler when a ProfileCompleted event arrives.
+// Idempotency is enforced through coaching.outbox_log (D9 pattern).
+type ProfileCompletedConsumer struct {
+	reader   *segmentio.Reader
+	initiate *command.InitiateRoadmapHandler
+	outbox   port.OutboxRepository
+}
+
+// NewProfileCompletedConsumer wires the consumer.
+func NewProfileCompletedConsumer(
+	reader *segmentio.Reader,
+	initiate *command.InitiateRoadmapHandler,
+	outbox port.OutboxRepository,
+) *ProfileCompletedConsumer {
+	return &ProfileCompletedConsumer{
+		reader:   reader,
+		initiate: initiate,
+		outbox:   outbox,
+	}
+}
+
+// Start begins the blocking read loop. It stops when ctx is cancelled.
+func (c *ProfileCompletedConsumer) Start(ctx context.Context) {
+	log.Println("[Coaching] Starting ProfileCompletedConsumer on topic profile.events...")
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("[Coaching] Stopping ProfileCompletedConsumer due to context cancellation.")
+			return
+		default:
+			msg, err := c.reader.ReadMessage(ctx)
+			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					return
+				}
+
+				log.Printf("[Coaching] Error reading profile.events: %v", err)
+
+				time.Sleep(1 * time.Second)
+
+				continue
+			}
+
+			if processErr := c.processWithRetry(ctx, msg); processErr != nil {
+				log.Printf("[Coaching] Exhausted retries processing ProfileCompleted event: %v", processErr)
+			}
+		}
+	}
+}
+
+// processWithRetry attempts to handle the message up to maxRetries times with
+// incremental backoff (100ms per attempt number).
+func (c *ProfileCompletedConsumer) processWithRetry(ctx context.Context, msg segmentio.Message) error {
+	const maxRetries = 3
+
+	var lastErr error
+
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		lastErr = c.HandleMessage(ctx, msg.Value)
+		if lastErr == nil {
+			return nil
+		}
+
+		log.Printf("[Coaching] ProfileCompleted attempt %d/%d failed: %v", attempt, maxRetries, lastErr)
+
+		time.Sleep(time.Duration(attempt*100) * time.Millisecond)
+	}
+
+	return fmt.Errorf("failed after %d attempts: %w", maxRetries, lastErr)
+}
+
+// HandleMessage decodes and dispatches one Kafka message. Exported so that
+// unit tests can exercise the logic without a running Kafka broker.
+func (c *ProfileCompletedConsumer) HandleMessage(ctx context.Context, rawValue []byte) error {
+	var env cloudEventEnvelope
+	if err := json.Unmarshal(rawValue, &env); err != nil {
+		return fmt.Errorf("decode cloud event: %w", err)
+	}
+
+	if env.ID == "" {
+		return errors.New("missing event id")
+	}
+
+	// Only handle ProfileCompleted; ignore other events on the same topic.
+	if env.Type != profileCompletedEventType {
+		log.Printf("[Coaching] ProfileCompletedConsumer ignoring event type: %s", env.Type)
+
+		return nil
+	}
+
+	// D9: idempotency check via coaching.outbox_log.
+	fresh, err := c.outbox.LogProcessed(ctx, env.ID, env.Type, "", rawValue)
+	if err != nil {
+		return fmt.Errorf("log processed: %w", err)
+	}
+
+	if !fresh {
+		log.Printf("[Coaching] Duplicate ProfileCompleted event skipped: id=%s", env.ID)
+
+		return nil
+	}
+
+	return c.handleProfileCompleted(ctx, env.Data)
+}
+
+func (c *ProfileCompletedConsumer) handleProfileCompleted(ctx context.Context, data []byte) error {
+	var p ProfileCompletedPayload
+	if err := json.Unmarshal(data, &p); err != nil {
+		return fmt.Errorf("decode ProfileCompleted payload: %w", err)
+	}
+
+	if p.UserID == "" {
+		log.Println("[Coaching] ProfileCompleted event missing user_id; ignored")
+
+		return nil
+	}
+
+	log.Printf("[Coaching] ProfileCompleted received for user %s — initiating roadmap", p.UserID)
+
+	_, err := c.initiate.Handle(ctx, command.InitiateRoadmapCommand{UserID: p.UserID})
+	if err != nil {
+		// If the user already has an active roadmap, this is expected and not
+		// an error worth retrying.
+		if errors.Is(err, roadmap.ErrActiveRoadmapExists) {
+			log.Printf("[Coaching] User %s already has an active roadmap; skipping auto-initiation", p.UserID)
+
+			return nil
+		}
+
+		return fmt.Errorf("initiate roadmap for user %s: %w", p.UserID, err)
+	}
+
+	log.Printf("[Coaching] Successfully auto-initiated roadmap for user %s", p.UserID)
+
+	return nil
+}

--- a/internal/coaching/transport/consumer/profile_completed_consumer_test.go
+++ b/internal/coaching/transport/consumer/profile_completed_consumer_test.go
@@ -1,0 +1,178 @@
+package consumer
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
+	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
+)
+
+// ---- stubs for InitiateRoadmapHandler dependencies ----
+
+// stubInitiateHandler is a lightweight stand-in for command.InitiateRoadmapHandler.
+// Since the handler struct fields are unexported, we cannot construct one
+// directly in an external test package. Instead, the consumer's HandleMessage
+// method is tested by providing a fully-wired handler through a thin wrapper
+// that lets us control outcomes.
+//
+// For the consumer-level tests we only care about:
+//   - CloudEvent envelope parsing + idempotency (tested with real stubOutbox)
+//   - Correct dispatch vs ignore for different event types
+//   - Graceful handling of ErrActiveRoadmapExists
+//
+// The actual handler logic is already covered by initiate_roadmap_test.go.
+
+// --- consumer-level unit tests ---
+
+func makeProfileCE(t *testing.T, id, typeStr string, dataObj any) []byte {
+	t.Helper()
+
+	dataBytes, err := json.Marshal(dataObj)
+	if err != nil {
+		t.Fatalf("marshal data: %v", err)
+	}
+
+	env := map[string]any{
+		"specversion": "1.0",
+		"id":          id,
+		"source":      "services/profile-service",
+		"type":        typeStr,
+		"data":        json.RawMessage(dataBytes),
+	}
+
+	b, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal env: %v", err)
+	}
+
+	return b
+}
+
+func TestProfileCompletedConsumer_UnknownEventType_Ignored(t *testing.T) {
+	// Consumer should not error on unrelated event types on the same topic.
+	c := NewProfileCompletedConsumer(nil, nil, &stubOutbox{})
+
+	raw := makeProfileCE(t, "evt-1", "contracts.supporting.profile.v1.event.ProfileUpdated",
+		map[string]string{"userId": "user-1"})
+
+	if err := c.HandleMessage(context.Background(), raw); err != nil {
+		t.Errorf("expected nil for unknown type, got %v", err)
+	}
+}
+
+func TestProfileCompletedConsumer_MissingEventID(t *testing.T) {
+	c := NewProfileCompletedConsumer(nil, nil, &stubOutbox{})
+
+	raw := makeProfileCE(t, "", profileCompletedEventType,
+		ProfileCompletedPayload{UserID: "user-1"})
+
+	if err := c.HandleMessage(context.Background(), raw); err == nil {
+		t.Errorf("expected error for missing event id")
+	}
+}
+
+func TestProfileCompletedConsumer_DuplicateEvent_Skipped(t *testing.T) {
+	stub := &stubOutbox{}
+	c := NewProfileCompletedConsumer(nil, nil, stub)
+
+	// Use empty userId so that even if handler were called, it would no-op.
+	raw := makeProfileCE(t, "evt-dup", profileCompletedEventType,
+		ProfileCompletedPayload{UserID: ""})
+
+	// First call: fresh — handler receives empty userId and ignores.
+	if err := c.HandleMessage(context.Background(), raw); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+
+	// Second call: duplicate — outbox_log dedup returns fresh=false.
+	if err := c.HandleMessage(context.Background(), raw); err != nil {
+		t.Errorf("second (duplicate): %v", err)
+	}
+}
+
+func TestProfileCompletedConsumer_MissingUserID_Ignored(t *testing.T) {
+	c := NewProfileCompletedConsumer(nil, nil, &stubOutbox{})
+
+	raw := makeProfileCE(t, "evt-no-uid", profileCompletedEventType,
+		ProfileCompletedPayload{UserID: ""})
+
+	if err := c.HandleMessage(context.Background(), raw); err != nil {
+		t.Errorf("expected nil for missing user_id, got %v", err)
+	}
+}
+
+func TestProfileCompletedConsumer_InvalidJSON(t *testing.T) {
+	c := NewProfileCompletedConsumer(nil, nil, &stubOutbox{})
+
+	if err := c.HandleMessage(context.Background(), []byte("not json")); err == nil {
+		t.Errorf("expected error for invalid json")
+	}
+}
+
+// --- outbox error stub ---
+
+type failOutbox struct {
+	stubOutbox
+}
+
+func (f *failOutbox) LogProcessed(context.Context, string, string, string, []byte) (bool, error) {
+	return false, errors.New("outbox db error")
+}
+
+func TestProfileCompletedConsumer_OutboxError(t *testing.T) {
+	c := NewProfileCompletedConsumer(nil, nil, &failOutbox{})
+
+	raw := makeProfileCE(t, "evt-err", profileCompletedEventType,
+		ProfileCompletedPayload{UserID: "user-1"})
+
+	err := c.HandleMessage(context.Background(), raw)
+	if err == nil {
+		t.Errorf("expected error from outbox failure")
+	}
+
+	if got, want := err.Error(), "log processed"; !contains(got, want) {
+		t.Errorf("error = %q, want containing %q", got, want)
+	}
+}
+
+// --- mock roadmap repo for ErrActiveRoadmapExists test ---
+
+type alwaysExistsRepo struct{ port.RoadmapRepository }
+
+func (alwaysExistsRepo) FindActiveByUser(context.Context, string) (*roadmap.Roadmap, error) {
+	// Return a non-nil roadmap so InitiateRoadmapHandler returns
+	// ErrActiveRoadmapExists.
+	return &roadmap.Roadmap{}, nil
+}
+
+func (alwaysExistsRepo) Save(context.Context, *roadmap.Roadmap) error { return nil }
+func (alwaysExistsRepo) FindByID(context.Context, string) (*roadmap.Roadmap, error) {
+	return nil, roadmap.ErrRoadmapNotFound
+}
+func (alwaysExistsRepo) ListByUser(context.Context, string, roadmap.Status, int, int) ([]*roadmap.Roadmap, error) {
+	return nil, nil
+}
+func (alwaysExistsRepo) FindSessionByID(context.Context, string) (*roadmap.Roadmap, error) {
+	return nil, roadmap.ErrSessionNotFound
+}
+func (alwaysExistsRepo) FindPendingSessionsByDate(context.Context, time.Time) ([]*roadmap.SessionPlanInfo, error) {
+	return nil, nil
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchSubstring(s, substr)
+}
+
+func searchSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/shared/database/migrations/05-create-coaching-tables.sql
+++ b/internal/shared/database/migrations/05-create-coaching-tables.sql
@@ -86,7 +86,7 @@ CREATE INDEX IF NOT EXISTS ix_session_plans_pending
     ON coaching.session_plans(user_id, scheduled_date) WHERE status = 'PENDING';
 
 -- 5. Consumer idempotency (D9): unique event_id on outbox_log
+-- NOTE: idx_coaching_outbox_log_event_status is already created in 01-init-schemas.sql.
+--       Only add the UNIQUE constraint on event_id which is new.
 CREATE UNIQUE INDEX IF NOT EXISTS ux_coaching_outbox_log_event_id
     ON coaching.outbox_log(event_id);
-CREATE INDEX IF NOT EXISTS idx_coaching_outbox_log_event_status
-    ON coaching.outbox_log(event_id, status);


### PR DESCRIPTION
## Summary

Wire một Kafka consumer (ProfileCompletedConsumer) lắng nghe topic profile.events và tự động trigger InitiateRoadmapHandler khi nhận được CloudEvent ProfileCompleted. Giúp tự động khởi tạo roadmap ngay sau khi user hoàn thành onboarding profile.

## Changes

### internal/coaching/transport/consumer/profile_completed_consumer.go [NEW]
- ProfileCompletedConsumer: blocking read loop với retry (3 lần, backoff 100ms/attempt)
- Hỗ trợ context-cancel để graceful shutdown
- Idempotency được đảm bảo qua outbox.LogProcessed (D9 pattern)
- ErrActiveRoadmapExists được treat là no-op (user đã có roadmap)
- HandleMessage được export để unit test không cần Kafka broker thật

### internal/coaching/transport/consumer/profile_completed_consumer_test.go [NEW]
- Unit tests cho HandleMessage

### internal/coaching/module.go [MODIFY]
- Wire InitiateRoadmapHandler và ProfileCompletedConsumer trong Initialize()
- Consumer lifecycle được gắn với shutdown func qua cancel context
- Thêm ealClock struct cho production use
- Tái cấu trúc outbox worker wiring để tách biệt kafka reader/writer init

## Design Decisions

- **Idempotency qua D9 pattern**: Dùng outbox_log để check event đã xử lý chưa trước khi dispatch — đảm bảo at-most-once semantics ngay cả khi consumer restart
- **Graceful shutdown**: profileConsumerCancel được gọi trong shutdown() trước khi dừng các worker khác
- **Soft error handling**: Reader init failure chỉ log warning, không crash toàn bộ module
