### PR TITLE
🐛 fix(nutrition): fix meals/ingredients JSON serialization & Kafka topic auto-provisioning

### DIFF
--- a/internal/nutrition/domain/aggregate/nutrition_plan.go
+++ b/internal/nutrition/domain/aggregate/nutrition_plan.go
@@ -70,6 +70,32 @@ func NewMealOption(
 	}
 }
 
+func ReconstructMealOption(
+	optionID, mealName string,
+	calories, proteinGrams, carbGrams, fatGrams float64,
+	ingredients []IngredientGram,
+	cookingSteps []string,
+	isLogged, isNutiFoodProduct bool,
+) MealOption {
+	ingCopy := make([]IngredientGram, len(ingredients))
+	copy(ingCopy, ingredients)
+	stepCopy := make([]string, len(cookingSteps))
+	copy(stepCopy, cookingSteps)
+
+	return MealOption{
+		optionID:          optionID,
+		mealName:          mealName,
+		calories:          calories,
+		proteinGrams:      proteinGrams,
+		carbGrams:         carbGrams,
+		fatGrams:          fatGrams,
+		ingredients:       ingCopy,
+		cookingSteps:      stepCopy,
+		isLogged:          isLogged,
+		isNutiFoodProduct: isNutiFoodProduct,
+	}
+}
+
 func (m *MealOption) OptionID() string        { return m.optionID }
 func (m *MealOption) MealName() string        { return m.mealName }
 func (m *MealOption) Calories() float64       { return m.calories }

--- a/internal/nutrition/infrastructure/persistence/mapper.go
+++ b/internal/nutrition/infrastructure/persistence/mapper.go
@@ -80,12 +80,136 @@ func (g *GormRecipe) ToDomain() *repository.CachedRecipe {
 		_ = json.Unmarshal(g.CookingStepsJSON, &steps)
 	}
 
+	ings, _ := UnmarshalIngredientsJSON(g.IngredientsJSON)
+
 	return &repository.CachedRecipe{
 		ID:             g.ID,
 		IngredientHash: g.IngredientHash,
 		RecipeName:     g.RecipeName,
 		CookingStyle:   g.CookingStyle,
+		Ingredients:    ings,
 		CookingSteps:   steps,
 		CreatedAt:      g.CreatedAt,
 	}
