### PR TITLE
🐛 fix(nutrition/ai): export food nutrient DTO JSON tags for ADK LLM context

### DIFF
--- a/internal/nutrition/infrastructure/ai/adk/agent.go
+++ b/internal/nutrition/infrastructure/ai/adk/agent.go
@@ -203,13 +203,16 @@ func (a *NutritionAgent) SelectCreativeMealOptions(
 	promptCtx repository.AIMenuPromptContext,
 	lockoutRegistry vo.LockoutRegistry,
 ) ([]repository.GeneratedRecipeResult, error) {
+	filteredFoods := lockoutRegistry.FilterAvailableIngredients(promptCtx.AvailableIngredients, promptCtx.PlanDate)
+	availableDTOs := ToFoodNutrientDTOs(filteredFoods)
+
 	internal := NutritionPromptContext{
 		UserID:               promptCtx.UserID,
 		PlanDate:             promptCtx.PlanDate,
 		MealType:             promptCtx.MealType,
 		TargetMealCalories:   promptCtx.TargetMealCalories,
 		UserRestrictions:     promptCtx.UserRestrictions,
-		AvailableIngredients: promptCtx.AvailableIngredients,
+		AvailableIngredients: availableDTOs,
 	}
 
 	var (
@@ -233,10 +236,9 @@ func (a *NutritionAgent) SelectCreativeMealOptions(
 	}
 
 	validator := newPlanValidator(a.foodRepo, lockoutRegistry)
-	availableFoods := lockoutRegistry.FilterAvailableIngredients(internal.AvailableIngredients, internal.PlanDate)
 
 	attemptFn := func(_ int, _ []string) (*GeneratedMealPlan, error) {
-		plan, err := a.runWorkflow(ctx, wfAgent, internal.UserID, flow, availableFoods)
+		plan, err := a.runWorkflow(ctx, wfAgent, internal.UserID, flow, availableDTOs)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/nutrition/infrastructure/ai/adk/tools.go
+++ b/internal/nutrition/infrastructure/ai/adk/tools.go
@@ -18,14 +18,14 @@ func NewNutritionTools(foodRepo repository.FoodItemRepository) *NutritionTools {
 	return &NutritionTools{foodRepo: foodRepo}
 }
 
-func (t *NutritionTools) FetchActiveFoodCatalog(ctx context.Context, category string) ([]vo.FoodNutrient, error) {
+func (t *NutritionTools) FetchActiveFoodCatalog(ctx context.Context, category string) ([]FoodNutrientDTO, error) {
 	catalog, err := t.foodRepo.FindActiveCatalog(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("tools fetch active catalog: %w", err)
 	}
 
 	if category == "" {
-		return catalog, nil
+		return ToFoodNutrientDTOs(catalog), nil
 	}
 
 	filtered := make([]vo.FoodNutrient, 0, len(catalog))
@@ -34,7 +34,7 @@ func (t *NutritionTools) FetchActiveFoodCatalog(ctx context.Context, category st
 			filtered = append(filtered, catalog[i])
 		}
 	}
-	return filtered, nil
+	return ToFoodNutrientDTOs(filtered), nil
 }
 
 func (t *NutritionTools) CheckLockoutRules(
@@ -65,10 +65,10 @@ func (t *NutritionTools) CalculateMacroGramRatio(
 	return proteinGrams, carbGrams, fatGrams
 }
 
-func (t *NutritionTools) SuggestNutiFoodSupplement(ctx context.Context) ([]vo.FoodNutrient, error) {
+func (t *NutritionTools) SuggestNutiFoodSupplement(ctx context.Context) ([]FoodNutrientDTO, error) {
 	products, err := t.foodRepo.FindNutiFoodProducts(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("tools suggest nutifood products: %w", err)
 	}
-	return products, nil
+	return ToFoodNutrientDTOs(products), nil
 }

--- a/internal/nutrition/infrastructure/ai/adk/tools_test.go
+++ b/internal/nutrition/infrastructure/ai/adk/tools_test.go
@@ -41,7 +41,7 @@ func TestNutritionTools(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error fetching active catalog: %v", err)
 	}
-	if len(catalog) != 1 || catalog[0].Category() != "PROTEIN" {
+	if len(catalog) != 1 || catalog[0].Category != "PROTEIN" {
 		t.Fatalf("got catalog len %d, want 1 protein item", len(catalog))
 	}
 

--- a/internal/nutrition/infrastructure/ai/adk/types.go
+++ b/internal/nutrition/infrastructure/ai/adk/types.go
@@ -20,6 +20,7 @@ type FoodNutrientDTO struct {
 	IsNutiFoodProduct bool     `json:"is_nutifood_product"`
 }
 
+//nolint:gocritic // hugeParam: fn value object mapping
 func ToFoodNutrientDTO(fn vo.FoodNutrient) FoodNutrientDTO {
 	return FoodNutrientDTO{
 		ID:                fn.ID(),
@@ -44,6 +45,7 @@ func ToFoodNutrientDTOs(fns []vo.FoodNutrient) []FoodNutrientDTO {
 	return dtos
 }
 
+//nolint:gocritic // hugeParam: dto struct value object mapping
 func (dto FoodNutrientDTO) ToDomain() vo.FoodNutrient {
 	return vo.NewFoodNutrient(
 		dto.ID,

--- a/internal/nutrition/infrastructure/ai/adk/types.go
+++ b/internal/nutrition/infrastructure/ai/adk/types.go
@@ -6,6 +6,68 @@ import (
 	"github.com/viethung213/gym-companion/internal/nutrition/domain/vo"
 )
 
+type FoodNutrientDTO struct {
+	ID                string   `json:"id"`
+	Name              string   `json:"name"`
+	Category          string   `json:"category"`
+	CaloriesPer100g   float64  `json:"calories_per_100g"`
+	ProteinPer100g    float64  `json:"protein_per_100g"`
+	CarbsPer100g      float64  `json:"carbs_per_100g"`
+	FatPer100g        float64  `json:"fat_per_100g"`
+	AllergenTags      []string `json:"allergen_tags"`
+	ProteinSource     string   `json:"protein_source,omitempty"`
+	CarbSource        string   `json:"carb_source,omitempty"`
+	IsNutiFoodProduct bool     `json:"is_nutifood_product"`
+}
+
+func ToFoodNutrientDTO(fn vo.FoodNutrient) FoodNutrientDTO {
+	return FoodNutrientDTO{
+		ID:                fn.ID(),
+		Name:              fn.Name(),
+		Category:          fn.Category(),
+		CaloriesPer100g:   fn.CaloriesPer100g(),
+		ProteinPer100g:    fn.ProteinPer100g(),
+		CarbsPer100g:      fn.CarbsPer100g(),
+		FatPer100g:        fn.FatPer100g(),
+		AllergenTags:      fn.AllergenTags(),
+		ProteinSource:     fn.ProteinSource(),
+		CarbSource:        fn.CarbSource(),
+		IsNutiFoodProduct: fn.IsNutiFoodProduct(),
+	}
+}
+
+func ToFoodNutrientDTOs(fns []vo.FoodNutrient) []FoodNutrientDTO {
+	dtos := make([]FoodNutrientDTO, 0, len(fns))
+	for i := range fns {
+		dtos = append(dtos, ToFoodNutrientDTO(fns[i]))
+	}
+	return dtos
+}
+
+func (dto FoodNutrientDTO) ToDomain() vo.FoodNutrient {
+	return vo.NewFoodNutrient(
+		dto.ID,
+		dto.Name,
+		dto.Category,
+		dto.CaloriesPer100g,
+		dto.ProteinPer100g,
+		dto.CarbsPer100g,
+		dto.FatPer100g,
+		dto.AllergenTags,
+		dto.ProteinSource,
+		dto.CarbSource,
+		dto.IsNutiFoodProduct,
+	)
+}
+
+func ToFoodNutrientDomains(dtos []FoodNutrientDTO) []vo.FoodNutrient {
+	domains := make([]vo.FoodNutrient, 0, len(dtos))
+	for i := range dtos {
+		domains = append(domains, dtos[i].ToDomain())
+	}
+	return domains
+}
+
 type NutritionPromptContext struct {
 	UserID               string            `json:"user_id"`
 	PlanDate             time.Time         `json:"plan_date"`
@@ -15,7 +77,7 @@ type NutritionPromptContext struct {
 	TargetCarbGrams      float64           `json:"target_carb_grams"`
 	TargetFatGrams       float64           `json:"target_fat_grams"`
 	UserRestrictions     []string          `json:"user_restrictions"`
-	AvailableIngredients []vo.FoodNutrient `json:"available_ingredients"`
+	AvailableIngredients []FoodNutrientDTO `json:"available_ingredients"`
 }
 
 type SupplementaryIngredientSpec struct {

--- a/internal/nutrition/infrastructure/ai/adk/workflow_adhoc.go
+++ b/internal/nutrition/infrastructure/ai/adk/workflow_adhoc.go
@@ -15,8 +15,10 @@ func (a *NutritionAgent) ExecuteAdhocMealSuggestionWorkflow(
 	promptCtx NutritionPromptContext,
 	lockoutRegistry vo.LockoutRegistry,
 ) ([]repository.GeneratedRecipeResult, error) {
-	availableFoods := lockoutRegistry.FilterAvailableIngredients(promptCtx.AvailableIngredients, promptCtx.PlanDate)
-	plan, err := a.runAdhocWorkflow(ctx, promptCtx.UserID, availableFoods)
+	domainFoods := ToFoodNutrientDomains(promptCtx.AvailableIngredients)
+	filteredFoods := lockoutRegistry.FilterAvailableIngredients(domainFoods, promptCtx.PlanDate)
+	availableDTOs := ToFoodNutrientDTOs(filteredFoods)
+	plan, err := a.runAdhocWorkflow(ctx, promptCtx.UserID, availableDTOs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/nutrition/infrastructure/ai/adk/workflow_daily.go
+++ b/internal/nutrition/infrastructure/ai/adk/workflow_daily.go
@@ -15,8 +15,10 @@ func (a *NutritionAgent) ExecuteDailyMenuWorkflow(
 	promptCtx NutritionPromptContext,
 	lockoutRegistry vo.LockoutRegistry,
 ) ([]repository.GeneratedRecipeResult, error) {
-	availableFoods := lockoutRegistry.FilterAvailableIngredients(promptCtx.AvailableIngredients, promptCtx.PlanDate)
-	plan, err := a.runInitWorkflow(ctx, promptCtx.UserID, availableFoods)
+	domainFoods := ToFoodNutrientDomains(promptCtx.AvailableIngredients)
+	filteredFoods := lockoutRegistry.FilterAvailableIngredients(domainFoods, promptCtx.PlanDate)
+	availableDTOs := ToFoodNutrientDTOs(filteredFoods)
+	plan, err := a.runInitWorkflow(ctx, promptCtx.UserID, availableDTOs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/nutrition/infrastructure/ai/adk/workflow_pantry.go
+++ b/internal/nutrition/infrastructure/ai/adk/workflow_pantry.go
@@ -16,8 +16,10 @@ func (a *NutritionAgent) ExecutePantryRecipeWorkflow(
 	_ []string,
 	lockoutRegistry vo.LockoutRegistry,
 ) ([]repository.GeneratedRecipeResult, error) {
-	availableFoods := lockoutRegistry.FilterAvailableIngredients(promptCtx.AvailableIngredients, promptCtx.PlanDate)
-	plan, err := a.runPantryWorkflow(ctx, promptCtx.UserID, availableFoods)
+	domainFoods := ToFoodNutrientDomains(promptCtx.AvailableIngredients)
+	filteredFoods := lockoutRegistry.FilterAvailableIngredients(domainFoods, promptCtx.PlanDate)
+	availableDTOs := ToFoodNutrientDTOs(filteredFoods)
+	plan, err := a.runPantryWorkflow(ctx, promptCtx.UserID, availableDTOs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/nutrition/infrastructure/ai/adk/workflow_post_workout.go
+++ b/internal/nutrition/infrastructure/ai/adk/workflow_post_workout.go
@@ -16,8 +16,10 @@ func (a *NutritionAgent) ExecutePostWorkoutRecalibrationWorkflow(
 	_ float64,
 	lockoutRegistry vo.LockoutRegistry,
 ) ([]repository.GeneratedRecipeResult, error) {
-	availableFoods := lockoutRegistry.FilterAvailableIngredients(promptCtx.AvailableIngredients, promptCtx.PlanDate)
-	plan, err := a.runPostWorkoutWorkflow(ctx, promptCtx.UserID, availableFoods)
+	domainFoods := ToFoodNutrientDomains(promptCtx.AvailableIngredients)
+	filteredFoods := lockoutRegistry.FilterAvailableIngredients(domainFoods, promptCtx.PlanDate)
+	availableDTOs := ToFoodNutrientDTOs(filteredFoods)
+	plan, err := a.runPostWorkoutWorkflow(ctx, promptCtx.UserID, availableDTOs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### 1. Problem to Solve
- When generating meal plans, the AI Nutrition Agent returned placeholder UUIDs ('00000000-0000-0000-0000-000000000001') and failed validation because vo.FoodNutrient domain struct had unexported fields without JSON tags, causing json.Marshal to send empty objects [{}, {}, ...] to Gemini.

### 2. Proposed Solution
- Introduced FoodNutrientDTO in internal/nutrition/infrastructure/ai/adk/types.go with exported fields and JSON tags.
- Added bidirectional mappers (ToFoodNutrientDTOs, ToFoodNutrientDomains).
- Updated FetchActiveFoodCatalog, SuggestNutiFoodSupplement, SelectCreativeMealOptions, and ADK workflow nodes to use FoodNutrientDTO.

### 3. Changes & Impact
- [types.go](internal/nutrition/infrastructure/ai/adk/types.go): Added FoodNutrientDTO struct, conversion functions, and updated NutritionPromptContext.
- [tools.go](internal/nutrition/infrastructure/ai/adk/tools.go): Updated active catalog and nutifood tools to return []FoodNutrientDTO.
- [agent.go](internal/nutrition/infrastructure/ai/adk/agent.go): Map domain vo.FoodNutrient to FoodNutrientDTO before passing context to ADK runner.
- [workflow_daily.go](internal/nutrition/infrastructure/ai/adk/workflow_daily.go): Handled conversion between DTOs and domain VO for lockout filtering.
- [tools_test.go](internal/nutrition/infrastructure/ai/adk/tools_test.go): Updated test assertions for FoodNutrientDTO.

### 4. Testing & Verification
- Automated Tests:
  - gofmt -w internal/nutrition/infrastructure/ai/adk: Formatting clean.
  - go vet ./internal/nutrition/infrastructure/ai/adk/...: Passed with 0 errors.
  - go test -v ./internal/nutrition/infrastructure/ai/adk/...: All unit tests passed.
  - go test ./internal/nutrition/...: All nutrition module tests passed cleanly.