### PR TITLE
🐛 fix(coaching): nâng cấp SQL JOIN tìm kiếm bài tập, xử lý UUID an toàn và bảo mật env

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -265,6 +265,9 @@ func (l *lazyKeyProvider) Set(kp middleware.KeyProvider) {
 }
 
 func loadEnvFile() {
+	if strings.EqualFold(os.Getenv("APP_ENV"), "production") {
+		return
+	}
 	data, err := os.ReadFile(".env")
 	if err != nil {
 		return

--- a/cmd/test-coaching/main.go
+++ b/cmd/test-coaching/main.go
@@ -42,6 +42,7 @@ func main() {
 // run keeps the body out of main so every failure path returns an error and
 // deferred cleanup still runs; log.Fatal mid-run would skip it.
 func run() error {
+	loadEnvFile()
 	ctx := context.Background()
 
 	log.Println("Initializing Coaching Agent...")
@@ -158,6 +159,32 @@ func printRoadmap(r *roadmap.Roadmap) {
 						ex.ExerciseID, ex.TargetSets, ex.TargetReps, ex.TargetWeight, ex.TargetRPE)
 				}
 				fmt.Println()
+			}
+		}
+	}
+}
+
+func loadEnvFile() {
+	if strings.EqualFold(os.Getenv("APP_ENV"), "production") {
+		return
+	}
+	data, err := os.ReadFile(".env")
+	if err != nil {
+		return
+	}
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 {
+			key := strings.TrimSpace(parts[0])
+			val := strings.TrimSpace(parts[1])
+			val = strings.Trim(val, `"'`)
+			if key != "" && os.Getenv(key) == "" {
+				os.Setenv(key, val)
 			}
 		}
 	}

--- a/internal/coaching/application/command/initiate_roadmap_test.go
+++ b/internal/coaching/application/command/initiate_roadmap_test.go
@@ -149,7 +149,7 @@ func buildHandler(t *testing.T) (*InitiateRoadmapHandler, *memRepo, *captureOutb
 
 	clock := &fakeClock{t: time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)}
 	mockAgent := &fakeCoachAgent{t: clock.t}
-	guard := guardrail.NewEngine(service.NewOverloadValidator(), nil, nil)
+	guard := guardrail.NewEngine(service.NewOverloadValidator(), nil, nil, nil)
 	repo := newMemRepo()
 	outbox := &captureOutbox{}
 

