### PR TITLE
🐛 fix(event): hoàn thiện cross-module event consumers, CloudEvent decoding và đa topic subscription

### DIFF
--- a/internal/coaching/module.go
+++ b/internal/coaching/module.go
@@ -169,6 +169,24 @@ func Initialize(ctx context.Context, deps *ModuleDeps) (*coachingGrpc.Server, po
 		suggestAdHocHandler = query.NewSuggestAdHocSessionHandler(deps.RoadmapRepo, coachAgent, clock)
 	}
 
+	var completeSessionHandler *command.CompleteSessionHandler
+	var abortSessionHandler *command.AbortSessionHandler
+	if deps.RoadmapRepo != nil && deps.OutboxWriter != nil && txMgr != nil {
+		completeSessionHandler = command.NewCompleteSessionHandler(
+			txMgr,
+			deps.RoadmapRepo,
+			service.NewSCRCalculator(),
+			deps.OutboxWriter,
+			clock,
+		)
+		abortSessionHandler = command.NewAbortSessionHandler(
+			txMgr,
+			deps.RoadmapRepo,
+			deps.OutboxWriter,
+			clock,
+		)
+	}
+
 	coachingServer := coachingGrpc.NewServer(
 		initiateHandler,
 		regenerateHandler,
@@ -190,6 +208,8 @@ func Initialize(ctx context.Context, deps *ModuleDeps) (*coachingGrpc.Server, po
 	var outboxWorker *worker.OutboxWorker
 	var profileConsumer *consumer.ProfileCompletedConsumer
 	var profileConsumerCancel context.CancelFunc
+	var workoutConsumer *consumer.WorkoutExecutionConsumer
+	var workoutConsumerCancel context.CancelFunc
 
 	if deps.KafkaRegistry != nil {
 		cfg := config.LoadConfig()
@@ -205,13 +225,13 @@ func Initialize(ctx context.Context, deps *ModuleDeps) (*coachingGrpc.Server, po
 			}
 		}
 
-		// Subscribe to profile.events for auto-initiation of roadmaps.
+		// Subscribe to profile.events for auto-initiation / regeneration of roadmaps.
 		if initiateHandler != nil && outboxRepo != nil {
 			reader, rErr := deps.KafkaRegistry.GetReader(
 				"coaching-profile-completed-group", "profile.events", brokers,
 			)
 			if rErr == nil && reader != nil {
-				profileConsumer = consumer.NewProfileCompletedConsumer(reader, initiateHandler, outboxRepo)
+				profileConsumer = consumer.NewProfileCompletedConsumer(reader, initiateHandler, regenerateHandler, outboxRepo)
 				var consumerCtx context.Context
 				consumerCtx, profileConsumerCancel = context.WithCancel(ctx)
 				go profileConsumer.Start(consumerCtx)
@@ -222,6 +242,29 @@ func Initialize(ctx context.Context, deps *ModuleDeps) (*coachingGrpc.Server, po
 		} else {
 			log.Println("⚠️ Coaching ProfileCompletedConsumer not started (missing InitiateRoadmapHandler or OutboxRepo)")
 		}
+
+		// Subscribe to workout_execution.events for session completion / abortion.
+		if completeSessionHandler != nil && abortSessionHandler != nil && outboxRepo != nil {
+			weReader, weErr := deps.KafkaRegistry.GetReader(
+				"coaching-workout-execution-group", "workout_execution.events", brokers,
+			)
+			if weErr == nil && weReader != nil {
+				workoutConsumer = consumer.NewWorkoutExecutionConsumer(
+					weReader,
+					completeSessionHandler,
+					abortSessionHandler,
+					outboxRepo,
+				)
+				var weCtx context.Context
+				weCtx, workoutConsumerCancel = context.WithCancel(ctx)
+				go workoutConsumer.Start(weCtx)
+				log.Println("✅ Coaching WorkoutExecutionConsumer started (workout_execution.events)")
+			} else {
+				log.Printf("⚠️ Coaching WorkoutExecutionConsumer not started: reader error=%v", weErr)
+			}
+		} else {
+			log.Println("⚠️ Coaching WorkoutExecutionConsumer not started (missing CompleteSessionHandler, AbortSessionHandler or OutboxRepo)")
+		}
 	}
 
 	log.Println("✅ Coaching Module initialized successfully")
@@ -230,6 +273,9 @@ func Initialize(ctx context.Context, deps *ModuleDeps) (*coachingGrpc.Server, po
 		log.Println("Shutting down Coaching Module...")
 		if profileConsumerCancel != nil {
 			profileConsumerCancel()
+		}
+		if workoutConsumerCancel != nil {
+			workoutConsumerCancel()
 		}
 		if reminderWorker != nil {
 			reminderWorker.Stop()

--- a/internal/coaching/transport/consumer/profile_completed_consumer.go
+++ b/internal/coaching/transport/consumer/profile_completed_consumer.go
@@ -15,35 +15,77 @@ import (
 	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
 )
 
-// profileCompletedEventType is the CloudEvent type emitted by the Profile
-// module when a user finishes onboarding.
-const profileCompletedEventType = "contracts.supporting.profile.v1.event.ProfileCompleted"
+// CloudEvent types emitted by the Profile module.
+const (
+	profileCompletedEventType      = "contracts.supporting.profile.v1.event.ProfileCompleted"
+	profileCompletedEventTypeShort = "contracts.supporting.profile.v1.profileCompleted"
 
-// ProfileCompletedPayload mirrors the data field of a ProfileCompleted
-// CloudEvent. Only the fields Coaching actually needs are decoded.
-type ProfileCompletedPayload struct {
-	UserID string `json:"userId"`
+	profileUpdatedEventType      = "contracts.supporting.profile.v1.event.ProfileUpdated"
+	profileUpdatedEventTypeShort = "contracts.supporting.profile.v1.profileUpdated"
+
+	injuryReportedEventType      = "contracts.supporting.profile.v1.event.InjuryReported"
+	injuryReportedEventTypeShort = "contracts.supporting.profile.v1.injuryReported"
+
+	injuryRecoveredEventType      = "contracts.supporting.profile.v1.event.InjuryRecovered"
+	injuryRecoveredEventTypeShort = "contracts.supporting.profile.v1.injuryRecovered"
+)
+
+// ProfileEventPayload mirrors the data field of Profile CloudEvents.
+type ProfileEventPayload struct {
+	UserID      string `json:"userId"`
+	MuscleGroup string `json:"muscleGroup"`
+}
+
+// UnmarshalJSON supports both camelCase and snake_case for flexibility.
+func (p *ProfileEventPayload) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		UserIDCamel      string `json:"userId"`
+		UserIDSnake      string `json:"user_id"`
+		MuscleGroupCamel string `json:"muscleGroup"`
+		MuscleGroupSnake string `json:"muscle_group"`
+	}
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	if raw.UserIDCamel != "" {
+		p.UserID = raw.UserIDCamel
+	} else {
+		p.UserID = raw.UserIDSnake
+	}
+
+	if raw.MuscleGroupCamel != "" {
+		p.MuscleGroup = raw.MuscleGroupCamel
+	} else {
+		p.MuscleGroup = raw.MuscleGroupSnake
+	}
+
+	return nil
 }
 
 // ProfileCompletedConsumer listens to the "profile.events" Kafka topic and
-// triggers InitiateRoadmapHandler when a ProfileCompleted event arrives.
+// triggers InitiateRoadmapHandler or RegenerateScheduleHandler when profile events arrive.
 // Idempotency is enforced through coaching.outbox_log (D9 pattern).
 type ProfileCompletedConsumer struct {
-	reader   *segmentio.Reader
-	initiate *command.InitiateRoadmapHandler
-	outbox   port.OutboxRepository
+	reader     *segmentio.Reader
+	initiate   *command.InitiateRoadmapHandler
+	regenerate *command.RegenerateScheduleHandler
+	outbox     port.OutboxRepository
 }
 
 // NewProfileCompletedConsumer wires the consumer.
 func NewProfileCompletedConsumer(
 	reader *segmentio.Reader,
 	initiate *command.InitiateRoadmapHandler,
+	regenerate *command.RegenerateScheduleHandler,
 	outbox port.OutboxRepository,
 ) *ProfileCompletedConsumer {
 	return &ProfileCompletedConsumer{
-		reader:   reader,
-		initiate: initiate,
-		outbox:   outbox,
+		reader:     reader,
+		initiate:   initiate,
+		regenerate: regenerate,
+		outbox:     outbox,
 	}
 }
 
@@ -64,14 +106,12 @@ func (c *ProfileCompletedConsumer) Start(ctx context.Context) {
 				}
 
 				log.Printf("[Coaching] Error reading profile.events: %v", err)
-
 				time.Sleep(1 * time.Second)
-
 				continue
 			}
 
 			if processErr := c.processWithRetry(ctx, &msg); processErr != nil {
-				log.Printf("[Coaching] Exhausted retries processing ProfileCompleted event: %v", processErr)
+				log.Printf("[Coaching] Exhausted retries processing profile event: %v", processErr)
 			}
 		}
 	}
@@ -83,16 +123,13 @@ func (c *ProfileCompletedConsumer) processWithRetry(ctx context.Context, msg *se
 	const maxRetries = 3
 
 	var lastErr error
-
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		lastErr = c.HandleMessage(ctx, msg.Value)
-
 		if lastErr == nil {
 			return nil
 		}
 
-		log.Printf("[Coaching] ProfileCompleted attempt %d/%d failed: %v", attempt, maxRetries, lastErr)
-
+		log.Printf("[Coaching] Profile event attempt %d/%d failed: %v", attempt, maxRetries, lastErr)
 		time.Sleep(time.Duration(attempt*100) * time.Millisecond)
 	}
 
@@ -111,13 +148,6 @@ func (c *ProfileCompletedConsumer) HandleMessage(ctx context.Context, rawValue [
 		return errors.New("missing event id")
 	}
 
-	// Only handle ProfileCompleted; ignore other events on the same topic.
-	if env.Type != profileCompletedEventType {
-		log.Printf("[Coaching] ProfileCompletedConsumer ignoring event type: %s", env.Type)
-
-		return nil
-	}
-
 	// D9: idempotency check via coaching.outbox_log.
 	fresh, err := c.outbox.LogProcessed(ctx, env.ID, env.Type, "", rawValue)
 	if err != nil {
@@ -125,23 +155,41 @@ func (c *ProfileCompletedConsumer) HandleMessage(ctx context.Context, rawValue [
 	}
 
 	if !fresh {
-		log.Printf("[Coaching] Duplicate ProfileCompleted event skipped: id=%s", env.ID)
-
+		log.Printf("[Coaching] Duplicate profile event skipped: id=%s", env.ID)
 		return nil
 	}
 
-	return c.handleProfileCompleted(ctx, env.Data)
+	switch env.Type {
+	case profileCompletedEventType, profileCompletedEventTypeShort:
+		return c.handleProfileCompleted(ctx, env.Data)
+
+	case profileUpdatedEventType, profileUpdatedEventTypeShort:
+		return c.handleProfileUpdated(ctx, env.Data)
+
+	case injuryReportedEventType, injuryReportedEventTypeShort:
+		return c.handleInjuryReported(ctx, env.Data)
+
+	case injuryRecoveredEventType, injuryRecoveredEventTypeShort:
+		return c.handleInjuryRecovered(ctx, env.Data)
+
+	default:
+		log.Printf("[Coaching] ProfileCompletedConsumer ignoring event type: %s", env.Type)
+		return nil
+	}
 }
 
 func (c *ProfileCompletedConsumer) handleProfileCompleted(ctx context.Context, data []byte) error {
-	var p ProfileCompletedPayload
+	if c.initiate == nil {
+		return nil
+	}
+
+	var p ProfileEventPayload
 	if err := json.Unmarshal(data, &p); err != nil {
 		return fmt.Errorf("decode ProfileCompleted payload: %w", err)
 	}
 
 	if p.UserID == "" {
 		log.Println("[Coaching] ProfileCompleted event missing user_id; ignored")
-
 		return nil
 	}
 
@@ -149,11 +197,8 @@ func (c *ProfileCompletedConsumer) handleProfileCompleted(ctx context.Context, d
 
 	_, err := c.initiate.Handle(ctx, command.InitiateRoadmapCommand{UserID: p.UserID})
 	if err != nil {
-		// If the user already has an active roadmap, this is expected and not
-		// an error worth retrying.
 		if errors.Is(err, roadmap.ErrActiveRoadmapExists) {
 			log.Printf("[Coaching] User %s already has an active roadmap; skipping auto-initiation", p.UserID)
-
 			return nil
 		}
 
@@ -161,6 +206,80 @@ func (c *ProfileCompletedConsumer) handleProfileCompleted(ctx context.Context, d
 	}
 
 	log.Printf("[Coaching] Successfully auto-initiated roadmap for user %s", p.UserID)
+	return nil
+}
 
+func (c *ProfileCompletedConsumer) handleProfileUpdated(ctx context.Context, data []byte) error {
+	if c.regenerate == nil {
+		return nil
+	}
+
+	var p ProfileEventPayload
+	if err := json.Unmarshal(data, &p); err != nil {
+		return fmt.Errorf("decode ProfileUpdated payload: %w", err)
+	}
+
+	if p.UserID == "" {
+		return nil
+	}
+
+	log.Printf("[Coaching] ProfileUpdated received for user %s — regenerating pending schedule", p.UserID)
+	_, err := c.regenerate.Handle(ctx, command.RegenerateScheduleCommand{
+		UserID: p.UserID,
+		Reason: "profile_updated",
+	})
+	if err != nil && !errors.Is(err, roadmap.ErrRoadmapNotFound) {
+		return fmt.Errorf("regenerate schedule on profile updated for user %s: %w", p.UserID, err)
+	}
+	return nil
+}
+
+func (c *ProfileCompletedConsumer) handleInjuryReported(ctx context.Context, data []byte) error {
+	if c.regenerate == nil {
+		return nil
+	}
+
+	var p ProfileEventPayload
+	if err := json.Unmarshal(data, &p); err != nil {
+		return fmt.Errorf("decode InjuryReported payload: %w", err)
+	}
+
+	if p.UserID == "" {
+		return nil
+	}
+
+	log.Printf("[Coaching] InjuryReported received for user %s (muscle: %s) — regenerating schedule", p.UserID, p.MuscleGroup)
+	_, err := c.regenerate.Handle(ctx, command.RegenerateScheduleCommand{
+		UserID: p.UserID,
+		Reason: "injury_reported",
+	})
+	if err != nil && !errors.Is(err, roadmap.ErrRoadmapNotFound) {
+		return fmt.Errorf("regenerate schedule on injury reported for user %s: %w", p.UserID, err)
+	}
+	return nil
+}
+
+func (c *ProfileCompletedConsumer) handleInjuryRecovered(ctx context.Context, data []byte) error {
+	if c.regenerate == nil {
+		return nil
+	}
+
+	var p ProfileEventPayload
+	if err := json.Unmarshal(data, &p); err != nil {
+		return fmt.Errorf("decode InjuryRecovered payload: %w", err)
+	}
+
+	if p.UserID == "" {
+		return nil
+	}
+
+	log.Printf("[Coaching] InjuryRecovered received for user %s — regenerating schedule", p.UserID)
+	_, err := c.regenerate.Handle(ctx, command.RegenerateScheduleCommand{
+		UserID: p.UserID,
+		Reason: "injury_recovered",
+	})
+	if err != nil && !errors.Is(err, roadmap.ErrRoadmapNotFound) {
+		return fmt.Errorf("regenerate schedule on injury recovered for user %s: %w", p.UserID, err)
+	}
 	return nil
 }

--- a/internal/coaching/transport/consumer/profile_completed_consumer_test.go
+++ b/internal/coaching/transport/consumer/profile_completed_consumer_test.go
@@ -11,23 +11,6 @@ import (
 	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
 )
 
-// ---- stubs for InitiateRoadmapHandler dependencies ----
-
-// stubInitiateHandler is a lightweight stand-in for command.InitiateRoadmapHandler.
-// Since the handler struct fields are unexported, we cannot construct one
-// directly in an external test package. Instead, the consumer's HandleMessage
-// method is tested by providing a fully-wired handler through a thin wrapper
-// that lets us control outcomes.
-//
-// For the consumer-level tests we only care about:
-//   - CloudEvent envelope parsing + idempotency (tested with real stubOutbox)
-//   - Correct dispatch vs ignore for different event types
-//   - Graceful handling of ErrActiveRoadmapExists
-//
-// The actual handler logic is already covered by initiate_roadmap_test.go.
-
-// --- consumer-level unit tests ---
-
 func makeProfileCE(t *testing.T, id, typeStr string, dataObj any) []byte {
 	t.Helper()
 
@@ -54,9 +37,9 @@ func makeProfileCE(t *testing.T, id, typeStr string, dataObj any) []byte {
 
 func TestProfileCompletedConsumer_UnknownEventType_Ignored(t *testing.T) {
 	// Consumer should not error on unrelated event types on the same topic.
-	c := NewProfileCompletedConsumer(nil, nil, &stubOutbox{})
+	c := NewProfileCompletedConsumer(nil, nil, nil, &stubOutbox{})
 
-	raw := makeProfileCE(t, "evt-1", "contracts.supporting.profile.v1.event.ProfileUpdated",
+	raw := makeProfileCE(t, "evt-1", "some.unrelated.event",
 		map[string]string{"userId": "user-1"})
 
 	if err := c.HandleMessage(context.Background(), raw); err != nil {
@@ -65,10 +48,10 @@ func TestProfileCompletedConsumer_UnknownEventType_Ignored(t *testing.T) {
 }
 
 func TestProfileCompletedConsumer_MissingEventID(t *testing.T) {
-	c := NewProfileCompletedConsumer(nil, nil, &stubOutbox{})
+	c := NewProfileCompletedConsumer(nil, nil, nil, &stubOutbox{})
 
 	raw := makeProfileCE(t, "", profileCompletedEventType,
-		ProfileCompletedPayload{UserID: "user-1"})
+		ProfileEventPayload{UserID: "user-1"})
 
 	if err := c.HandleMessage(context.Background(), raw); err == nil {
 		t.Errorf("expected error for missing event id")
@@ -77,11 +60,11 @@ func TestProfileCompletedConsumer_MissingEventID(t *testing.T) {
 
 func TestProfileCompletedConsumer_DuplicateEvent_Skipped(t *testing.T) {
 	stub := &stubOutbox{}
-	c := NewProfileCompletedConsumer(nil, nil, stub)
+	c := NewProfileCompletedConsumer(nil, nil, nil, stub)
 
 	// Use empty userId so that even if handler were called, it would no-op.
 	raw := makeProfileCE(t, "evt-dup", profileCompletedEventType,
-		ProfileCompletedPayload{UserID: ""})
+		ProfileEventPayload{UserID: ""})
 
 	// First call: fresh — handler receives empty userId and ignores.
 	if err := c.HandleMessage(context.Background(), raw); err != nil {
@@ -95,18 +78,43 @@ func TestProfileCompletedConsumer_DuplicateEvent_Skipped(t *testing.T) {
 }
 
 func TestProfileCompletedConsumer_MissingUserID_Ignored(t *testing.T) {
-	c := NewProfileCompletedConsumer(nil, nil, &stubOutbox{})
+	c := NewProfileCompletedConsumer(nil, nil, nil, &stubOutbox{})
 
 	raw := makeProfileCE(t, "evt-no-uid", profileCompletedEventType,
-		ProfileCompletedPayload{UserID: ""})
+		ProfileEventPayload{UserID: ""})
 
 	if err := c.HandleMessage(context.Background(), raw); err != nil {
 		t.Errorf("expected nil for missing user_id, got %v", err)
 	}
 }
 
+func TestProfileCompletedConsumer_ProfileUpdatedAndInjuryEvents(t *testing.T) {
+	c := NewProfileCompletedConsumer(nil, nil, nil, &stubOutbox{})
+
+	// Test ProfileUpdated
+	rawUpd := makeProfileCE(t, "evt-upd", profileUpdatedEventType,
+		ProfileEventPayload{UserID: "usr-1"})
+	if err := c.HandleMessage(context.Background(), rawUpd); err != nil {
+		t.Errorf("expected nil for ProfileUpdated with nil handler, got %v", err)
+	}
+
+	// Test InjuryReported
+	rawInj := makeProfileCE(t, "evt-inj", injuryReportedEventType,
+		ProfileEventPayload{UserID: "usr-1", MuscleGroup: "Chest"})
+	if err := c.HandleMessage(context.Background(), rawInj); err != nil {
+		t.Errorf("expected nil for InjuryReported with nil handler, got %v", err)
+	}
+
+	// Test InjuryRecovered
+	rawRec := makeProfileCE(t, "evt-rec", injuryRecoveredEventType,
+		ProfileEventPayload{UserID: "usr-1"})
+	if err := c.HandleMessage(context.Background(), rawRec); err != nil {
+		t.Errorf("expected nil for InjuryRecovered with nil handler, got %v", err)
+	}
+}
+
 func TestProfileCompletedConsumer_InvalidJSON(t *testing.T) {
-	c := NewProfileCompletedConsumer(nil, nil, &stubOutbox{})
+	c := NewProfileCompletedConsumer(nil, nil, nil, &stubOutbox{})
 
 	if err := c.HandleMessage(context.Background(), []byte("not json")); err == nil {
 		t.Errorf("expected error for invalid json")
@@ -124,10 +132,10 @@ func (f *failOutbox) LogProcessed(context.Context, string, string, string, []byt
 }
 
 func TestProfileCompletedConsumer_OutboxError(t *testing.T) {
-	c := NewProfileCompletedConsumer(nil, nil, &failOutbox{})
+	c := NewProfileCompletedConsumer(nil, nil, nil, &failOutbox{})
 
 	raw := makeProfileCE(t, "evt-err", profileCompletedEventType,
-		ProfileCompletedPayload{UserID: "user-1"})
+		ProfileEventPayload{UserID: "user-1"})
 
 	err := c.HandleMessage(context.Background(), raw)
 	if err == nil {
@@ -144,8 +152,6 @@ func TestProfileCompletedConsumer_OutboxError(t *testing.T) {
 type alwaysExistsRepo struct{ port.RoadmapRepository }
 
 func (alwaysExistsRepo) FindActiveByUser(context.Context, string) (*roadmap.Roadmap, error) {
-	// Return a non-nil roadmap so InitiateRoadmapHandler returns
-	// ErrActiveRoadmapExists.
 	return &roadmap.Roadmap{}, nil
 }
 

--- a/internal/coaching/transport/consumer/workout_execution_consumer.go
+++ b/internal/coaching/transport/consumer/workout_execution_consumer.go
@@ -9,7 +9,9 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"time"
 
+	segmentio "github.com/segmentio/kafka-go"
 	"github.com/viethung213/gym-companion/internal/coaching/application/command"
 	"github.com/viethung213/gym-companion/internal/coaching/application/port"
 	"github.com/viethung213/gym-companion/internal/coaching/domain/roadmap"
@@ -25,29 +27,162 @@ type cloudEventEnvelope struct {
 }
 
 // WorkoutSessionCompletedPayload mirrors the proto CloudEvent data field.
+// It flexibly decodes both camelCase (protojson) and snake_case JSON keys.
 type WorkoutSessionCompletedPayload struct {
-	SessionID        string  `json:"session_id"`
-	UserID           string  `json:"user_id"`
-	CompletedAt      string  `json:"completed_at"` // RFC3339
-	TotalSets        int32   `json:"total_sets"`
-	TotalVolume      float32 `json:"total_volume"`
-	AverageFormScore float32 `json:"average_form_score"`
-	AverageRPE       float32 `json:"average_rpe"`
-	PlanID           string  `json:"plan_id"`
+	SessionID        string  `json:"sessionId"`
+	UserID           string  `json:"userId"`
+	CompletedAt      string  `json:"completedAt"` // RFC3339
+	TotalSets        int32   `json:"totalSets"`
+	TotalVolume      float32 `json:"totalVolume"`
+	AverageFormScore float32 `json:"averageFormScore"`
+	AverageRPE       float32 `json:"averageRpe"`
+	PlanID           string  `json:"planId"`
+}
+
+// UnmarshalJSON implements custom unmarshaling to support both camelCase and snake_case.
+func (p *WorkoutSessionCompletedPayload) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		// camelCase (protojson)
+		SessionIDCamel        string   `json:"sessionId"`
+		UserIDCamel           string   `json:"userId"`
+		CompletedAtCamel      string   `json:"completedAt"`
+		TotalSetsCamel        int32    `json:"totalSets"`
+		TotalVolumeCamel      float32  `json:"totalVolume"`
+		AverageFormScoreCamel *float32 `json:"averageFormScore"`
+		AverageRPECamel       float32  `json:"averageRpe"`
+		PlanIDCamel           string   `json:"planId"`
+
+		// snake_case
+		SessionIDSnake        string   `json:"session_id"`
+		UserIDSnake           string   `json:"user_id"`
+		CompletedAtSnake      string   `json:"completed_at"`
+		TotalSetsSnake        int32    `json:"total_sets"`
+		TotalVolumeSnake      float32  `json:"total_volume"`
+		AverageFormScoreSnake *float32 `json:"average_form_score"`
+		AverageRPESnake       float32  `json:"average_rpe"`
+		PlanIDSnake           string   `json:"plan_id"`
+	}
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	if raw.PlanIDCamel != "" {
+		p.PlanID = raw.PlanIDCamel
+	} else {
+		p.PlanID = raw.PlanIDSnake
+	}
+
+	if raw.SessionIDCamel != "" {
+		p.SessionID = raw.SessionIDCamel
+	} else {
+		p.SessionID = raw.SessionIDSnake
+	}
+
+	if raw.UserIDCamel != "" {
+		p.UserID = raw.UserIDCamel
+	} else {
+		p.UserID = raw.UserIDSnake
+	}
+
+	if raw.CompletedAtCamel != "" {
+		p.CompletedAt = raw.CompletedAtCamel
+	} else {
+		p.CompletedAt = raw.CompletedAtSnake
+	}
+
+	if raw.TotalSetsCamel != 0 {
+		p.TotalSets = raw.TotalSetsCamel
+	} else {
+		p.TotalSets = raw.TotalSetsSnake
+	}
+
+	if raw.TotalVolumeCamel != 0 {
+		p.TotalVolume = raw.TotalVolumeCamel
+	} else {
+		p.TotalVolume = raw.TotalVolumeSnake
+	}
+
+	if raw.AverageFormScoreCamel != nil {
+		p.AverageFormScore = *raw.AverageFormScoreCamel
+	} else if raw.AverageFormScoreSnake != nil {
+		p.AverageFormScore = *raw.AverageFormScoreSnake
+	}
+
+	if raw.AverageRPECamel != 0 {
+		p.AverageRPE = raw.AverageRPECamel
+	} else {
+		p.AverageRPE = raw.AverageRPESnake
+	}
+
+	return nil
 }
 
 // WorkoutSessionAbortedPayload mirrors the proto CloudEvent data field.
+// It flexibly decodes both camelCase (protojson) and snake_case JSON keys.
 type WorkoutSessionAbortedPayload struct {
-	SessionID string `json:"session_id"`
-	UserID    string `json:"user_id"`
-	AbortedAt string `json:"aborted_at"`
+	SessionID string `json:"sessionId"`
+	UserID    string `json:"userId"`
+	AbortedAt string `json:"abortedAt"`
 	Reason    string `json:"reason"`
-	PlanID    string `json:"plan_id"`
+	PlanID    string `json:"planId"`
+}
+
+func (p *WorkoutSessionAbortedPayload) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		// camelCase (protojson)
+		SessionIDCamel string `json:"sessionId"`
+		UserIDCamel    string `json:"userId"`
+		AbortedAtCamel string `json:"abortedAt"`
+		PlanIDCamel    string `json:"planId"`
+
+		// snake_case
+		SessionIDSnake string `json:"session_id"`
+		UserIDSnake    string `json:"user_id"`
+		AbortedAtSnake string `json:"aborted_at"`
+		PlanIDSnake    string `json:"plan_id"`
+
+		// Shared field
+		Reason string `json:"reason"`
+	}
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	p.Reason = raw.Reason
+
+	if raw.PlanIDCamel != "" {
+		p.PlanID = raw.PlanIDCamel
+	} else {
+		p.PlanID = raw.PlanIDSnake
+	}
+
+	if raw.SessionIDCamel != "" {
+		p.SessionID = raw.SessionIDCamel
+	} else {
+		p.SessionID = raw.SessionIDSnake
+	}
+
+	if raw.UserIDCamel != "" {
+		p.UserID = raw.UserIDCamel
+	} else {
+		p.UserID = raw.UserIDSnake
+	}
+
+	if raw.AbortedAtCamel != "" {
+		p.AbortedAt = raw.AbortedAtCamel
+	} else {
+		p.AbortedAt = raw.AbortedAtSnake
+	}
+
+	return nil
 }
 
 // WorkoutExecutionConsumer routes WorkoutSessionCompleted/Aborted events to
 // the appropriate command handler.
 type WorkoutExecutionConsumer struct {
+	reader   *segmentio.Reader
 	complete *command.CompleteSessionHandler
 	abort    *command.AbortSessionHandler
 	outbox   port.OutboxRepository
@@ -55,11 +190,69 @@ type WorkoutExecutionConsumer struct {
 
 // NewWorkoutExecutionConsumer wires the consumer.
 func NewWorkoutExecutionConsumer(
+	reader *segmentio.Reader,
 	complete *command.CompleteSessionHandler,
 	abort *command.AbortSessionHandler,
 	outbox port.OutboxRepository,
 ) *WorkoutExecutionConsumer {
-	return &WorkoutExecutionConsumer{complete: complete, abort: abort, outbox: outbox}
+	return &WorkoutExecutionConsumer{
+		reader:   reader,
+		complete: complete,
+		abort:    abort,
+		outbox:   outbox,
+	}
+}
+
+// Start begins the blocking read loop. It stops when ctx is cancelled.
+func (c *WorkoutExecutionConsumer) Start(ctx context.Context) {
+	log.Println("[Coaching] Starting WorkoutExecutionConsumer on topic workout_execution.events...")
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("[Coaching] Stopping WorkoutExecutionConsumer due to context cancellation.")
+			return
+		default:
+			if c.reader == nil {
+				log.Println("[Coaching] WorkoutExecutionConsumer reader is nil; stopping loop.")
+				return
+			}
+
+			msg, err := c.reader.ReadMessage(ctx)
+			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					return
+				}
+
+				log.Printf("[Coaching] Error reading workout_execution.events: %v", err)
+				time.Sleep(1 * time.Second)
+				continue
+			}
+
+			if processErr := c.processWithRetry(ctx, &msg); processErr != nil {
+				log.Printf("[Coaching] Exhausted retries processing workout execution event: %v", processErr)
+			}
+		}
+	}
+}
+
+// processWithRetry attempts to handle the message up to maxRetries times with
+// incremental backoff (100ms per attempt number).
+func (c *WorkoutExecutionConsumer) processWithRetry(ctx context.Context, msg *segmentio.Message) error {
+	const maxRetries = 3
+
+	var lastErr error
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		lastErr = c.HandleMessage(ctx, msg.Value)
+		if lastErr == nil {
+			return nil
+		}
+
+		log.Printf("[Coaching] Workout event attempt %d/%d failed: %v", attempt, maxRetries, lastErr)
+		time.Sleep(time.Duration(attempt*100) * time.Millisecond)
+	}
+
+	return fmt.Errorf("failed after %d attempts: %w", maxRetries, lastErr)
 }
 
 // HandleMessage decodes and dispatches one Kafka message. Errors are returned
@@ -76,29 +269,27 @@ func (c *WorkoutExecutionConsumer) HandleMessage(ctx context.Context, rawValue [
 	}
 
 	// D9: idempotency check via coaching.outbox_log
-
 	fresh, err := c.outbox.LogProcessed(ctx, env.ID, env.Type, "", rawValue)
-
 	if err != nil {
 		return fmt.Errorf("log processed: %w", err)
 	}
 
 	if !fresh {
 		log.Printf("[Coaching] Duplicate event skipped: id=%s type=%s", env.ID, env.Type)
-
 		return nil
 	}
 
 	switch env.Type {
-	case "contracts.core.workout_execution.v1.event.WorkoutSessionCompleted":
+	case "contracts.core.workout_execution.v1.workoutSessionCompleted",
+		"contracts.core.workout_execution.v1.event.WorkoutSessionCompleted":
 		return c.handleCompleted(ctx, env.Data)
 
-	case "contracts.core.workout_execution.v1.event.WorkoutSessionAborted":
+	case "contracts.core.workout_execution.v1.workoutSessionAborted",
+		"contracts.core.workout_execution.v1.event.WorkoutSessionAborted":
 		return c.handleAborted(ctx, env.Data)
 
 	default:
 		log.Printf("[Coaching] Ignoring unknown event type: %s", env.Type)
-
 		return nil
 	}
 }
@@ -112,25 +303,19 @@ func (c *WorkoutExecutionConsumer) handleCompleted(ctx context.Context, data []b
 
 	if p.PlanID == "" {
 		log.Printf("[Coaching] WorkoutSessionCompleted missing plan_id; session=%s ignored", p.SessionID)
-
 		return nil
 	}
 
 	_, err := c.complete.Handle(ctx, command.CompleteSessionCommand{
-		SessionPlanID: p.PlanID,
-
-		TotalActualSets: int(p.TotalSets),
-
+		SessionPlanID:       p.PlanID,
+		TotalActualSets:     int(p.TotalSets),
 		TotalPrescribedSets: 0, // Best-effort: recomputed inside handler if available.
-
-		AverageActualRPE: float64(p.AverageRPE),
-
-		CompletedAt: p.CompletedAt,
+		AverageActualRPE:    float64(p.AverageRPE),
+		CompletedAt:         p.CompletedAt,
 	})
 
 	if errors.Is(err, roadmap.ErrSessionNotFound) {
 		log.Printf("[Coaching] WorkoutSessionCompleted references unknown plan_id=%s; ignoring", p.PlanID)
-
 		return nil
 	}
 
@@ -155,7 +340,6 @@ func (c *WorkoutExecutionConsumer) handleAborted(ctx context.Context, data []byt
 
 	if errors.Is(err, roadmap.ErrSessionNotFound) {
 		log.Printf("[Coaching] WorkoutSessionAborted references unknown plan_id=%s; ignoring", p.PlanID)
-
 		return nil
 	}
 

--- a/internal/coaching/transport/consumer/workout_execution_consumer_test.go
+++ b/internal/coaching/transport/consumer/workout_execution_consumer_test.go
@@ -44,25 +44,19 @@ func makeCE(t *testing.T, id, typeStr string, dataObj any) []byte {
 	t.Helper()
 
 	dataBytes, err := json.Marshal(dataObj)
-
 	if err != nil {
 		t.Fatalf("marshal data: %v", err)
 	}
 
 	env := map[string]any{
 		"specversion": "1.0",
-
-		"id": id,
-
-		"source": "test",
-
-		"type": typeStr,
-
-		"data": json.RawMessage(dataBytes),
+		"id":          id,
+		"source":      "test",
+		"type":        typeStr,
+		"data":        json.RawMessage(dataBytes),
 	}
 
 	b, err := json.Marshal(env)
-
 	if err != nil {
 		t.Fatalf("marshal env: %v", err)
 	}
@@ -71,7 +65,7 @@ func makeCE(t *testing.T, id, typeStr string, dataObj any) []byte {
 }
 
 func TestConsumer_UnknownEventType_Ignored(t *testing.T) {
-	c := NewWorkoutExecutionConsumer(nil, nil, &stubOutbox{})
+	c := NewWorkoutExecutionConsumer(nil, nil, nil, &stubOutbox{})
 
 	raw := makeCE(t, "evt-1", "some.unknown.event", map[string]string{"x": "y"})
 
@@ -81,11 +75,10 @@ func TestConsumer_UnknownEventType_Ignored(t *testing.T) {
 }
 
 func TestConsumer_MissingEventID(t *testing.T) {
-	c := NewWorkoutExecutionConsumer(nil, nil, &stubOutbox{})
+	c := NewWorkoutExecutionConsumer(nil, nil, nil, &stubOutbox{})
 
-	raw := makeCE(t, "", "contracts.core.workout_execution.v1.event.WorkoutSessionCompleted",
-
-		WorkoutSessionCompletedPayload{PlanID: "sp-1"})
+	raw := makeCE(t, "", "contracts.core.workout_execution.v1.workoutSessionCompleted",
+		map[string]any{"planId": "sp-1"})
 
 	if err := c.HandleMessage(context.Background(), raw); err == nil {
 		t.Errorf("expected error for missing event id")
@@ -94,22 +87,134 @@ func TestConsumer_MissingEventID(t *testing.T) {
 
 func TestConsumer_DuplicateEvent_Skipped(t *testing.T) {
 	stub := &stubOutbox{}
+	c := NewWorkoutExecutionConsumer(nil, nil, nil, stub)
 
-	c := NewWorkoutExecutionConsumer(nil, nil, stub)
-
-	raw := makeCE(t, "evt-1", "contracts.core.workout_execution.v1.event.WorkoutSessionCompleted",
-
-		WorkoutSessionCompletedPayload{PlanID: "" /* deliberately empty to short-circuit before handler */})
+	raw := makeCE(t, "evt-1", "contracts.core.workout_execution.v1.workoutSessionCompleted",
+		map[string]any{"planId": "" /* empty planId to short-circuit before handler */})
 
 	// First call: fresh — since PlanID empty, handler no-ops.
-
 	if err := c.HandleMessage(context.Background(), raw); err != nil {
 		t.Fatalf("first: %v", err)
 	}
 
 	// Second call: duplicate — outbox_log dedup returns fresh=false.
-
 	if err := c.HandleMessage(context.Background(), raw); err != nil {
 		t.Errorf("second (duplicate): %v", err)
 	}
+}
+
+func TestWorkoutSessionCompletedPayload_Unmarshal(t *testing.T) {
+	t.Run("camelCase protojson mapping", func(t *testing.T) {
+		raw := []byte(`{
+			"sessionId": "sess-1",
+			"userId": "user-1",
+			"completedAt": "2026-08-09T00:00:00Z",
+			"totalSets": 12,
+			"totalVolume": 1500.5,
+			"averageFormScore": 92.5,
+			"averageRpe": 8.0,
+			"planId": "plan-101"
+		}`)
+
+		var p WorkoutSessionCompletedPayload
+		if err := json.Unmarshal(raw, &p); err != nil {
+			t.Fatalf("unmarshal error: %v", err)
+		}
+
+		if got, want := p.PlanID, "plan-101"; got != want {
+			t.Errorf("PlanID got %s, want %s", got, want)
+		}
+		if got, want := p.SessionID, "sess-1"; got != want {
+			t.Errorf("SessionID got %s, want %s", got, want)
+		}
+		if got, want := p.UserID, "user-1"; got != want {
+			t.Errorf("UserID got %s, want %s", got, want)
+		}
+		if got, want := p.TotalSets, int32(12); got != want {
+			t.Errorf("TotalSets got %d, want %d", got, want)
+		}
+		if got, want := p.TotalVolume, float32(1500.5); got != want {
+			t.Errorf("TotalVolume got %f, want %f", got, want)
+		}
+		if got, want := p.AverageFormScore, float32(92.5); got != want {
+			t.Errorf("AverageFormScore got %f, want %f", got, want)
+		}
+		if got, want := p.AverageRPE, float32(8.0); got != want {
+			t.Errorf("AverageRPE got %f, want %f", got, want)
+		}
+	})
+
+	t.Run("snake_case fallback mapping", func(t *testing.T) {
+		raw := []byte(`{
+			"session_id": "sess-2",
+			"user_id": "user-2",
+			"completed_at": "2026-08-09T00:00:00Z",
+			"total_sets": 8,
+			"total_volume": 800.0,
+			"average_form_score": 85.0,
+			"average_rpe": 7.5,
+			"plan_id": "plan-202"
+		}`)
+
+		var p WorkoutSessionCompletedPayload
+		if err := json.Unmarshal(raw, &p); err != nil {
+			t.Fatalf("unmarshal error: %v", err)
+		}
+
+		if got, want := p.PlanID, "plan-202"; got != want {
+			t.Errorf("PlanID got %s, want %s", got, want)
+		}
+		if got, want := p.SessionID, "sess-2"; got != want {
+			t.Errorf("SessionID got %s, want %s", got, want)
+		}
+		if got, want := p.AverageRPE, float32(7.5); got != want {
+			t.Errorf("AverageRPE got %f, want %f", got, want)
+		}
+	})
+}
+
+func TestWorkoutSessionAbortedPayload_Unmarshal(t *testing.T) {
+	t.Run("camelCase mapping", func(t *testing.T) {
+		raw := []byte(`{
+			"sessionId": "sess-3",
+			"userId": "user-3",
+			"abortedAt": "2026-08-09T00:00:00Z",
+			"reason": "timeout",
+			"planId": "plan-303"
+		}`)
+
+		var p WorkoutSessionAbortedPayload
+		if err := json.Unmarshal(raw, &p); err != nil {
+			t.Fatalf("unmarshal error: %v", err)
+		}
+
+		if got, want := p.PlanID, "plan-303"; got != want {
+			t.Errorf("PlanID got %s, want %s", got, want)
+		}
+		if got, want := p.Reason, "timeout"; got != want {
+			t.Errorf("Reason got %s, want %s", got, want)
+		}
+	})
+
+	t.Run("snake_case mapping", func(t *testing.T) {
+		raw := []byte(`{
+			"session_id": "sess-4",
+			"user_id": "user-4",
+			"aborted_at": "2026-08-09T00:00:00Z",
+			"reason": "user_cancelled",
+			"plan_id": "plan-404"
+		}`)
+
+		var p WorkoutSessionAbortedPayload
+		if err := json.Unmarshal(raw, &p); err != nil {
+			t.Fatalf("unmarshal error: %v", err)
+		}
+
+		if got, want := p.PlanID, "plan-404"; got != want {
+			t.Errorf("PlanID got %s, want %s", got, want)
+		}
+		if got, want := p.Reason, "user_cancelled"; got != want {
+			t.Errorf("Reason got %s, want %s", got, want)
+		}
+	})
 }

--- a/internal/notification/module.go
+++ b/internal/notification/module.go
@@ -83,13 +83,22 @@ func Initialize(ctx context.Context, deps ModuleDeps) (*notificationGRPC.GRPCHan
 			log.Printf("Warning: failed to get kafka writer for notification outbox: %v", wErr)
 		}
 
-		// Inbound Event Consumer
-		reader, rErr := deps.KafkaRegistry.GetReader("notification-group", "notification.events", brokers)
-		if rErr == nil && reader != nil {
-			consumer := notificationConsumer.NewNotificationEventConsumer(reader, sendPushHandler, outboxLogRepo)
-			go consumer.Start(ctxWorkers)
-		} else {
-			log.Printf("Warning: failed to get kafka reader for notification events: %v", rErr)
+		// Inbound Event Consumers for all module event topics
+		topics := []string{
+			"notification.events",
+			"coaching.events",
+			"nutrition.events",
+			"workout_execution.events",
+		}
+		for _, topic := range topics {
+			reader, rErr := deps.KafkaRegistry.GetReader("notification-group", topic, brokers)
+			if rErr == nil && reader != nil {
+				consumer := notificationConsumer.NewNotificationEventConsumer(reader, sendPushHandler, outboxLogRepo)
+				go consumer.Start(ctxWorkers)
+				log.Printf("Notification consumer started on topic '%s'", topic)
+			} else {
+				log.Printf("Warning: failed to get kafka reader for notification topic %s: %v", topic, rErr)
+			}
 		}
 
 		// Inbound Event Failure Retry Worker

--- a/internal/notification/transport/consumer/event_consumer.go
+++ b/internal/notification/transport/consumer/event_consumer.go
@@ -52,13 +52,21 @@ func getPushAllowedEventRules() map[string]eventPushConfig {
 			DefaultTitle: "Gym Companion Thông Báo",
 			DefaultBody:  "Bạn có thông báo mới từ ứng dụng.",
 		},
+		"contracts.generic.notification.v1.notificationRequested": {
+			DefaultTitle: "Gym Companion Thông Báo",
+			DefaultBody:  "Bạn có thông báo mới từ ứng dụng.",
+		},
 
 		// =========================================================================
-		// 2. CORE MODULE: WORKOUT EXECUTION (Lập Kỷ kỷ lục cá nhân mới - PR)
+		// 2. CORE MODULE: WORKOUT EXECUTION (Lập Kỷ lục cá nhân mới - PR)
 		// =========================================================================
 		"contracts.core.workout_execution.v1.event.NewPersonalRecordAchieved": {
-			DefaultTitle: "Kỷ kỷ lục cá nhân mới! 🏆",
-			DefaultBody:  "Chúc mừng bạn vừa xác lập một kỷ kỷ lục cá nhân (PR) mới!",
+			DefaultTitle: "Kỷ lục cá nhân mới! 🏆",
+			DefaultBody:  "Chúc mừng bạn vừa xác lập một kỷ lục cá nhân (PR) mới!",
+		},
+		"contracts.core.workout_execution.v1.newPersonalRecordAchieved": {
+			DefaultTitle: "Kỷ lục cá nhân mới! 🏆",
+			DefaultBody:  "Chúc mừng bạn vừa xác lập một kỷ lục cá nhân (PR) mới!",
 		},
 
 		// =========================================================================
@@ -68,11 +76,19 @@ func getPushAllowedEventRules() map[string]eventPushConfig {
 			DefaultTitle: "Nhắc nhở bữa ăn 🥗",
 			DefaultBody:  "Sắp đến giờ ăn theo lịch dinh dưỡng (trước 30 phút). Nhớ chuẩn bị bữa ăn nhé!",
 		},
+		"contracts.core.nutrition.v1.upcomingMealReminder": {
+			DefaultTitle: "Nhắc nhở bữa ăn 🥗",
+			DefaultBody:  "Sắp đến giờ ăn theo lịch dinh dưỡng (trước 30 phút). Nhớ chuẩn bị bữa ăn nhé!",
+		},
 
 		// =========================================================================
 		// 4. CORE MODULE: COACHING (Sắp đến giờ tập - Trước 1 tiếng)
 		// =========================================================================
 		"contracts.core.coaching.v1.event.UpcomingWorkoutReminder": {
+			DefaultTitle: "Nhắc nhở buổi tập ⏰",
+			DefaultBody:  "Sắp đến giờ tập luyện theo lịch HLV (trước 1 tiếng). Chuẩn bị sẵn sàng nhé!",
+		},
+		"contracts.core.coaching.v1.upcomingWorkoutReminder": {
 			DefaultTitle: "Nhắc nhở buổi tập ⏰",
 			DefaultBody:  "Sắp đến giờ tập luyện theo lịch HLV (trước 1 tiếng). Chuẩn bị sẵn sàng nhé!",
 		},

--- a/internal/nutrition/infrastructure/kafka/consumer.go
+++ b/internal/nutrition/infrastructure/kafka/consumer.go
@@ -4,17 +4,27 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"strings"
 	"time"
 
 	segmentio "github.com/segmentio/kafka-go"
 	"github.com/viethung213/gym-companion/internal/nutrition/application/command"
 )
 
+type cloudEventEnvelope struct {
+	SpecVersion string          `json:"specversion"`
+	ID          string          `json:"id"`
+	Source      string          `json:"source"`
+	Type        string          `json:"type"`
+	Data        json.RawMessage `json:"data"`
+}
+
 type WorkoutSessionCompletedPayload struct {
-	SessionID           string    `json:"sessionId"`
-	UserID              string    `json:"userId"`
-	TotalCaloriesBurned float64   `json:"totalCaloriesBurned"`
-	CompletedAt         time.Time `json:"completedAt"`
+	SessionID           string  `json:"sessionId"`
+	UserID              string  `json:"userId"`
+	TotalCaloriesBurned float64 `json:"totalCaloriesBurned"`
+	TotalVolume         float64 `json:"totalVolume"`
+	CompletedAt         string  `json:"completedAt"`
 }
 
 type Consumer struct {
@@ -35,7 +45,7 @@ func (c *Consumer) Start(ctx context.Context) error {
 		return nil
 	}
 
-	log.Println("[Nutrition Kafka Consumer] Started listening to Kafka topic 'workout.session.completed'")
+	log.Println("[Nutrition Kafka Consumer] Started listening to Kafka topic 'workout_execution.events'")
 
 	for {
 		select {
@@ -63,14 +73,32 @@ func (c *Consumer) Start(ctx context.Context) error {
 
 //nolint:gocritic // msg is passed by value per kafka library signature
 func (c *Consumer) handleMessage(ctx context.Context, msg segmentio.Message) {
-	var payload WorkoutSessionCompletedPayload
-	if err := json.Unmarshal(msg.Value, &payload); err != nil {
-		log.Printf("[Nutrition Kafka Consumer] Error unmarshaling event payload: %v", err)
+	var env cloudEventEnvelope
+	if err := json.Unmarshal(msg.Value, &env); err != nil {
+		log.Printf("[Nutrition Kafka Consumer] Error unmarshaling CloudEvent envelope: %v", err)
 		return
 	}
 
-	log.Printf("[Nutrition Kafka Consumer] Received WorkoutSessionCompleted Event: UserID=%s, Burned=%.2f kcal",
-		payload.UserID, payload.TotalCaloriesBurned)
+	if !strings.HasSuffix(env.Type, "workoutSessionCompleted") && !strings.HasSuffix(env.Type, "WorkoutSessionCompleted") {
+		return
+	}
+
+	var payload WorkoutSessionCompletedPayload
+	if len(env.Data) > 0 {
+		if err := json.Unmarshal(env.Data, &payload); err != nil {
+			log.Printf("[Nutrition Kafka Consumer] Error unmarshaling event payload: %v", err)
+			return
+		}
+	} else {
+		// Fallback if payload is not wrapped in data
+		if err := json.Unmarshal(msg.Value, &payload); err != nil {
+			log.Printf("[Nutrition Kafka Consumer] Error unmarshaling raw payload: %v", err)
+			return
+		}
+	}
+
+	log.Printf("[Nutrition Kafka Consumer] Received WorkoutSessionCompleted Event: UserID=%s, SessionID=%s, Volume=%.2f",
+		payload.UserID, payload.SessionID, payload.TotalVolume)
 
 	if c.recalibrateHandler != nil && payload.UserID != "" {
 		_, err := c.recalibrateHandler.Handle(ctx, command.RecalibratePlanWithPantryCommand{

--- a/internal/nutrition/infrastructure/kafka/consumer_test.go
+++ b/internal/nutrition/infrastructure/kafka/consumer_test.go
@@ -1,0 +1,104 @@
+package kafka
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	segmentio "github.com/segmentio/kafka-go"
+	"github.com/viethung213/gym-companion/internal/nutrition/application/command"
+	"github.com/viethung213/gym-companion/internal/nutrition/domain/aggregate"
+	"github.com/viethung213/gym-companion/internal/nutrition/domain/repository"
+)
+
+type mockPlanRepo struct {
+	calledUserID string
+}
+
+var _ repository.NutritionPlanRepository = (*mockPlanRepo)(nil)
+
+func (m *mockPlanRepo) FindByUserIDAndDate(ctx context.Context, userID string, date time.Time) (*aggregate.NutritionPlan, error) {
+	m.calledUserID = userID
+	return nil, errors.New("plan not found")
+}
+
+func (m *mockPlanRepo) Save(ctx context.Context, plan *aggregate.NutritionPlan) error {
+	return nil
+}
+
+func (m *mockPlanRepo) Update(ctx context.Context, plan *aggregate.NutritionPlan) error {
+	return nil
+}
+
+func (m *mockPlanRepo) FindActiveUserIDs(ctx context.Context, withinDays int) ([]string, error) {
+	return nil, nil
+}
+
+func (m *mockPlanRepo) FindPlansForDate(ctx context.Context, targetDate time.Time) ([]*aggregate.NutritionPlan, error) {
+	return nil, nil
+}
+
+func (m *mockPlanRepo) GetUserMealSchedules(ctx context.Context, userID string) (map[string]string, error) {
+	return nil, nil
+}
+
+func (m *mockPlanRepo) SaveUserMealSchedules(ctx context.Context, userID string, schedules map[string]string) error {
+	return nil
+}
+
+func TestConsumer_HandleMessage(t *testing.T) {
+	t.Run("CloudEvent envelope with WorkoutSessionCompleted payload", func(t *testing.T) {
+		mockRepo := &mockPlanRepo{}
+		recalHandler := command.NewRecalibratePlanWithPantryHandler(mockRepo, nil, nil, nil)
+		c := NewConsumer(nil, recalHandler)
+
+		innerPayload := map[string]any{
+			"sessionId":   "sess-101",
+			"userId":      "usr-202",
+			"totalVolume": 1250.0,
+			"completedAt": "2026-08-09T00:00:00Z",
+		}
+		dataBytes, _ := json.Marshal(innerPayload)
+
+		ce := map[string]any{
+			"specversion": "1.0",
+			"id":          "evt-123",
+			"source":      "services/workout-execution-service",
+			"type":        "contracts.core.workout_execution.v1.workoutSessionCompleted",
+			"data":        json.RawMessage(dataBytes),
+		}
+		ceBytes, _ := json.Marshal(ce)
+
+		c.handleMessage(context.Background(), segmentio.Message{
+			Value: ceBytes,
+		})
+
+		if got, want := mockRepo.calledUserID, "usr-202"; got != want {
+			t.Errorf("expected recalibrate called for user %s, got %s", want, got)
+		}
+	})
+
+	t.Run("Non-workout event is ignored", func(t *testing.T) {
+		mockRepo := &mockPlanRepo{}
+		recalHandler := command.NewRecalibratePlanWithPantryHandler(mockRepo, nil, nil, nil)
+		c := NewConsumer(nil, recalHandler)
+
+		ce := map[string]any{
+			"specversion": "1.0",
+			"id":          "evt-456",
+			"type":        "contracts.core.nutrition.v1.mealLogged",
+			"data":        json.RawMessage(`{"userId":"usr-303"}`),
+		}
+		ceBytes, _ := json.Marshal(ce)
+
+		c.handleMessage(context.Background(), segmentio.Message{
+			Value: ceBytes,
+		})
+
+		if mockRepo.calledUserID != "" {
+			t.Errorf("expected no recalibration, but called for %s", mockRepo.calledUserID)
+		}
+	})
+}


### PR DESCRIPTION
### 1. Mục tiêu & Vấn đề giải quyết (Problem to Solve)
- **Coaching Module**: Chưa có consumer lắng nghe các sự kiện `WorkoutSessionCompleted` và `WorkoutSessionAborted` từ module `workout_execution`, khiến trạng thái các buổi tập (`SessionPlan`) trong Roadmap không tự động chuyển sang `COMPLETED` / `ABORTED`. Đồng thời, các sự kiện cập nhật profile/chấn thương (`ProfileUpdated`, `InjuryReported`, `InjuryRecovered`) chưa được đón nhận để điều chỉnh lịch tập.
- **Nutrition Module**: Consumer `WorkoutSessionCompleted` giải mã trực tiếp toàn bộ Kafka message vào struct thay vì bóc tách trường `data` từ CloudEvent envelope, khiến `UserID` luôn nhận giá trị rỗng và luồng tự động bù calo/dinh dưỡng sau tập không bao giờ chạy.
- **Notification Module**: Kafka reader chỉ lắng nghe duy nhất topic `"notification.events"`, trong khi các sự kiện nhắc nhở quan trọng được phát ra từ `"coaching.events"` (nhắc buổi tập -1h), `"nutrition.events"` (nhắc bữa ăn -30p), và `"workout_execution.events"` (kỷ lục cá nhân PR).

---

### 2. Giải pháp thực hiện (Proposed Solution)
1. **Coaching Module**:
   - Triển khai và wire `WorkoutExecutionConsumer` trong [internal/coaching/module.go](internal/coaching/module.go) lắng nghe topic `workout_execution.events` (group `coaching-workout-execution-group`).
   - Hỗ trợ unmarshal linh hoạt cả `camelCase` (từ `protojson.Marshal` như `planId`, `sessionId`, `averageRpe`) và `snake_case`.
   - Mở rộng [profile_completed_consumer.go](internal/coaching/transport/consumer/profile_completed_consumer.go) để đón nhận `ProfileUpdated`, `InjuryReported`, `InjuryRecovered` và kích hoạt `RegenerateScheduleHandler`.
2. **Nutrition Module**:
   - Cập nhật [internal/nutrition/infrastructure/kafka/consumer.go](internal/nutrition/infrastructure/kafka/consumer.go) bóc tách lớp `cloudEventEnvelope` trước khi decode `env.Data` thành `WorkoutSessionCompletedPayload`.
   - Bổ sung unit test kiểm thử bóc tách CloudEvent và kích hoạt `RecalibratePlanWithPantryHandler`.
3. **Notification Module**:
   - Cập nhật [internal/notification/module.go](internal/notification/module.go) khởi tạo reader lắng nghe đồng thời 4 topic: `"notification.events"`, `"coaching.events"`, `"nutrition.events"`, `"workout_execution.events"`.
   - Mở rộng quy tắc nhận diện event type (hỗ trợ cả dạng camelCase rút gọn) trong [event_consumer.go](internal/notification/transport/consumer/event_consumer.go).

---

### 3. Thay đổi chi tiết các file (Changes & Impact)
- `[internal/coaching/module.go](internal/coaching/module.go)`: Wire `WorkoutExecutionConsumer`, truyền `RegenerateScheduleHandler` vào `ProfileCompletedConsumer`, quản lý lifecycle context và graceful shutdown.
- `[internal/coaching/transport/consumer/workout_execution_consumer.go](internal/coaching/transport/consumer/workout_execution_consumer.go)`: Custom JSON unmarshaler cho payload hoàn thành/hủy buổi tập, hỗ trợ đa dạng event types, thêm `Start(ctx)` loop kèm retry backoff.
- `[internal/coaching/transport/consumer/workout_execution_consumer_test.go](internal/coaching/transport/consumer/workout_execution_consumer_test.go)`: Test cases cho unmarshal camelCase/snake_case, dedup idempotency, missing event ID.
- `[internal/coaching/transport/consumer/profile_completed_consumer.go](internal/coaching/transport/consumer/profile_completed_consumer.go)`: Mở rộng xử lý `ProfileUpdated`, `InjuryReported`, `InjuryRecovered`.
- `[internal/coaching/transport/consumer/profile_completed_consumer_test.go](internal/coaching/transport/consumer/profile_completed_consumer_test.go)`: Cập nhật mock repository và test cases cho các sự kiện mới.
- `[internal/nutrition/infrastructure/kafka/consumer.go](internal/nutrition/infrastructure/kafka/consumer.go)`: Giải mã CloudEvent envelope `data` lấy đúng `UserID` và `TotalVolume` sau buổi tập.
- `[internal/nutrition/infrastructure/kafka/consumer_test.go](internal/nutrition/infrastructure/kafka/consumer_test.go)`: Unit test cho consumer của Nutrition.
- `[internal/notification/module.go](internal/notification/module.go)`: Đăng ký consumer loop cho cả 4 topic sự kiện từ các module liên quan.
- `[internal/notification/transport/consumer/event_consumer.go](internal/notification/transport/consumer/event_consumer.go)`: Bổ sung event types camelCase cho PR, Meal Reminder và Workout Reminder.

---

### 4. Kiểm thử & Xác minh (Testing & Verification)
- **Automated Unit & Integration Tests**:
  - `go test ./internal/...` $\rightarrow$ **PASS 100%** trên toàn bộ 7 modules (`auth`, `coaching`, `exercise`, `notification`, `nutrition`, `profile`, `workout_execution`).
  - `go test -v ./internal/coaching/transport/consumer/...` $\rightarrow$ PASS.
  - `go test -v ./internal/nutrition/infrastructure/kafka/...` $\rightarrow$ PASS.
  - `go test -v ./internal/notification/transport/consumer/...` $\rightarrow$ PASS.
- **Build Verification**:
  - `go build ./...` $\rightarrow$ Hoàn tất không có lỗi biên dịch.
