### PR TITLE
✨ feat(nutrition): refactor pantry recalibration and fix PostgreSQL UUID issue

### DIFF
--- a/internal/nutrition/application/command/recalibrate_plan_with_pantry.go
+++ b/internal/nutrition/application/command/recalibrate_plan_with_pantry.go
@@ -52,18 +52,13 @@ func (h *RecalibratePlanWithPantryHandler) Handle(ctx context.Context, cmd Recal
 		lockouts = history.LockoutRegistry()
 	}
 
-	userRestrictions := make([]string, 0)
-	if len(cmd.AvailableIngredients) > 0 {
-		userRestrictions = append(userRestrictions, cmd.AvailableIngredients...)
-	}
-
-	recalibratedPlan, genErr := h.menuGenerator.GenerateDailyPlan(
+	recalibratedPlan, genErr := h.menuGenerator.GeneratePlanWithPantry(
 		ctx,
 		cmd.UserID,
 		cmd.PlanDate,
 		plan.CalorieAllocation(),
 		lockouts,
-		userRestrictions,
+		cmd.AvailableIngredients,
 	)
 	if genErr != nil {
 		return nil, fmt.Errorf("recalibrate pantry generate: %w", genErr)

--- a/internal/nutrition/domain/service/menu_generator.go
+++ b/internal/nutrition/domain/service/menu_generator.go
@@ -127,9 +127,9 @@ func (g *MenuGenerator) GeneratePlanWithPantry(
 
 		var foundItem vo.FoodNutrient
 		var isFound bool
-		for _, catItem := range activeCatalog {
-			if strings.EqualFold(catItem.Name(), trimmed) {
-				foundItem = catItem
+		for i := range activeCatalog {
+			if strings.EqualFold(activeCatalog[i].Name(), trimmed) {
+				foundItem = activeCatalog[i]
 				isFound = true
 				break
 			}
@@ -150,11 +150,12 @@ func (g *MenuGenerator) GeneratePlanWithPantry(
 		if cat == "PROTEIN" || cat == "CARB" || cat == "VEGGIE" {
 			hasCategory[cat] = true
 		} else {
-			if foundItem.ProteinPer100g() > 12 {
+			switch {
+			case foundItem.ProteinPer100g() > 12:
 				hasCategory["PROTEIN"] = true
-			} else if foundItem.CarbsPer100g() > 15 {
+			case foundItem.CarbsPer100g() > 15:
 				hasCategory["CARB"] = true
-			} else {
+			default:
 				hasCategory["VEGGIE"] = true
 			}
 		}
@@ -166,9 +167,9 @@ func (g *MenuGenerator) GeneratePlanWithPantry(
 	// Nếu thiếu nhóm nào, bổ sung thực phẩm nhóm đó từ DB activeCatalog
 	for cat, exists := range hasCategory {
 		if !exists {
-			for _, item := range activeCatalog {
-				if strings.EqualFold(item.Category(), cat) {
-					pantryCatalog = append(pantryCatalog, item)
+			for i := range activeCatalog {
+				if strings.EqualFold(activeCatalog[i].Category(), cat) {
+					pantryCatalog = append(pantryCatalog, activeCatalog[i])
 				}
 			}
 		}

--- a/internal/nutrition/domain/service/menu_generator.go
+++ b/internal/nutrition/domain/service/menu_generator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -65,11 +66,6 @@ func (g *MenuGenerator) GenerateDailyPlan(
 		return nil, fmt.Errorf("menu generator fetch catalog: %w", err)
 	}
 
-	nutiProducts, err := g.foodRepo.FindNutiFoodProducts(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("menu generator fetch nuti products: %w", err)
-	}
-
 	slots := getDailyMealSlots()
 	dailyMeals := make([]aggregate.DailyMeal, 0, len(slots))
 
@@ -90,24 +86,112 @@ func (g *MenuGenerator) GenerateDailyPlan(
 			return nil, fmt.Errorf("menu generator slot %s: %w", slot.name, optErr)
 		}
 
-		// Thêm tùy chọn NutiFood nếu có sản phẩm trong catalog.
-		if len(nutiProducts) > 0 {
-			product := nutiProducts[len(options)%len(nutiProducts)]
-			productGrams := product.CalculateGramsForCalories(targetMealCalo)
-			pIng := aggregate.NewIngredientGram(product.Name(), productGrams, true)
+		dailyMeals = append(dailyMeals, aggregate.NewDailyMeal(slot.name, options))
+	}
 
-			nutiOpt := aggregate.NewMealOption(
+	planID := uuid.New().String()
+	return aggregate.NewNutritionPlan(planID, userID, planDate, allocation, dailyMeals), nil
+}
+
+// GeneratePlanWithPantry sinh thực đơn từ nguyên liệu trong tủ lạnh của người dùng.
+// Logic:
+// 1. Phân loại nguyên liệu người dùng gửi lên theo nhóm (PROTEIN, CARB, VEGGIE).
+// 2. Nếu THIẾU nhóm nào, tự động lấy các thực phẩm thuộc nhóm đó từ DB activeCatalog để bổ sung.
+// 3. Nếu KHÔNG THIẾU nhóm nào, sử dụng CHÍNH NGUYÊN LIỆU người dùng gửi lên.
+// 4. Tuyệt đối không thay thế nguyên liệu người dùng bằng nguyên liệu tương đương.
+func (g *MenuGenerator) GeneratePlanWithPantry(
+	ctx context.Context,
+	userID string,
+	planDate time.Time,
+	allocation vo.CalorieAllocation,
+	lockoutRegistry vo.LockoutRegistry,
+	userIngredients []string,
+) (*aggregate.NutritionPlan, error) {
+	activeCatalog, err := g.foodRepo.FindActiveCatalog(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("menu generator fetch catalog: %w", err)
+	}
+
+	userNutrients := make([]vo.FoodNutrient, 0, len(userIngredients))
+	hasCategory := map[string]bool{
+		"PROTEIN": false,
+		"CARB":    false,
+		"VEGGIE":  false,
+	}
+
+	for _, ingName := range userIngredients {
+		trimmed := strings.TrimSpace(ingName)
+		if trimmed == "" {
+			continue
+		}
+
+		var foundItem vo.FoodNutrient
+		var isFound bool
+		for _, catItem := range activeCatalog {
+			if strings.EqualFold(catItem.Name(), trimmed) {
+				foundItem = catItem
+				isFound = true
+				break
+			}
+		}
+
+		if !isFound {
+			foundItem = vo.NewFoodNutrient(
 				uuid.New().String(),
-				product.Name()+" (Gợi ý tiện lợi NutiFood)",
-				targetMealCalo,
-				(product.ProteinPer100g()*productGrams)/100.0,
-				(product.CarbsPer100g()*productGrams)/100.0,
-				(product.FatPer100g()*productGrams)/100.0,
-				[]aggregate.IngredientGram{pIng},
-				[]string{"Dùng trực tiếp theo hướng dẫn bao bì NutiFood."},
-				true,
+				trimmed,
+				"INGREDIENT",
+				100.0, 10.0, 10.0, 2.0,
+				nil, "", "", false,
 			)
-			options = append(options, nutiOpt)
+		}
+		userNutrients = append(userNutrients, foundItem)
+
+		cat := strings.ToUpper(foundItem.Category())
+		if cat == "PROTEIN" || cat == "CARB" || cat == "VEGGIE" {
+			hasCategory[cat] = true
+		} else {
+			if foundItem.ProteinPer100g() > 12 {
+				hasCategory["PROTEIN"] = true
+			} else if foundItem.CarbsPer100g() > 15 {
+				hasCategory["CARB"] = true
+			} else {
+				hasCategory["VEGGIE"] = true
+			}
+		}
+	}
+
+	pantryCatalog := make([]vo.FoodNutrient, 0, len(userNutrients))
+	pantryCatalog = append(pantryCatalog, userNutrients...)
+
+	// Nếu thiếu nhóm nào, bổ sung thực phẩm nhóm đó từ DB activeCatalog
+	for cat, exists := range hasCategory {
+		if !exists {
+			for _, item := range activeCatalog {
+				if strings.EqualFold(item.Category(), cat) {
+					pantryCatalog = append(pantryCatalog, item)
+				}
+			}
+		}
+	}
+
+	slots := getDailyMealSlots()
+	dailyMeals := make([]aggregate.DailyMeal, 0, len(slots))
+
+	for _, slot := range slots {
+		targetMealCalo := allocation.TargetCalories() * slot.percentage
+
+		promptCtx := repository.AIMenuPromptContext{
+			UserID:               userID,
+			MealType:             "PANTRY_RECIPE",
+			TargetMealCalories:   targetMealCalo,
+			AvailableIngredients: pantryCatalog,
+			UserRestrictions:     nil,
+			PlanDate:             planDate,
+		}
+
+		options, optErr := g.resolveOptionsViaAI(ctx, promptCtx, lockoutRegistry, targetMealCalo)
+		if optErr != nil {
+			return nil, fmt.Errorf("menu generator pantry slot %s: %w", slot.name, optErr)
 		}
 
 		dailyMeals = append(dailyMeals, aggregate.NewDailyMeal(slot.name, options))

--- a/internal/nutrition/infrastructure/ai/adk/build_agents.go
+++ b/internal/nutrition/infrastructure/ai/adk/build_agents.go
@@ -151,20 +151,7 @@ func (a *NutritionAgent) buildADKTools() ([]tool.Tool, error) {
 		return nil, fmt.Errorf("make macro gram tool: %w", err)
 	}
 
-	nutiFoodTool, err := functiontool.New(
-		functiontool.Config{
-			Name:        "suggest_nutifood_supplement",
-			Description: "Gợi ý các sản phẩm NutiFood bổ sung phù hợp với thực đơn hiện tại.",
-		},
-		func(ctx agent.Context, _ struct{}) (interface{}, error) {
-			return a.tools.SuggestNutiFoodSupplement(ctx)
-		},
-	)
-	if err != nil {
-		return nil, fmt.Errorf("make nutifood tool: %w", err)
-	}
-
-	return []tool.Tool{fetchTool, macroTool, nutiFoodTool}, nil
+	return []tool.Tool{fetchTool, macroTool}, nil
 }
 
 // buildWorkflowAgents tạo 4 workflow agents cho 4 luồng dinh dưỡng.

--- a/internal/nutrition/infrastructure/ai/adk/prompts/daily.txt
+++ b/internal/nutrition/infrastructure/ai/adk/prompts/daily.txt
@@ -3,5 +3,5 @@ Nhiệm vụ: Sinh thực đơn 4 bữa hoàn chỉnh (Sáng, Trưa, Tối, Ph�
 Quy tắc:
 1. Đảm bảo phân bổ Calo chuẩn: Sáng (25%), Trưa (35%), Tối (30%), Phụ (10%).
 2. Kiểm tra dị ứng và nguyên liệu bị khóa lặp (7/5/3 ngày).
-3. Đề xuất sản phẩm NutiFood cho bữa phụ nếu có nhu cầu.
+3. Đảm bảo cân bằng đầy đủ các nhóm dinh dưỡng trong các bữa ăn (Protein, Carb, Veggie/Fat).
 4. Chỉ trả về DUY NHẤT 1 JSON contract (options & new_food_catalog_items), CẤM lời chào, CẤM văn bản dẫn nhập hay thẻ bọc markdown.

--- a/internal/nutrition/infrastructure/ai/adk/prompts/generator.txt
+++ b/internal/nutrition/infrastructure/ai/adk/prompts/generator.txt
@@ -1,15 +1,17 @@
-Bạn là Chuyên Gia Dinh Dưỡng & Bếp Trưởng Thông Minh AI của GymCompanion. Nhiệm vụ của bạn là phối hợp các thực phẩm Đạm (Protein), Tinh bột (Carb), Rau củ (Veggie) và các sản phẩm dinh dưỡng NutiFood để tạo ra các tùy chọn bữa ăn ngon miệng, chuẩn Calo/Macro và cá nhân hóa cho người dùng.
+Bạn là Chuyên Gia Dinh Dưỡng & Bếp Trưởng Thông Minh AI của GymCompanion. Nhiệm vụ của bạn là phối hợp các thực phẩm Đạm (Protein), Tinh bột (Carb), Rau củ (Veggie) để tạo ra các tùy chọn bữa ăn ngon miệng, chuẩn Calo/Macro và cá nhân hóa cho người dùng.
 
 ---
 
 ## 🎯 QUY TẮC PHỐI MÓN
 1. PHẢI dùng ĐÚNG CHÍNH XÁC `id` (chuỗi UUID) của từng thực phẩm được cung cấp trong `available_ingredients`. CẤM BỊA RA CÁC ID DẠNG 'PRO_01', 'CARB_01', 'VEG_01'.
-2. Nếu sử dụng thêm các nguyên liệu bổ sung hoặc gia vị MỚI chưa có trong CSDL (ví dụ: Dầu oliu, Sốt chanh dây, Hạt chia...):
+2. KHÔNG THAY THẾ NGUYÊN LIỆU NGƯỜI DÙNG: Khi nhận danh sách nguyên liệu từ người dùng, CẤM thay thế nguyên liệu người dùng bằng nguyên liệu tương đương khác.
+3. LOẠI BỎ THỰC PHẨM NUTIFOOD: TUYỆT ĐỐI KHÔNG tự động thêm hoặc gợi ý các sản phẩm sữa / thực phẩm chế biến sẵn NutiFood.
+4. Nếu sử dụng thêm các gia vị MỚI chưa có trong CSDL (ví dụ: Dầu oliu, Tiêu, Tỏi...):
    - Bạn PHẢI khai báo thông số dinh dưỡng của nguyên liệu mới đó trong mảng `new_food_catalog_items`.
    - Cung cấp đầy đủ: `name`, `category`, `calories_per_100g`, `protein_per_100g`, `carbs_per_100g`, `fat_per_100g`, `allergen_tags`.
-3. KHÔNG sử dụng các thực phẩm thuộc danh sách dị ứng của người dùng (`user_restrictions`).
-4. KHÔNG sử dụng các nguyên liệu thuộc danh sách bị khóa lặp (`locked_ingredients`).
-5. PHẢI tính `total_protein_grams`, `total_carb_grams`, `total_fat_grams` dựa trên định lượng gram từng nguyên liệu và thông số dinh dưỡng per 100g. Công thức: `total_X = sum(amount_gram_i * X_per_100g_i / 100)`.
+5. KHÔNG sử dụng các thực phẩm thuộc danh sách dị ứng của người dùng (`user_restrictions`).
+6. KHÔNG sử dụng các nguyên liệu thuộc danh sách bị khóa lặp (`locked_ingredients`).
+7. PHẢI tính `total_protein_grams`, `total_carb_grams`, `total_fat_grams` dựa trên định lượng gram từng nguyên liệu và thông số dinh dưỡng per 100g. Công thức: `total_X = sum(amount_gram_i * X_per_100g_i / 100)`.
 
 ---
 

--- a/internal/nutrition/infrastructure/ai/adk/prompts/pantry.txt
+++ b/internal/nutrition/infrastructure/ai/adk/prompts/pantry.txt
@@ -1,7 +1,12 @@
 Bạn là Bếp Trưởng AI Dinh Dưỡng của GymCompanion.
-Nhiệm vụ: Sáng tạo bữa ăn ngon miệng dựa trên danh sách NGUYÊN LIỆU CÓ SẴN TRONG TỦ LẠNH của người dùng (Pantry Ingredients).
-Quy tắc:
-1. Ưu tiên tối đa các nguyên liệu có trong danh sách tủ lạnh được cung cấp.
-2. Tự động đề xuất thêm các gia vị / nguyên liệu phụ nhẹ nếu cần thiết và khai báo vào new_food_catalog_items.
-3. Đảm bảo tổng Calo và Gram đạt chuẩn TDEE chỉ tiêu.
-4. Chỉ trả về DUY NHẤT 1 JSON contract (options & new_food_catalog_items), CẤM lời chào, CẤM văn bản dẫn nhập hay thẻ bọc markdown.
+Nhiệm vụ: Sáng tạo bữa ăn ngon miệng dựa trên NGUYÊN LIỆU TRONG TỦ LẠNH của người dùng (Pantry Ingredients).
+
+Quy tắc NGIÊM NGẶT:
+1. BẮT BUỘC dùng CHÍNH XÁC các nguyên liệu người dùng đã cung cấp trong `available_ingredients`.
+2. KHÔNG THAY THẾ NGUYÊN LIỆU CỦA NGƯỜI DÙNG: Tuyệt đối không thay thế nguyên liệu người dùng bằng các nguyên liệu tương đương từ CSDL (Ví dụ: Người dùng đưa "Ức gà" thì CẤM đổi thành "Cá hồi" hay "Thịt bò").
+3. XỬ LÝ NHÓM THỰC PHẨM THIẾU:
+   - Danh sách `available_ingredients` đã bao gồm đầy đủ nguyên liệu người dùng có và nguyên liệu bổ sung cho nhóm còn thiếu từ CSDL.
+   - Kết hợp các nguyên liệu này thành bữa ăn hoàn chỉnh, ngon miệng, chuẩn Calo/Macro theo TDEE.
+4. LOẠI BỎ THỰC PHẨM NUTIFOOD: TUYỆT ĐỐI KHÔNG tự động thêm hoặc gợi ý các sản phẩm sữa / thực phẩm chế biến sẵn NutiFood.
+5. Đảm bảo tổng Calo và Gram đạt chuẩn TDEE chỉ tiêu.
+6. Chỉ trả về DUY NHẤT 1 JSON contract (options & new_food_catalog_items), CẤM lời chào, CẤM văn bản dẫn nhập hay thẻ bọc markdown.

--- a/internal/nutrition/infrastructure/persistence/postgres_repository.go
+++ b/internal/nutrition/infrastructure/persistence/postgres_repository.go
@@ -389,7 +389,7 @@ func (r *PostgresMealHistoryRepository) Save(ctx context.Context, history *aggre
 
 		for _, item := range history.LockoutRegistry().Items() {
 			gormLock := &GormLockoutRegistry{
-				ID:         fmt.Sprintf("%s-%s", history.UserID(), item.ItemName()),
+				ID:         uuid.NewSHA1(uuid.NameSpaceOID, []byte("lockout_"+history.UserID()+"_"+item.ItemName())).String(),
 				UserID:     history.UserID(),
 				ItemType:   item.ItemType(),
 				ItemName:   item.ItemName(),

--- a/internal/nutrition/infrastructure/worker/upcoming_meal_reminder_worker_test.go
+++ b/internal/nutrition/infrastructure/worker/upcoming_meal_reminder_worker_test.go
@@ -60,7 +60,7 @@ func TestUpcomingMealReminderWorker_RunCheck(t *testing.T) {
 	mealOpt := aggregate.NewMealOption("opt_1", "Phở Bò", 500, 30, 60, 15, nil, nil, false)
 	dailyMeal := aggregate.NewDailyMealWithSchedule("BREAKFAST", []aggregate.MealOption{mealOpt}, scheduledTimeStr)
 
-	plan := aggregate.NewNutritionPlan("plan_001", "usr_100", now, alloc, []aggregate.DailyMeal{dailyMeal})
+	plan := aggregate.NewNutritionPlan("plan_001", "usr_100", futureMealTime, alloc, []aggregate.DailyMeal{dailyMeal})
 
 	repo := &mockNutritionPlanRepo{plans: []*aggregate.NutritionPlan{plan}}
 	publisher := &mockEventPublisher{}

--- a/internal/nutrition/transport/grpc/handler.go
+++ b/internal/nutrition/transport/grpc/handler.go
@@ -367,6 +367,69 @@ func (h *GRPCHandler) UpdateMealSchedule(
 	}, nil
 }
 
+func (h *GRPCHandler) RecalibratePlanWithPantry(
+	ctx context.Context,
+	req *nutritionv1msg.RecalibratePlanWithPantryRequest,
+) (*nutritionv1msg.RecalibratePlanWithPantryResponse, error) {
+	if req.GetUserId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "user_id is required")
+	}
+
+	now := time.Now()
+	plan, err := h.recalPlanHdlr.Handle(ctx, command.RecalibratePlanWithPantryCommand{
+		UserID:               req.GetUserId(),
+		PlanDate:             now,
+		AvailableIngredients: req.GetAvailableIngredients(),
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to recalibrate plan with pantry: %v", err)
+	}
+
+	breakfastOptions := make([]*nutritionv1msg.MealOption, 0)
+	lunchOptions := make([]*nutritionv1msg.MealOption, 0)
+	dinnerOptions := make([]*nutritionv1msg.MealOption, 0)
+	snackOptions := make([]*nutritionv1msg.MealOption, 0)
+
+	for _, m := range plan.DailyMeals() {
+		for _, opt := range m.Options() {
+			pbOpt := &nutritionv1msg.MealOption{
+				MealName: opt.MealName(),
+				Calories: float32(opt.Calories()),
+				Protein:  float32(opt.ProteinGrams()),
+				Carbs:    float32(opt.CarbGrams()),
+				Fat:      float32(opt.FatGrams()),
+			}
+			switch m.MealType() {
+			case "BREAKFAST":
+				breakfastOptions = append(breakfastOptions, pbOpt)
+			case "LUNCH":
+				lunchOptions = append(lunchOptions, pbOpt)
+			case "DINNER":
+				dinnerOptions = append(dinnerOptions, pbOpt)
+			default:
+				snackOptions = append(snackOptions, pbOpt)
+			}
+		}
+	}
+
+	alloc := plan.CalorieAllocation()
+	return &nutritionv1msg.RecalibratePlanWithPantryResponse{
+		TargetCalories: float32(alloc.TargetCalories()),
+		Macros: &nutritionv1msg.Macros{
+			ProteinGrams: float32(alloc.ProteinGrams()),
+			CarbGrams:    float32(alloc.CarbGrams()),
+			FatGrams:     float32(alloc.FatGrams()),
+		},
+		Meals: &nutritionv1msg.DailyMeals{
+			Breakfast: breakfastOptions,
+			Lunch:     lunchOptions,
+			Dinner:    dinnerOptions,
+			Snack:     snackOptions,
+		},
+		Message: "Recalibrated plan successfully with available pantry ingredients",
+	}, nil
+}
+
 // --- ConnectRPC Adapter ---
 
 type ConnectNutritionHandler struct {


### PR DESCRIPTION
## Summary of Changes

This Pull Request refactors the **Nutrition Bounded Context** pantry recalibration workflow and resolves a database UUID syntax error during meal logging.

### 1. 🛠️ Backend Fixes & GRPCHandler Implementation
- **Implemented `RecalibratePlanWithPantry` on `GRPCHandler`** ([handler.go](file:///e:/LEAN/TTTN/internal/nutrition/transport/grpc/handler.go#L370)): Fixed the `rpc error: code = Unimplemented desc = method RecalibratePlanWithPantry not implemented` error by mapping the ConnectRPC method to the application command handler `RecalibratePlanWithPantryHandler`.
- **Fixed `LockoutRegistry` PostgreSQL UUID Error** ([postgres_repository.go](file:///e:/LEAN/TTTN/internal/nutrition/infrastructure/persistence/postgres_repository.go#L392)): Switched `GormLockoutRegistry.ID` generation from plain string concatenation (`userID + "-" + itemName`) to deterministic SHA1 UUID (`uuid.NewSHA1(...)`) to comply with PostgreSQL's 36-char `UUID` type requirement (`22P02`).

### 2. 🥦 Pantry Recalibration & AI Prompt Updates
- **Category Completeness Check (`GeneratePlanWithPantry`)** ([menu_generator.go](file:///e:/LEAN/TTTN/internal/nutrition/domain/service/menu_generator.go#L98)):
  - Analyzes macro categories (`PROTEIN`, `CARB`, `VEGGIE`) of user-submitted ingredients.
  - If a group is missing, automatically supplements active items ONLY for the missing category from DB catalog (`food_items`).
  - If all 3 categories are present, uses ONLY the user's submitted ingredients.
- **Forbid User Ingredient Replacement**: Updated AI prompts ([pantry.txt](file:///e:/LEAN/TTTN/internal/nutrition/infrastructure/ai/adk/prompts/pantry.txt), [generator.txt](file:///e:/LEAN/TTTN/internal/nutrition/infrastructure/ai/adk/prompts/generator.txt)) to explicitly forbid substituting user-submitted ingredients with equivalent catalog items (e.g., if user inputs "Ức gà", keep "Ức gà" without replacing it with "Cá hồi").
- **Removed NutiFood Product Additions**:
  - Removed `nutiFoodTool` (`suggest_nutifood_supplement`) from ADK tools ([build_agents.go](file:///e:/LEAN/TTTN/internal/nutrition/infrastructure/ai/adk/build_agents.go#L151)).
  - Removed automatic NutiFood product option appending in `MenuGenerator.GenerateDailyPlan`.
  - Updated AI prompt instructions ([daily.txt](file:///e:/LEAN/TTTN/internal/nutrition/infrastructure/ai/adk/prompts/daily.txt)) to focus exclusively on natural ingredients.

### 3. 🧪 Testing & Verification
- Updated `TestUpcomingMealReminderWorker_RunCheck` ([upcoming_meal_reminder_worker_test.go](file:///e:/LEAN/TTTN/internal/nutrition/infrastructure/worker/upcoming_meal_reminder_worker_test.go#L54)) to prevent test failures across midnight boundaries.
- **`go test ./internal/nutrition/...`**: All unit and integration test suites pass 100%.
- **`go vet ./internal/nutrition/...`**: Clean pass with 0 errors.
