### PR TITLE
🐛 fix: resolve schema selection error in database migrations and pool search path

### DIFF
--- a/internal/shared/database/db.go
+++ b/internal/shared/database/db.go
@@ -73,10 +73,17 @@ func (r *Registry) GetPool(module string) (*sql.DB, error) {
 		}
 
 		// Inject search_path parameter to enforce module schema isolation at query time
+		// while allowing fallback to public schema for shared extensions and functions
 		if strings.Contains(globalURL, "?") {
-			dbURL = fmt.Sprintf("%s&search_path=%s", globalURL, module)
+			dbURL = fmt.Sprintf("%s&search_path=%s,public", globalURL, module)
 		} else {
-			dbURL = fmt.Sprintf("%s?search_path=%s", globalURL, module)
+			dbURL = fmt.Sprintf("%s?search_path=%s,public", globalURL, module)
+		}
+	} else if !strings.Contains(dbURL, "search_path") {
+		if strings.Contains(dbURL, "?") {
+			dbURL = fmt.Sprintf("%s&search_path=%s,public", dbURL, module)
+		} else {
+			dbURL = fmt.Sprintf("%s?search_path=%s,public", dbURL, module)
 		}
 	}
 

--- a/internal/shared/database/migrations/01-init-schemas.sql
+++ b/internal/shared/database/migrations/01-init-schemas.sql
@@ -5,8 +5,11 @@
 -- and Outbox Log tables (processed_at for incoming).
 -- ==========================================
 
--- Enable pg_trgm extension for substring & trigram search
-CREATE EXTENSION IF NOT EXISTS pg_trgm;
+-- ------------------------------------------
+-- 0. CORE EXTENSIONS & PUBLIC SCHEMA
+-- ------------------------------------------
+CREATE SCHEMA IF NOT EXISTS public;
+CREATE EXTENSION IF NOT EXISTS pg_trgm SCHEMA public;
 
 -- ------------------------------------------
 -- 1. SCHEMA: auth

--- a/internal/shared/database/migrations/11-create-trgm-indexes-for-exercise-and-motion.sql
+++ b/internal/shared/database/migrations/11-create-trgm-indexes-for-exercise-and-motion.sql
@@ -2,8 +2,9 @@
 -- 11. Add pg_trgm extension and GIN trigram indexes for exercise & motion substring search
 -- ==========================================
 
--- Enable pg_trgm extension for substring/trigram matching
-CREATE EXTENSION IF NOT EXISTS pg_trgm;
+-- Enable pg_trgm extension for substring/trigram matching in public schema
+CREATE SCHEMA IF NOT EXISTS public;
+CREATE EXTENSION IF NOT EXISTS pg_trgm SCHEMA public;
 
 -- Fast substring search (ILIKE '%keyword%') for exercises table
 CREATE INDEX IF NOT EXISTS idx_exercises_name_trgm 


### PR DESCRIPTION
### 1. Problem to Solve
- Khi khởi động server lần đầu trên database mới, script migration `01-init-schemas.sql` gặp lỗi `fatal error: run database auto migrations: execute embedded migration 01-init-schemas.sql: pq: no schema has been selected to create in (3F000)`.
- Nguyên nhân do connection pool của `auth` được gán `search_path=auth` khi schema `auth` chưa tồn tại, khiến lệnh `CREATE EXTENSION IF NOT EXISTS pg_trgm` ở đầu file migration không tìm thấy schema hợp lệ để khởi tạo extension.
- Ngoài ra, nếu `search_path` không chứa `public`, các Bounded Context khác sẽ không tìm thấy operator class `gin_trgm_ops` khi tạo index trigram.

### 2. Proposed Solution
- Khởi tạo rõ ràng schema `public` và chỉ định `SCHEMA public` khi tạo extension `pg_trgm` trong các file migration (`01-init-schemas.sql`, `11-create-trgm-indexes-for-exercise-and-motion.sql`).
- Cập nhật hàm `GetPool()` trong `db.go` để thiết lập `search_path=<module>,public` đảm bảo mỗi module vừa có schema isolation vừa dùng được các extension/hàm chung trong `public`.

### 3. Changes & Impact
- [internal/shared/database/migrations/01-init-schemas.sql](internal/shared/database/migrations/01-init-schemas.sql): Khởi tạo schema `public` trước và cấu hình `CREATE EXTENSION IF NOT EXISTS pg_trgm SCHEMA public`.
- [internal/shared/database/migrations/11-create-trgm-indexes-for-exercise-and-motion.sql](internal/shared/database/migrations/11-create-trgm-indexes-for-exercise-and-motion.sql): Bổ sung `CREATE SCHEMA IF NOT EXISTS public` và `SCHEMA public` đảm bảo tính an toàn và idempotent.
- [internal/shared/database/db.go](internal/shared/database/db.go): Cấu hình fallback `public` trong `search_path` (`<module>,public`).

### 4. Testing & Verification
- **Automated Tests**: Chạy `go test ./internal/shared/database/...` (Passed).
- **Build Verification**: Chạy `go build -v ./cmd/api` biên dịch thành công không có lỗi.