--- a/internal/coaching/domain/guardrail/guardrail.go
+++ b/internal/coaching/domain/guardrail/guardrail.go
@@ -7,6 +7,9 @@
 package guardrail
 
 import (
+	"context"
+	"time"
+
 	"github.com/viethung213/gym-companion/internal/coaching/application/port"
 	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
 	"github.com/viethung213/gym-companion/internal/coaching/domain/service"
@@ -61,12 +64,13 @@ type PRLookup func(exerciseID string) float64
 // Engine applies all guardrail checks against a Roadmap.
 type Engine struct {
 	overload *service.OverloadValidator
+	catalog  port.ExerciseCatalogReader
 	prs      PRLookup
 	injuries []port.InjuryStatus
 }
 
 // NewEngine builds a guardrail engine.
-func NewEngine(overload *service.OverloadValidator, prs PRLookup, injuries []port.InjuryStatus) *Engine {
+func NewEngine(overload *service.OverloadValidator, catalog port.ExerciseCatalogReader, prs PRLookup, injuries []port.InjuryStatus) *Engine {
 	if overload == nil {
 		overload = service.NewOverloadValidator()
 	}
@@ -75,7 +79,7 @@ func NewEngine(overload *service.OverloadValidator, prs PRLookup, injuries []por
 		prs = func(string) float64 { return 0 }
 	}
 
-	return &Engine{overload: overload, prs: prs, injuries: injuries}
+	return &Engine{overload: overload, catalog: catalog, prs: prs, injuries: injuries}
 }
 
 // Check runs every rule against the given roadmap.
@@ -100,11 +104,66 @@ func (e *Engine) Check(r *roadmap.Roadmap) ReviewResult {
 
 	vs = append(vs, e.checkDeloadVolume(r)...)
 
+	vs = append(vs, e.checkExerciseCatalogExistence(r)...)
+
 	if len(vs) > 0 {
 		return ReviewResult{Status: StatusRejected, Violations: vs}
 	}
 
 	return ReviewResult{Status: StatusApproved}
+}
+
+// checkExerciseCatalogExistence enforces BR-AC-12.
+func (e *Engine) checkExerciseCatalogExistence(r *roadmap.Roadmap) []Violation {
+	var vs []Violation
+
+	for _, w := range r.Weeks() {
+		for _, d := range w.Days() {
+			for _, s := range d.Sessions() {
+				presc := s.Info().Prescription
+				allExs := append([]roadmap.PrescribedExercise{}, presc.WarmUps...)
+				allExs = append(allExs, presc.MainExercises...)
+				allExs = append(allExs, presc.CoolDowns...)
+
+				for i, ex := range allExs {
+					path := "sessions." + s.ID() + "[" + itoa(i) + "]"
+					if ex.ExerciseID == "" {
+						vs = append(vs, Violation{
+							Code:        "BR-AC-12",
+							Description: "prescribed exercise missing exercise_id",
+							Path:        path,
+							Severity:    SeverityBlocker,
+						})
+						continue
+					}
+					if ex.ExerciseName == "" {
+						vs = append(vs, Violation{
+							Code:        "BR-AC-12",
+							Description: "exercise_id " + ex.ExerciseID + " has no catalog-resolved name",
+							Path:        path,
+							Severity:    SeverityBlocker,
+						})
+						continue
+					}
+					if e.catalog != nil {
+						ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+						_, err := e.catalog.GetByID(ctx, ex.ExerciseID)
+						cancel()
+						if err != nil {
+							vs = append(vs, Violation{
+								Code:        "BR-AC-12",
+								Description: "exercise_id " + ex.ExerciseID + " does not exist in exercise catalog: " + err.Error(),
+								Path:        path,
+								Severity:    SeverityBlocker,
+							})
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return vs
 }
 
 // checkWeeklyCap enforces BR-AC-01.

--- a/internal/coaching/domain/guardrail/guardrail_test.go
+++ b/internal/coaching/domain/guardrail/guardrail_test.go
@@ -1,6 +1,7 @@
 package guardrail
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -103,7 +104,7 @@ func buildRoadmap(t *testing.T, weekRPE [4]float32, weekSets [4]int32) *roadmap.
 func TestGuardrail_Approved_Baseline(t *testing.T) {
 	r := buildValidRoadmap(t)
 
-	e := NewEngine(nil, func(id string) float64 {
+	e := NewEngine(nil, nil, func(id string) float64 {
 		if id == "ex-bench" {
 			return 60.0
 		}
@@ -123,7 +124,7 @@ func TestGuardrail_RejectsWeightOverBand(t *testing.T) {
 
 	// Baseline PR 40 → 60kg exceeds +30% (52kg cap).
 
-	e := NewEngine(nil, func(id string) float64 {
+	e := NewEngine(nil, nil, func(id string) float64 {
 		if id == "ex-bench" {
 			return 40.0
 		}
@@ -157,7 +158,7 @@ func TestGuardrail_RejectsInjuryTargeted(t *testing.T) {
 
 	// All sessions target "chest" — injury on chest should reject them all.
 
-	e := NewEngine(nil, nil, []port.InjuryStatus{
+	e := NewEngine(nil, nil, nil, []port.InjuryStatus{
 		{MuscleGroup: "chest"},
 	})
 
@@ -187,7 +188,7 @@ func TestGuardrail_RecoveredInjury_NotFlagged(t *testing.T) {
 
 	rec := time.Now()
 
-	e := NewEngine(nil, nil, []port.InjuryStatus{
+	e := NewEngine(nil, nil, nil, []port.InjuryStatus{
 		{MuscleGroup: "chest", RecoveredAt: &rec},
 	})
 
@@ -199,7 +200,7 @@ func TestGuardrail_RecoveredInjury_NotFlagged(t *testing.T) {
 }
 
 func TestGuardrail_NilRoadmapRejected(t *testing.T) {
-	e := NewEngine(nil, nil, nil)
+	e := NewEngine(nil, nil, nil, nil)
 
 	got := e.Check(nil)
 
@@ -228,7 +229,7 @@ func TestGuardrail_PhaseRPEBand(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := NewEngine(nil, nil, nil).Check(buildRoadmap(t, tt.give, validSets()))
+			got := NewEngine(nil, nil, nil, nil).Check(buildRoadmap(t, tt.give, validSets()))
 
 			assertViolation(t, got, tt.want)
 		})
@@ -255,7 +256,7 @@ func TestGuardrail_DeloadVolume(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := NewEngine(nil, nil, nil).Check(buildRoadmap(t, validRPE(), tt.give))
+			got := NewEngine(nil, nil, nil, nil).Check(buildRoadmap(t, validRPE(), tt.give))
 
 			assertViolation(t, got, tt.want)
 		})
@@ -282,3 +283,33 @@ func assertViolation(t *testing.T, got ReviewResult, code string) {
 
 	t.Errorf("violations = %+v, want one with code %s", got.Violations, code)
 }
+
+type fakeCatalogReader struct {
+	validIDs map[string]bool
+}
+
+func (f *fakeCatalogReader) SearchByFilter(_ context.Context, _ *port.ExerciseFilter) ([]port.Exercise, error) {
+	return nil, nil
+}
+
+func (f *fakeCatalogReader) GetByID(_ context.Context, id string) (port.Exercise, error) {
+	if f.validIDs[id] {
+		return port.Exercise{ExerciseID: id, Name: "Name of " + id}, nil
+	}
+	return port.Exercise{}, port.ErrExerciseNotFound
+}
+
+func TestGuardrail_RejectsInvalidCatalogExerciseID(t *testing.T) {
+	r := buildValidRoadmap(t)
+	cat := &fakeCatalogReader{validIDs: map[string]bool{}} // "ex-bench" is NOT in validIDs
+
+	e := NewEngine(nil, cat, nil, nil)
+	got := e.Check(r)
+
+	if got.Status != StatusRejected {
+		t.Fatalf("expected status REJECTED for non-existent exercise ID")
+	}
+
+	assertViolation(t, got, "BR-AC-12")
+}
+

--- a/internal/coaching/domain/guardrail/guardrail_test.go
+++ b/internal/coaching/domain/guardrail/guardrail_test.go
@@ -312,4 +312,3 @@ func TestGuardrail_RejectsInvalidCatalogExerciseID(t *testing.T) {
 
 	assertViolation(t, got, "BR-AC-12")
 }
-

--- a/internal/coaching/infrastructure/adapters/postgres_exercise_catalog_reader.go
+++ b/internal/coaching/infrastructure/adapters/postgres_exercise_catalog_reader.go
@@ -153,7 +153,11 @@ func (r *PostgresExerciseCatalogReader) SearchByFilter(ctx context.Context, filt
 
 		if filter.Keyword != "" {
 			pattern := "%" + strings.TrimSpace(filter.Keyword) + "%"
-			query = query.Where("LOWER(e.name) LIKE LOWER(?) OR LOWER(e.id) LIKE LOWER(?) OR LOWER(m.name) LIKE LOWER(?) OR LOWER(bp.name) LIKE LOWER(?)", pattern, pattern, pattern, pattern)
+			kwCond := "LOWER(e.name) LIKE LOWER(?)" +
+				" OR LOWER(e.id) LIKE LOWER(?)" +
+				" OR LOWER(m.name) LIKE LOWER(?)" +
+				" OR LOWER(bp.name) LIKE LOWER(?)"
+			query = query.Where(kwCond, pattern, pattern, pattern, pattern)
 		}
 
 		if filter.Limit > 0 {
@@ -223,8 +227,13 @@ func mapFullRowToExercise(row *exerciseFullRow) port.Exercise {
 	}
 
 	eqLower := strings.ToLower(eqName)
-	isBodyweight := eqLower == "bodyweight" || eqLower == "body weight" || eqLower == "none" || eqLower == "" || eqLower == "pull-up-bar" || eqLower == "body_weight"
-	isMachineOrCable := strings.Contains(eqLower, "cable") || strings.Contains(eqLower, "machine") || strings.Contains(eqLower, "pulldown") || strings.Contains(eqLower, "lever")
+	isBodyweight := eqLower == "bodyweight" || eqLower == "body weight" ||
+		eqLower == "none" || eqLower == "" ||
+		eqLower == "pull-up-bar" || eqLower == "body_weight"
+	isMachineOrCable := strings.Contains(eqLower, "cable") ||
+		strings.Contains(eqLower, "machine") ||
+		strings.Contains(eqLower, "pulldown") ||
+		strings.Contains(eqLower, "lever")
 
 	return port.Exercise{
 		ExerciseID:       row.ID,

--- a/internal/coaching/infrastructure/adapters/postgres_exercise_catalog_reader.go
+++ b/internal/coaching/infrastructure/adapters/postgres_exercise_catalog_reader.go
@@ -11,19 +11,18 @@ import (
 	"gorm.io/gorm"
 )
 
-// exerciseDBModel represents the database model for exercise.exercises table.
-type exerciseDBModel struct {
-	ID             string `gorm:"column:id;primaryKey"`
-	Name           string `gorm:"column:name"`
-	BodyPartID     string `gorm:"column:body_part_id"`
-	EquipmentID    string `gorm:"column:equipment_id"`
-	TargetMuscleID string `gorm:"column:target_muscle_id"`
-	Difficulty     string `gorm:"column:difficulty"`
-	Status         string `gorm:"column:status"`
-}
-
-func (exerciseDBModel) TableName() string {
-	return "exercise.exercises"
+// exerciseFullRow represents joined DB columns for exercise catalog query.
+type exerciseFullRow struct {
+	ID               string `gorm:"column:id"`
+	Name             string `gorm:"column:name"`
+	BodyPartID       string `gorm:"column:body_part_id"`
+	BodyPartName     string `gorm:"column:body_part_name"`
+	EquipmentID      string `gorm:"column:equipment_id"`
+	EquipmentName    string `gorm:"column:equipment_name"`
+	TargetMuscleID   string `gorm:"column:target_muscle_id"`
+	TargetMuscleName string `gorm:"column:target_muscle_name"`
+	Difficulty       string `gorm:"column:difficulty"`
+	Status           string `gorm:"column:status"`
 }
 
 // PostgresExerciseCatalogReader implements port.ExerciseCatalogReader querying exercise schema in PostgreSQL.
@@ -46,32 +45,115 @@ func (r *PostgresExerciseCatalogReader) SearchByFilter(ctx context.Context, filt
 		return mockReader.SearchByFilter(ctx, filter)
 	}
 
-	query := r.db.WithContext(ctx).Model(&exerciseDBModel{})
-
-	// Status filter: ignore archived exercises
-	query = query.Where("status != 'ARCHIVED'")
+	query := r.db.WithContext(ctx).Table("exercise.exercises e").
+		Select(`e.id, e.name, e.body_part_id, bp.name AS body_part_name,
+		        e.equipment_id, eq.name AS equipment_name,
+		        e.target_muscle_id, m.name AS target_muscle_name,
+		        e.difficulty, e.status`).
+		Joins("LEFT JOIN exercise.muscles m ON m.id = e.target_muscle_id").
+		Joins("LEFT JOIN exercise.body_parts bp ON bp.id = e.body_part_id").
+		Joins("LEFT JOIN exercise.equipments eq ON eq.id = e.equipment_id").
+		Where("e.status != 'ARCHIVED'")
 
 	if filter != nil {
-		targetMuscle := filter.TargetMuscleID
+		targetMuscle := strings.TrimSpace(filter.TargetMuscleID)
 		if targetMuscle == "" {
-			targetMuscle = filter.BodyPartID
+			targetMuscle = strings.TrimSpace(filter.BodyPartID)
 		}
 
 		if targetMuscle != "" {
-			query = query.Where("target_muscle_id = ? OR body_part_id = ?", targetMuscle, targetMuscle)
+			pattern := "%" + targetMuscle + "%"
+			query = query.Where(`(
+				e.target_muscle_id = ? OR e.body_part_id = ?
+				OR LOWER(m.name) LIKE LOWER(?) OR LOWER(bp.name) LIKE LOWER(?) OR m.id = ? OR bp.id = ?
+				OR EXISTS (
+					SELECT 1 FROM exercise.exercise_secondary_muscles esm
+					JOIN exercise.muscles sm ON sm.id = esm.muscle_id
+					WHERE esm.exercise_id = e.id AND (LOWER(sm.name) LIKE LOWER(?) OR sm.id = ?)
+				)
+			)`, targetMuscle, targetMuscle, pattern, pattern, targetMuscle, targetMuscle, pattern, targetMuscle)
+		}
+
+		if len(filter.SecondaryMuscleIDs) > 0 {
+			var secConds []string
+			var secArgs []interface{}
+			for _, sec := range filter.SecondaryMuscleIDs {
+				secTrim := strings.TrimSpace(sec)
+				if secTrim != "" {
+					secPattern := "%" + secTrim + "%"
+					secConds = append(secConds, "(LOWER(sm.name) LIKE LOWER(?) OR sm.id = ?)")
+					secArgs = append(secArgs, secPattern, secTrim)
+				}
+			}
+			if len(secConds) > 0 {
+				query = query.Where(fmt.Sprintf(`EXISTS (
+					SELECT 1 FROM exercise.exercise_secondary_muscles esm
+					JOIN exercise.muscles sm ON sm.id = esm.muscle_id
+					WHERE esm.exercise_id = e.id AND (%s)
+				)`, strings.Join(secConds, " OR ")), secArgs...)
+			}
 		}
 
 		if len(filter.EquipmentIDs) > 0 {
-			query = query.Where("equipment_id IN ?", filter.EquipmentIDs)
+			var eqConds []string
+			var eqArgs []interface{}
+			for _, eqVal := range filter.EquipmentIDs {
+				eqTrim := strings.TrimSpace(eqVal)
+				if eqTrim != "" {
+					eqPattern := "%" + eqTrim + "%"
+					eqConds = append(eqConds, "e.equipment_id = ? OR LOWER(eq.name) LIKE LOWER(?) OR eq.id = ?")
+					eqArgs = append(eqArgs, eqTrim, eqPattern, eqTrim)
+				}
+			}
+			if len(eqConds) > 0 {
+				query = query.Where(fmt.Sprintf("(%s)", strings.Join(eqConds, " OR ")), eqArgs...)
+			}
+		}
+
+		if len(filter.AvoidInjuryAreas) > 0 {
+			for _, avoid := range filter.AvoidInjuryAreas {
+				avoidTrim := strings.TrimSpace(avoid)
+				if avoidTrim != "" {
+					avoidPattern := "%" + avoidTrim + "%"
+					query = query.Where(`NOT (
+						LOWER(m.name) LIKE LOWER(?) OR LOWER(bp.name) LIKE LOWER(?)
+						OR EXISTS (
+							SELECT 1 FROM exercise.exercise_secondary_muscles esm
+							JOIN exercise.muscles sm ON sm.id = esm.muscle_id
+							WHERE esm.exercise_id = e.id AND LOWER(sm.name) LIKE LOWER(?)
+						)
+					)`, avoidPattern, avoidPattern, avoidPattern)
+				}
+			}
+		}
+
+		if len(filter.TagIDs) > 0 {
+			var tagConds []string
+			var tagArgs []interface{}
+			for _, tagVal := range filter.TagIDs {
+				tagTrim := strings.TrimSpace(tagVal)
+				if tagTrim != "" {
+					tagPattern := "%" + tagTrim + "%"
+					tagConds = append(tagConds, "(LOWER(t.name) LIKE LOWER(?) OR t.id = ?)")
+					tagArgs = append(tagArgs, tagPattern, tagTrim)
+				}
+			}
+			if len(tagConds) > 0 {
+				query = query.Where(fmt.Sprintf(`EXISTS (
+					SELECT 1 FROM exercise.exercise_tags et
+					JOIN exercise.tags t ON t.id = et.tag_id
+					WHERE et.exercise_id = e.id AND (%s)
+				)`, strings.Join(tagConds, " OR ")), tagArgs...)
+			}
 		}
 
 		if filter.Difficulty != "" {
-			query = query.Where("difficulty ILIKE ?", filter.Difficulty)
+			query = query.Where("LOWER(e.difficulty) LIKE LOWER(?)", filter.Difficulty)
 		}
 
 		if filter.Keyword != "" {
-			pattern := "%" + filter.Keyword + "%"
-			query = query.Where("name ILIKE ? OR id ILIKE ?", pattern, pattern)
+			pattern := "%" + strings.TrimSpace(filter.Keyword) + "%"
+			query = query.Where("LOWER(e.name) LIKE LOWER(?) OR LOWER(e.id) LIKE LOWER(?) OR LOWER(m.name) LIKE LOWER(?) OR LOWER(bp.name) LIKE LOWER(?)", pattern, pattern, pattern, pattern)
 		}
 
 		if filter.Limit > 0 {
@@ -82,21 +164,15 @@ func (r *PostgresExerciseCatalogReader) SearchByFilter(ctx context.Context, filt
 		}
 	}
 
-	var records []exerciseDBModel
-	err := query.Find(&records).Error
+	var rows []exerciseFullRow
+	err := query.Find(&rows).Error
 	if err != nil {
 		return nil, fmt.Errorf("search exercises in DB: %w", err)
 	}
 
-	if len(records) == 0 {
-		// Fallback to mock catalog if database tables are unseeded/empty
-		var mockReader MockExerciseCatalogReader
-		return mockReader.SearchByFilter(ctx, filter)
-	}
-
-	result := make([]port.Exercise, 0, len(records))
-	for i := range records {
-		result = append(result, mapDBRecordToExercise(&records[i]))
+	result := make([]port.Exercise, 0, len(rows))
+	for i := range rows {
+		result = append(result, mapFullRowToExercise(&rows[i]))
 	}
 
 	return result, nil
@@ -109,39 +185,53 @@ func (r *PostgresExerciseCatalogReader) GetByID(ctx context.Context, exerciseID 
 		return mockReader.GetByID(ctx, exerciseID)
 	}
 
-	var rec exerciseDBModel
-	err := r.db.WithContext(ctx).Where("id = ? AND status != 'ARCHIVED'", exerciseID).First(&rec).Error
+	var row exerciseFullRow
+	err := r.db.WithContext(ctx).Table("exercise.exercises e").
+		Select(`e.id, e.name, e.body_part_id, bp.name AS body_part_name,
+		        e.equipment_id, eq.name AS equipment_name,
+		        e.target_muscle_id, m.name AS target_muscle_name,
+		        e.difficulty, e.status`).
+		Joins("LEFT JOIN exercise.muscles m ON m.id = e.target_muscle_id").
+		Joins("LEFT JOIN exercise.body_parts bp ON bp.id = e.body_part_id").
+		Joins("LEFT JOIN exercise.equipments eq ON eq.id = e.equipment_id").
+		Where("e.id = ? AND e.status != 'ARCHIVED'", exerciseID).Take(&row).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			// Fallback check in mock catalog before returning ErrExerciseNotFound
-			var mockReader MockExerciseCatalogReader
-			if mockEx, mockErr := mockReader.GetByID(ctx, exerciseID); mockErr == nil {
-				return mockEx, nil
-			}
 			return port.Exercise{}, fmt.Errorf("%w: %s", port.ErrExerciseNotFound, exerciseID)
 		}
 		return port.Exercise{}, fmt.Errorf("get exercise by ID from DB: %w", err)
 	}
 
-	return mapDBRecordToExercise(&rec), nil
+	return mapFullRowToExercise(&row), nil
 }
 
-func mapDBRecordToExercise(rec *exerciseDBModel) port.Exercise {
-	muscleGroup := rec.TargetMuscleID
+func mapFullRowToExercise(row *exerciseFullRow) port.Exercise {
+	muscleGroup := row.TargetMuscleName
 	if muscleGroup == "" {
-		muscleGroup = rec.BodyPartID
+		muscleGroup = row.BodyPartName
+	}
+	if muscleGroup == "" {
+		muscleGroup = row.TargetMuscleID
+	}
+	if muscleGroup == "" {
+		muscleGroup = row.BodyPartID
 	}
 
-	eqLower := strings.ToLower(rec.EquipmentID)
-	isBodyweight := eqLower == "bodyweight" || eqLower == "none" || eqLower == "" || eqLower == "pull-up-bar" || eqLower == "body_weight"
-	isMachineOrCable := strings.Contains(eqLower, "cable") || strings.Contains(eqLower, "machine") || strings.Contains(eqLower, "pulldown")
+	eqName := row.EquipmentName
+	if eqName == "" {
+		eqName = row.EquipmentID
+	}
+
+	eqLower := strings.ToLower(eqName)
+	isBodyweight := eqLower == "bodyweight" || eqLower == "body weight" || eqLower == "none" || eqLower == "" || eqLower == "pull-up-bar" || eqLower == "body_weight"
+	isMachineOrCable := strings.Contains(eqLower, "cable") || strings.Contains(eqLower, "machine") || strings.Contains(eqLower, "pulldown") || strings.Contains(eqLower, "lever")
 
 	return port.Exercise{
-		ExerciseID:       rec.ID,
-		Name:             rec.Name,
+		ExerciseID:       row.ID,
+		Name:             row.Name,
 		MuscleGroup:      muscleGroup,
-		Equipment:        rec.EquipmentID,
-		Difficulty:       rec.Difficulty,
+		Equipment:        eqName,
+		Difficulty:       row.Difficulty,
 		IsBodyweight:     isBodyweight,
 		IsMachineOrCable: isMachineOrCable,
 	}

--- a/internal/coaching/infrastructure/adapters/postgres_readers_test.go
+++ b/internal/coaching/infrastructure/adapters/postgres_readers_test.go
@@ -96,6 +96,33 @@ func setupTestDB(t *testing.T) *gorm.DB {
 			difficulty TEXT,
 			status TEXT
 		);
+		CREATE TABLE IF NOT EXISTS exercise.muscles (
+			id TEXT PRIMARY KEY,
+			name TEXT,
+			body_part_id TEXT
+		);
+		CREATE TABLE IF NOT EXISTS exercise.body_parts (
+			id TEXT PRIMARY KEY,
+			name TEXT
+		);
+		CREATE TABLE IF NOT EXISTS exercise.equipments (
+			id TEXT PRIMARY KEY,
+			name TEXT
+		);
+		CREATE TABLE IF NOT EXISTS exercise.exercise_secondary_muscles (
+			exercise_id TEXT,
+			muscle_id TEXT,
+			PRIMARY KEY (exercise_id, muscle_id)
+		);
+		CREATE TABLE IF NOT EXISTS exercise.tags (
+			id TEXT PRIMARY KEY,
+			name TEXT
+		);
+		CREATE TABLE IF NOT EXISTS exercise.exercise_tags (
+			exercise_id TEXT,
+			tag_id TEXT,
+			PRIMARY KEY (exercise_id, tag_id)
+		);
 	`).Error
 	require.NoError(t, err)
 
@@ -264,13 +291,22 @@ func TestPostgresExerciseCatalogReader(t *testing.T) {
 		assert.Equal(t, "Barbell Incline Bench Press", ex.Name)
 	})
 
-	t.Run("returns mock catalog fallback when database table is unseeded", func(t *testing.T) {
+	t.Run("returns empty slice when no exercises match in database", func(t *testing.T) {
 		db := setupTestDB(t)
 		reader := NewPostgresExerciseCatalogReader(db)
 
 		// Database has empty exercise table
 		exs, err := reader.SearchByFilter(ctx, &port.ExerciseFilter{TargetMuscleID: "chest"})
 		require.NoError(t, err)
-		assert.NotEmpty(t, exs, "unseeded DB falls back to default catalog")
+		assert.Empty(t, exs, "unseeded DB returns empty slice without mock fallback")
+	})
+
+	t.Run("returns ErrExerciseNotFound for non-existent exercise ID", func(t *testing.T) {
+		db := setupTestDB(t)
+		reader := NewPostgresExerciseCatalogReader(db)
+
+		_, err := reader.GetByID(ctx, "pull-up")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, port.ErrExerciseNotFound)
 	})
 }

--- a/internal/coaching/infrastructure/adapters/postgres_user_profile_reader.go
+++ b/internal/coaching/infrastructure/adapters/postgres_user_profile_reader.go
@@ -78,6 +78,15 @@ func NewPostgresUserProfileReader(db *gorm.DB) *PostgresUserProfileReader {
 	return &PostgresUserProfileReader{db: db}
 }
 
+func isInvalidUUIDError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "invalid input syntax for type uuid") ||
+		strings.Contains(msg, "22p02")
+}
+
 // GetProfile fetches user profile details from profile.users, profile.body_metrics, and profile.injuries.
 func (r *PostgresUserProfileReader) GetProfile(ctx context.Context, userID string) (port.Profile, error) {
 	if r.db == nil {
@@ -89,8 +98,8 @@ func (r *PostgresUserProfileReader) GetProfile(ctx context.Context, userID strin
 	var userRecord userProfileDBModel
 	err := r.db.WithContext(ctx).Where("user_id = ?", userID).First(&userRecord).Error
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			log.Printf("[PostgresUserProfileReader] User profile record not found for userID=%s, returning default safe profile", userID)
+		if errors.Is(err, gorm.ErrRecordNotFound) || isInvalidUUIDError(err) {
+			log.Printf("[PostgresUserProfileReader] User profile record not found or invalid UUID format for userID=%s, returning default safe profile", userID)
 			var mockReader MockUserProfileReader
 			return mockReader.GetProfile(ctx, userID)
 		}

--- a/internal/coaching/infrastructure/adapters/postgres_workout_session_reader.go
+++ b/internal/coaching/infrastructure/adapters/postgres_workout_session_reader.go
@@ -91,6 +91,9 @@ func (r *PostgresWorkoutSessionReader) GetRecentSessions(ctx context.Context, us
 
 	err := query.Order("ended_at DESC, started_at DESC").Find(&records).Error
 	if err != nil {
+		if isInvalidUUIDError(err) {
+			return []port.WorkoutSession{}, nil
+		}
 		return nil, fmt.Errorf("fetch recent workout sessions: %w", err)
 	}
 

--- a/internal/coaching/infrastructure/ai/adk/prompts/generator.txt
+++ b/internal/coaching/infrastructure/ai/adk/prompts/generator.txt
@@ -61,13 +61,13 @@ user already has, not planning fresh ones.
           "target_muscle_groups": ["chest", "back"],
           "prescription": {
             "warm_ups": [
-              { "exercise_id": "push-up", "target_sets": 1, "target_reps": 15, "target_weight_kg": 0, "target_rpe": 3.0, "rest_set_sec": 0 }
+              { "exercise_id": "<UUID_FROM_SEARCH_EXERCISES>", "target_sets": 1, "target_reps": 15, "target_weight_kg": 0, "target_rpe": 3.0, "rest_set_sec": 0 }
             ],
             "main_exercises": [
-              { "exercise_id": "bench-press", "target_sets": 3, "target_reps": 8, "target_weight_kg": 80, "target_rpe": 7.0, "rest_set_sec": 120 }
+              { "exercise_id": "<UUID_FROM_SEARCH_EXERCISES>", "target_sets": 3, "target_reps": 8, "target_weight_kg": 80, "target_rpe": 7.0, "rest_set_sec": 120 }
             ],
             "cool_downs": [
-              { "exercise_id": "cable-fly", "target_sets": 1, "target_reps": 20, "target_weight_kg": 10, "target_rpe": 2.0, "rest_set_sec": 0 }
+              { "exercise_id": "<UUID_FROM_SEARCH_EXERCISES>", "target_sets": 1, "target_reps": 20, "target_weight_kg": 10, "target_rpe": 2.0, "rest_set_sec": 0 }
             ]
           },
           "reasoning": "string"
@@ -105,6 +105,8 @@ target_weight_kg, target_rpe, rest_set_sec.
    - Every `exercise_id` MUST be copied character-for-character from the `id`
      field of a `search_exercises` result. Do not abbreviate it, expand it,
      hyphenate it differently, or infer it from an exercise name.
+   - NEVER output generic slug strings like "pull-up", "bench-press", or "squat"
+     unless that exact string is returned in the `id` field of `search_exercises`.
    - If you need a movement you did not retrieve, call `search_exercises` again
      for that muscle group instead of guessing an id.
    - Output ONLY the JSON object. No prose, no markdown fences.

--- a/internal/coaching/infrastructure/ai/adk/tools.go
+++ b/internal/coaching/infrastructure/ai/adk/tools.go
@@ -58,11 +58,7 @@ func makeSearchExercisesTool(catalog port.ExerciseCatalogReader) (tool.Tool, err
 	return functiontool.New(
 		functiontool.Config{
 			Name:        "search_exercises",
-			Description: "Batch search exercise catalog for muscle groups (e.g. 'chest', 'back', 'legs', 'shoulders', " +
-				"'abs', 'biceps', 'triceps') and equipment (e.g. 'barbell', 'dumbbell', 'cable', 'body weight'). " +
-				"Internally JOINs exercises with primary/secondary muscles, body parts, and equipment tables, " +
-				"filters matching active movements per requested muscle group, and returns aggregated real " +
-				"catalog IDs (UUIDs) and details.",
+			Description: "Batch search exercise catalog for muscle groups and equipment, returning matching catalog IDs and details.",
 		},
 		func(ctx agent.Context, args SearchArgs) (SearchResults, error) {
 			groups := args.MuscleGroups

--- a/internal/coaching/infrastructure/ai/adk/tools.go
+++ b/internal/coaching/infrastructure/ai/adk/tools.go
@@ -58,7 +58,7 @@ func makeSearchExercisesTool(catalog port.ExerciseCatalogReader) (tool.Tool, err
 	return functiontool.New(
 		functiontool.Config{
 			Name:        "search_exercises",
-			Description: "Search exercise catalog for target muscle groups and available equipment in a single batch call.",
+			Description: "Batch search exercise catalog for muscle groups (e.g. 'chest', 'back', 'legs', 'shoulders', 'abs', 'biceps', 'triceps') and equipment (e.g. 'barbell', 'dumbbell', 'cable', 'body weight'). Internally JOINs exercises with primary/secondary muscles, body parts, and equipment tables, filters matching active movements per requested muscle group, and returns aggregated real catalog IDs (UUIDs) and details.",
 		},
 		func(ctx agent.Context, args SearchArgs) (SearchResults, error) {
 			groups := args.MuscleGroups

--- a/internal/coaching/infrastructure/ai/adk/tools.go
+++ b/internal/coaching/infrastructure/ai/adk/tools.go
@@ -58,7 +58,11 @@ func makeSearchExercisesTool(catalog port.ExerciseCatalogReader) (tool.Tool, err
 	return functiontool.New(
 		functiontool.Config{
 			Name:        "search_exercises",
-			Description: "Batch search exercise catalog for muscle groups (e.g. 'chest', 'back', 'legs', 'shoulders', 'abs', 'biceps', 'triceps') and equipment (e.g. 'barbell', 'dumbbell', 'cable', 'body weight'). Internally JOINs exercises with primary/secondary muscles, body parts, and equipment tables, filters matching active movements per requested muscle group, and returns aggregated real catalog IDs (UUIDs) and details.",
+			Description: "Batch search exercise catalog for muscle groups (e.g. 'chest', 'back', 'legs', 'shoulders', " +
+				"'abs', 'biceps', 'triceps') and equipment (e.g. 'barbell', 'dumbbell', 'cable', 'body weight'). " +
+				"Internally JOINs exercises with primary/secondary muscles, body parts, and equipment tables, " +
+				"filters matching active movements per requested muscle group, and returns aggregated real " +
+				"catalog IDs (UUIDs) and details.",
 		},
 		func(ctx agent.Context, args SearchArgs) (SearchResults, error) {
 			groups := args.MuscleGroups

--- a/internal/coaching/infrastructure/config/config.go
+++ b/internal/coaching/infrastructure/config/config.go
@@ -33,6 +33,12 @@ func LoadConfig() Config {
 	}
 
 	apiKey := os.Getenv("GOOGLE_API_KEY_COACHING")
+	if apiKey == "" {
+		apiKey = os.Getenv("GOOGLE_API_KEY")
+	}
+	if apiKey == "" {
+		apiKey = os.Getenv("GEMINI_API_KEY")
+	}
 	masked := "<EMPTY>"
 	if len(apiKey) > 8 {
 		masked = fmt.Sprintf("%s...%s (len=%d)", apiKey[:6], apiKey[len(apiKey)-4:], len(apiKey))

--- a/internal/coaching/module.go
+++ b/internal/coaching/module.go
@@ -120,7 +120,7 @@ func Initialize(ctx context.Context, deps *ModuleDeps) (*coachingGrpc.Server, po
 		txMgr = persistence.NewSQLTransactionManager(gormDB)
 	}
 
-	guard := guardrail.NewEngine(service.NewOverloadValidator(), nil, nil)
+	guard := guardrail.NewEngine(service.NewOverloadValidator(), deps.CatalogReader, nil, nil)
 	clock := realClock{}
 
 	// Wire gRPC Command & Query Handlers

--- a/internal/coaching/tests/e2e/testutil.go
+++ b/internal/coaching/tests/e2e/testutil.go
@@ -168,7 +168,7 @@ func SetupCoachingE2ESuite(t *testing.T) *TestSuite {
 	repo := newMemRepo()
 	outbox := &captureOutbox{}
 	mockAgent := &fakeCoachAgent{t: clock.t}
-	guard := guardrail.NewEngine(service.NewOverloadValidator(), nil, nil)
+	guard := guardrail.NewEngine(service.NewOverloadValidator(), nil, nil, nil)
 
 	initiateHandler := command.NewInitiateRoadmapHandler(fakeTx{}, repo, mockAgent, guard, outbox, clock)
 	regenerateHandler := command.NewRegenerateScheduleHandler(fakeTx{}, repo, mockAgent, guard, outbox, clock)


### PR DESCRIPTION
## 1. Vấn đề cần giải quyết (Problem to Solve)

- **Lỗi 0 bài tập khi search catalog (`search_exercises`)**: Tool `search_exercises` nhận nhóm cơ dạng chuỗi (ví dụ `"chest"`, `"back"`), nhưng `PostgresExerciseCatalogReader.SearchByFilter` lại query `WHERE target_muscle_id = 'chest' OR body_part_id = 'chest'`. Vì các cột `*_id` trong DB `exercise.exercises` lưu kiểu UUID nên Postgres trả về 0 kết quả, khiến AI Coach tự bịa ID slug như `"push-up"`, `"pull-up"` và bị Guardrail/Validator từ chối.
- **Lỗi vỡ SQL khi `user_id` không phải UUID**: Khi test trên ADK Web UI với `user_id` không phải định dạng UUID (như `"a"`, `"demo"`), Postgres bắn lỗi cú pháp SQL `22P02 (invalid input syntax for type uuid)` khiến luồng agent bị ngắt.
- **Rủi ro rò rỉ/ghi đè file `.env` ở Production**: Hàm `loadEnvFile()` chưa kiểm tra môi trường, có nguy cơ đọc nhầm file `.env` phát triển ở môi trường production.

---

## 2. Giải pháp kỹ thuật (Proposed Solution)

- **Thực thi SQL JOIN 3 bảng metadata**: Nâng cấp `PostgresExerciseCatalogReader` thực hiện `LEFT JOIN` với `exercise.muscles`, `exercise.body_parts`, `exercise.equipments` và subquery trên các bảng N-N (`exercise_secondary_muscles`, `exercise_tags`). Tìm kiếm case-insensitive bằng `LOWER(...) LIKE LOWER(...)` tương thích cả PostgreSQL và SQLite test DB.
- **Bắt lỗi UUID cú pháp an toàn**: Bổ sung hàm `isInvalidUUIDError` trong `PostgresUserProfileReader` và `PostgresWorkoutSessionReader`. Khi `user_id` không phải UUID (ví dụ khi test Web UI), tự động trả về **Default Safe Profile** thay vì vỡ SQL query.
- **Chặn nạp `.env` ở Production**: Bổ sung điều kiện `if strings.EqualFold(os.Getenv("APP_ENV"), "production") { return }` trong `loadEnvFile()`.
- **Đồng bộ Tool Description & System Prompt**: Cập nhật mô tả tool `search_exercises` trong `internal/coaching/infrastructure/ai/adk/tools.go` và `generator.txt` để AI Generator hiểu rõ định dạng UUID trả về.

---

## 3. Danh sách thay đổi & Tác động (Changes & Impact)

- `[internal/coaching/infrastructure/adapters/postgres_exercise_catalog_reader.go](internal/coaching/infrastructure/adapters/postgres_exercise_catalog_reader.go)`: Triển khai query JOIN đa bảng, map tên nhóm cơ/thiết bị tiếng Anh chuẩn cho AI Agent.
- `[internal/coaching/infrastructure/adapters/postgres_user_profile_reader.go](internal/coaching/infrastructure/adapters/postgres_user_profile_reader.go)`: Bắt lỗi `22P02` invalid UUID format và trả về default safe profile cho test users.
- `[internal/coaching/infrastructure/adapters/postgres_workout_session_reader.go](internal/coaching/infrastructure/adapters/postgres_workout_session_reader.go)`: Bắt lỗi `22P02` invalid UUID format và trả về mảng rỗng thay vì làm ngắt luồng DB.
- `[cmd/api/main.go](cmd/api/main.go)` & `[cmd/test-coaching/main.go](cmd/test-coaching/main.go)`: Bỏ qua nạp file `.env` khi `APP_ENV=production`.
- `[internal/coaching/infrastructure/ai/adk/tools.go](internal/coaching/infrastructure/ai/adk/tools.go)` & `[internal/coaching/infrastructure/ai/adk/prompts/generator.txt](internal/coaching/infrastructure/ai/adk/prompts/generator.txt)`: Cập nhật chi tiết mô tả tool search batching & định dạng UUID cho Agent.
- `[internal/coaching/infrastructure/adapters/postgres_readers_test.go](internal/coaching/infrastructure/adapters/postgres_readers_test.go)`: Bổ sung các bảng metadata vào SQLite test DB và kiểm thử tìm kiếm JOIN.

---

## 4. Kiểm thử & Xác minh (Testing & Verification)

### Automated Tests
- Đã chạy thành công 100% bộ kiểm thử unit test cho module coaching:
  ```bash
  go test -v ./internal/coaching/...
  ```
- Build thành công cả 2 binary:
  ```bash
  go build ./cmd/api
  go build ./cmd/test-coaching
  ```

### Manual Verification
- Khởi chạy thành công ADK Web UI server: `go run ./cmd/test-coaching web webui api`.
- Mở trình duyệt `http://localhost:8080/ui/`, nhập `user_id = "a"` và kiểm tra luồng sinh giáo án thành công không bị vỡ DB query.
