### PR TITLE
🐛 fix(db): strip UTF-8 BOM from SQL migrations to resolve PostgreSQL syntax error

### DIFF
--- a/internal/shared/database/migrator.go
+++ b/internal/shared/database/migrator.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"embed"
@@ -36,6 +37,9 @@ func RunAutoMigrations(ctx context.Context, db *sql.DB) error {
 		if err != nil {
 			return fmt.Errorf("read embedded migration file %s: %w", file, err)
 		}
+
+		// Strip UTF-8 Byte Order Mark (BOM) if present to avoid syntax errors in PostgreSQL parser
+		content = bytes.TrimPrefix(content, []byte("\xef\xbb\xbf"))
 
 		if _, err := db.ExecContext(ctx, string(content)); err != nil {
 			return fmt.Errorf("execute embedded migration %s: %w", file, err)

--- a/internal/shared/database/migrator_test.go
+++ b/internal/shared/database/migrator_test.go
@@ -1,0 +1,39 @@
+package database
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestStripBOM(t *testing.T) {
+	tests := []struct {
+		name string
+		give []byte
+		want []byte
+	}{
+		{
+			name: "With UTF-8 BOM",
+			give: append([]byte{0xEF, 0xBB, 0xBF}, []byte("SELECT 1;")...),
+			want: []byte("SELECT 1;"),
+		},
+		{
+			name: "Without BOM",
+			give: []byte("SELECT 1;"),
+			want: []byte("SELECT 1;"),
+		},
+		{
+			name: "Empty slice",
+			give: []byte{},
+			want: []byte{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := bytes.TrimPrefix(tt.give, []byte("\xef\xbb\xbf"))
+			if !bytes.Equal(got, tt.want) {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### 1. Problem to Solve
When running database auto-migrations on startup, PostgreSQL failed with syntax error `pq: syntax error at or near ""` at position 1:1 (42601) when executing `07-seed-exercises.sql`. This was caused by an invisible UTF-8 Byte Order Mark (BOM) (`0xEF, 0xBB, 0xBF`) at the beginning of the file.

### 2. Proposed Solution
- Stripped the UTF-8 BOM header from `07-seed-exercises.sql`.
- Added defensive `bytes.TrimPrefix(content, []byte("\xef\xbb\xbf"))` in `RunAutoMigrations` ([internal/shared/database/migrator.go](internal/shared/database/migrator.go)) to automatically strip BOM from embedded SQL migrations before sending them to PostgreSQL.
- Added unit test `TestStripBOM` in [internal/shared/database/migrator_test.go](internal/shared/database/migrator_test.go).

### 3. Changes & Impact
- `[internal/shared/database/migrations/07-seed-exercises.sql](internal/shared/database/migrations/07-seed-exercises.sql)`: Stripped leading 3 BOM bytes.
- `[internal/shared/database/migrator.go](internal/shared/database/migrator.go)`: Automatically strip BOM from migration content before execution.
- `[internal/shared/database/migrator_test.go](internal/shared/database/migrator_test.go)`: Unit tests for BOM stripping logic.

### 4. Testing & Verification
- **Automated Tests**: Executed `go test -v ./internal/shared/database/...` (PASSED).
- **Build Check**: Executed `go build ./cmd/api` (PASSED).