+}
+
+type jsonIngredientGramDTO struct {
+	IngredientName  string  `json:"ingredientName"`
+	Grams           float64 `json:"grams"`
+	IsSupplementary bool    `json:"isSupplementary"`
+}
+
+type jsonMealOptionDTO struct {
+	OptionID          string                  `json:"optionId"`
+	MealName          string                  `json:"mealName"`
+	Calories          float64                 `json:"calories"`
+	ProteinGrams      float64                 `json:"proteinGrams"`
+	CarbGrams         float64                 `json:"carbGrams"`
+	FatGrams          float64                 `json:"fatGrams"`
+	Ingredients       []jsonIngredientGramDTO `json:"ingredients"`
+	CookingSteps      []string                `json:"cookingSteps"`
+	IsLogged          bool                    `json:"isLogged"`
+	IsNutiFoodProduct bool                    `json:"isNutiFoodProduct"`
+}
+
+type jsonDailyMealDTO struct {
+	MealType      string              `json:"mealType"`
+	Options       []jsonMealOptionDTO `json:"options"`
+	ScheduledTime string              `json:"scheduledTime"`
+}
+
+func MarshalDailyMealsJSON(meals []aggregate.DailyMeal) ([]byte, error) {
+	dtos := make([]jsonDailyMealDTO, 0, len(meals))
+	for _, m := range meals {
+		optDTOs := make([]jsonMealOptionDTO, 0, len(m.Options()))
+		for _, opt := range m.Options() {
+			ingDTOs := make([]jsonIngredientGramDTO, 0, len(opt.Ingredients()))
+			for _, ing := range opt.Ingredients() {
+				ingDTOs = append(ingDTOs, jsonIngredientGramDTO{
+					IngredientName:  ing.IngredientName(),
+					Grams:           ing.Grams(),
+					IsSupplementary: ing.IsSupplementary(),
+				})
+			}
+			optDTOs = append(optDTOs, jsonMealOptionDTO{
+				OptionID:          opt.OptionID(),
+				MealName:          opt.MealName(),
+				Calories:          opt.Calories(),
+				ProteinGrams:      opt.ProteinGrams(),
+				CarbGrams:         opt.CarbGrams(),
+				FatGrams:          opt.FatGrams(),
+				Ingredients:       ingDTOs,
+				CookingSteps:      opt.CookingSteps(),
+				IsLogged:          opt.IsLogged(),
+				IsNutiFoodProduct: opt.IsNutiFoodProduct(),
+			})
+		}
+		dtos = append(dtos, jsonDailyMealDTO{
+			MealType:      m.MealType(),
+			Options:       optDTOs,
+			ScheduledTime: m.ScheduledTime(),
+		})
+	}
+	return json.Marshal(dtos)
+}
+
+func UnmarshalDailyMealsJSON(data []byte) ([]aggregate.DailyMeal, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var dtos []jsonDailyMealDTO
+	if err := json.Unmarshal(data, &dtos); err != nil {
+		return nil, err
+	}
+	meals := make([]aggregate.DailyMeal, 0, len(dtos))
+	for _, dto := range dtos {
+		opts := make([]aggregate.MealOption, 0, len(dto.Options))
+		for _, optDTO := range dto.Options {
+			ings := make([]aggregate.IngredientGram, 0, len(optDTO.Ingredients))
+			for _, ingDTO := range optDTO.Ingredients {
+				ings = append(ings, aggregate.NewIngredientGram(ingDTO.IngredientName, ingDTO.Grams, ingDTO.IsSupplementary))
+			}
+			opts = append(opts, aggregate.ReconstructMealOption(
+				optDTO.OptionID,
+				optDTO.MealName,
+				optDTO.Calories,
+				optDTO.ProteinGrams,
+				optDTO.CarbGrams,
+				optDTO.FatGrams,
+				ings,
+				optDTO.CookingSteps,
+				optDTO.IsLogged,
+				optDTO.IsNutiFoodProduct,
+			))
+		}
+		meals = append(meals, aggregate.NewDailyMealWithSchedule(dto.MealType, opts, dto.ScheduledTime))
+	}
+	return meals, nil
+}
+
+func MarshalIngredientsJSON(ingredients []aggregate.IngredientGram) ([]byte, error) {
+	dtos := make([]jsonIngredientGramDTO, 0, len(ingredients))
+	for _, ing := range ingredients {
+		dtos = append(dtos, jsonIngredientGramDTO{
+			IngredientName:  ing.IngredientName(),
+			Grams:           ing.Grams(),
+			IsSupplementary: ing.IsSupplementary(),
+		})
+	}
+	return json.Marshal(dtos)
+}
+
+func UnmarshalIngredientsJSON(data []byte) ([]aggregate.IngredientGram, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var dtos []jsonIngredientGramDTO
+	if err := json.Unmarshal(data, &dtos); err != nil {
+		return nil, err
+	}
+	ings := make([]aggregate.IngredientGram, 0, len(dtos))
+	for _, dto := range dtos {
+		ings = append(ings, aggregate.NewIngredientGram(dto.IngredientName, dto.Grams, dto.IsSupplementary))
+	}
+	return ings, nil
 }

--- a/internal/nutrition/infrastructure/persistence/models.go
+++ b/internal/nutrition/infrastructure/persistence/models.go
@@ -41,8 +41,8 @@ func (g *GormRecipe) TableName() string {
 
 type GormNutritionPlan struct {
 	ID             string    `gorm:"column:id;primaryKey"`
-	UserID         string    `gorm:"column:user_id"`
-	PlanDate       time.Time `gorm:"column:plan_date;type:date"`
+	UserID         string    `gorm:"column:user_id;uniqueIndex:unique_user_plan_date"`
+	PlanDate       time.Time `gorm:"column:plan_date;type:date;uniqueIndex:unique_user_plan_date"`
 	TargetCalories float64   `gorm:"column:target_calories"`
 	TargetProtein  float64   `gorm:"column:target_protein"`
 	TargetCarbs    float64   `gorm:"column:target_carbs"`

--- a/internal/nutrition/infrastructure/persistence/postgres_repository.go
+++ b/internal/nutrition/infrastructure/persistence/postgres_repository.go
@@ -12,6 +12,7 @@ import (
 	"github.com/viethung213/gym-companion/internal/nutrition/domain/repository"
 	"github.com/viethung213/gym-companion/internal/nutrition/domain/vo"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type PostgresFoodItemRepository struct {
@@ -118,7 +119,7 @@ func (r *PostgresRecipeCacheRepository) FindByHash(ctx context.Context, hash str
 
 func (r *PostgresRecipeCacheRepository) Save(ctx context.Context, recipe *repository.CachedRecipe) error {
 	stepsJSON, _ := json.Marshal(recipe.CookingSteps)
-	ingsJSON, _ := json.Marshal(recipe.Ingredients)
+	ingsJSON, _ := MarshalIngredientsJSON(recipe.Ingredients)
 
 	gormModel := &GormRecipe{
 		ID:               recipe.ID,
@@ -159,16 +160,13 @@ func (r *PostgresNutritionPlanRepository) FindByUserIDAndDate(ctx context.Contex
 	}
 
 	alloc, _ := vo.NewCalorieAllocation(gormPlan.TargetCalories, gormPlan.TargetProtein, gormPlan.TargetCarbs, gormPlan.TargetFat)
-	var meals []aggregate.DailyMeal
-	if len(gormPlan.MealsJSON) > 0 {
-		_ = json.Unmarshal(gormPlan.MealsJSON, &meals)
-	}
+	meals, _ := UnmarshalDailyMealsJSON(gormPlan.MealsJSON)
 
 	return aggregate.NewNutritionPlan(gormPlan.ID, gormPlan.UserID, gormPlan.PlanDate, alloc, meals), nil
 }
 
 func (r *PostgresNutritionPlanRepository) Save(ctx context.Context, plan *aggregate.NutritionPlan) error {
-	mealsJSON, _ := json.Marshal(plan.DailyMeals())
+	mealsJSON, _ := MarshalDailyMealsJSON(plan.DailyMeals())
 	alloc := plan.CalorieAllocation()
 
 	gormModel := &GormNutritionPlan{
@@ -185,14 +183,17 @@ func (r *PostgresNutritionPlanRepository) Save(ctx context.Context, plan *aggreg
 	}
 
 	db := getDB(ctx, r.db)
-	if err := db.Create(gormModel).Error; err != nil {
+	if err := db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "user_id"}, {Name: "plan_date"}},
+		DoUpdates: clause.AssignmentColumns([]string{"target_calories", "target_protein", "target_carbs", "target_fat", "meals_json", "updated_at"}),
+	}).Create(gormModel).Error; err != nil {
 		return fmt.Errorf("postgres nutrition plan repo save: %w", err)
 	}
 	return nil
 }
 
 func (r *PostgresNutritionPlanRepository) Update(ctx context.Context, plan *aggregate.NutritionPlan) error {
-	mealsJSON, _ := json.Marshal(plan.DailyMeals())
+	mealsJSON, _ := MarshalDailyMealsJSON(plan.DailyMeals())
 	alloc := plan.CalorieAllocation()
 
 	gormModel := &GormNutritionPlan{
@@ -241,10 +242,7 @@ func (r *PostgresNutritionPlanRepository) FindPlansForDate(ctx context.Context, 
 	for i := range gormPlans {
 		gormPlan := &gormPlans[i]
 		alloc, _ := vo.NewCalorieAllocation(gormPlan.TargetCalories, gormPlan.TargetProtein, gormPlan.TargetCarbs, gormPlan.TargetFat)
-		var meals []aggregate.DailyMeal
-		if len(gormPlan.MealsJSON) > 0 {
-			_ = json.Unmarshal(gormPlan.MealsJSON, &meals)
-		}
+		meals, _ := UnmarshalDailyMealsJSON(gormPlan.MealsJSON)
 		result = append(result, aggregate.NewNutritionPlan(gormPlan.ID, gormPlan.UserID, gormPlan.PlanDate, alloc, meals))
 	}
 	return result, nil

--- a/internal/nutrition/infrastructure/persistence/postgres_repository_test.go
+++ b/internal/nutrition/infrastructure/persistence/postgres_repository_test.go
@@ -155,7 +155,8 @@ func createTestTables(db *sql.DB) error {
 		`CREATE TABLE IF NOT EXISTS nutrition_plans (
 			id TEXT PRIMARY KEY, user_id TEXT, plan_date DATETIME,
 			target_calories REAL, target_protein REAL, target_carbs REAL, target_fat REAL,
-			meals_json TEXT, created_at DATETIME, updated_at DATETIME
+			meals_json TEXT, created_at DATETIME, updated_at DATETIME,
+			UNIQUE(user_id, plan_date)
 		)`,
 		`CREATE TABLE IF NOT EXISTS meal_histories (
 			id TEXT PRIMARY KEY, user_id TEXT UNIQUE, created_at DATETIME, updated_at DATETIME

--- a/internal/nutrition/test/testutil/testutil.go
+++ b/internal/nutrition/test/testutil/testutil.go
@@ -163,7 +163,8 @@ func CreateSchema(db *sql.DB) error {
 		`CREATE TABLE IF NOT EXISTS nutrition_plans (
 			id TEXT PRIMARY KEY, user_id TEXT, plan_date DATETIME,
 			target_calories REAL, target_protein REAL, target_carbs REAL, target_fat REAL,
-			meals_json TEXT, created_at DATETIME, updated_at DATETIME
+			meals_json TEXT, created_at DATETIME, updated_at DATETIME,
+			UNIQUE(user_id, plan_date)
 		)`,
 		`CREATE TABLE IF NOT EXISTS meal_histories (
 			id TEXT PRIMARY KEY, user_id TEXT UNIQUE, created_at DATETIME, updated_at DATETIME

--- a/internal/shared/kafka/registry.go
+++ b/internal/shared/kafka/registry.go
@@ -67,6 +67,8 @@ func (r *Registry) GetWriter(module string, brokers []string) (*kafka.Writer, er
 		return nil, fmt.Errorf("build security config for writer (%s): %w", module, err)
 	}
 
+	ensureTopicExists(brokers, module)
+
 	w = &kafka.Writer{
 		Addr:                   kafka.TCP(brokers...),
 		Topic:                  module,
@@ -104,6 +106,8 @@ func (r *Registry) GetReader(consumerGroup, topic string, brokers []string) (*ka
 	if exists {
 		return reader, nil
 	}
+
+	ensureTopicExists(brokers, topic)
 
 	dialer, _, err := buildSecurityConfig()
 	if err != nil {
@@ -236,4 +240,21 @@ func getFirstEnv(keys ...string) string {
 		}
 	}
 	return ""
+}
+
+func ensureTopicExists(brokers []string, topic string) {
+	if len(brokers) == 0 || topic == "" {
+		return
+	}
+	conn, err := kafka.Dial("tcp", brokers[0])
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	_ = conn.CreateTopics(kafka.TopicConfig{
+		Topic:             topic,
+		NumPartitions:     1,
+		ReplicationFactor: 1,
+	})
 }


### PR DESCRIPTION
## Summary
This PR fixes issues in the Nutrition module regarding empty \meals_json\ and \ingredients_json\ database columns, resolves duplicate key constraint violations during plan saving, and programmatically provisions Kafka topics on startup.

### Changes
- 🐛 **JSON Serialization Fix**: Added DTO structs (\jsonDailyMealDTO\, \jsonMealOptionDTO\, \jsonIngredientGramDTO\) in \infrastructure/persistence/mapper.go\ to properly serialize unexported domain struct fields into \meals_json\ and \ingredients_json\.
- 🗃️ **Duplicate Key Fix**: Updated \PostgresNutritionPlanRepository.Save\ with \clause.OnConflict\ upsert handling for \(user_id, plan_date)\ constraint.
- 🔌 **Kafka Topic Provisioning**: Added \ensureTopicExists\ in \shared/kafka/registry.go\ to auto-create missing Kafka topics on the broker programmatically when readers/writers are initialized.

### Testing
- Executed \go test -v ./internal/nutrition/... ./internal/shared/kafka/...\ — All unit & integration tests passed.
- Ran \go vet ./internal/nutrition/... ./internal/shared/kafka/...\ — Passed cleanly with 0 warnings.