### PR TITLE
🐛 fix: xử lý an toàn múi giờ cho buổi tập ad-hoc và unmarshal dynamic jsonb thông báo

### DIFF
--- a/internal/coaching/application/command/create_adhoc_session.go
+++ b/internal/coaching/application/command/create_adhoc_session.go
@@ -142,10 +142,11 @@ func (h *CreateAdhocSessionHandler) Handle(ctx context.Context, cmd CreateAdhocS
 func findOrFallbackDayPlan(rm *roadmap.Roadmap, date time.Time) *roadmap.DayPlan {
 	var lastDay *roadmap.DayPlan
 
+	targetDateStr := date.Format("2006-01-02")
 	for _, w := range rm.Weeks() {
 		for _, d := range w.Days() {
 			lastDay = d
-			if d.Info().ScheduledDate.Truncate(24*time.Hour) == date {
+			if d.Info().ScheduledDate.Format("2006-01-02") == targetDateStr {
 				return d
 			}
 		}

--- a/internal/notification/infrastructure/persistence/postgres/models.go
+++ b/internal/notification/infrastructure/persistence/postgres/models.go
@@ -74,8 +74,15 @@ type InAppNotificationModel struct {
 func (m *InAppNotificationModel) ToDomain() (*aggregate.InAppNotification, error) {
 	dataMap := make(map[string]string)
 	if len(m.Data) > 0 {
-		if err := json.Unmarshal(m.Data, &dataMap); err != nil {
-			return nil, fmt.Errorf("unmarshal in-app notification data JSON: %w", err)
+		var rawMap map[string]any
+		if err := json.Unmarshal(m.Data, &rawMap); err != nil {
+			if errDirect := json.Unmarshal(m.Data, &dataMap); errDirect != nil {
+				return nil, fmt.Errorf("unmarshal in-app notification data JSON: %w", err)
+			}
+		} else {
+			for k, v := range rawMap {
+				dataMap[k] = fmt.Sprintf("%v", v)
+			}
 		}
 	}
 	return aggregate.ReconstituteInAppNotification(

--- a/internal/notification/module.go
+++ b/internal/notification/module.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"connectrpc.com/connect"
@@ -69,7 +70,7 @@ func Initialize(ctx context.Context, deps ModuleDeps) (*notificationGRPC.GRPCHan
 
 	var kafkaPub *notificationKafka.Publisher
 	if deps.KafkaRegistry != nil && cfg.KafkaBrokers != "" {
-		brokers := []string{cfg.KafkaBrokers}
+		brokers := strings.Split(cfg.KafkaBrokers, ",")
 
 		// Outbound Outbox Worker Publisher
 		writer, wErr := deps.KafkaRegistry.GetWriter("notification.events", brokers)


### PR DESCRIPTION
## 📌 Tóm tắt các thay đổi (Summary of Changes)

Pull Request này giải quyết triệt để 3 lỗi nghiêm trọng ở 2 bounded context `coaching` và `notification`, giúp hệ thống vận hành ổn định, chính xác về mặt thời gian và ngăn ngừa toàn bộ các lỗi crash API thông báo khi nhận dữ liệu sự kiện từ Kafka.

---

## 🔍 Phân tích chi tiết các vấn đề (Problem Deep-Dive) & Giải pháp

### 1. 🕒 Lỗi Múi giờ làm lệch ngày buổi tập tự do (`internal/coaching/application/command/create_adhoc_session.go`)
* **Tình huống thực tế (User Journey)**:
  - Khi người dùng ở múi giờ Việt Nam (UTC+7) mở ứng dụng vào ngày hôm nay và bấm **"Quick Workout"** (Tập tự do).
* **Cơ chế lỗi (Root Cause)**:
  - Client gửi ngày theo giờ địa phương (`2026-08-12 00:00:00 +07:00`), trong khi `ScheduledDate` trong Database được lưu ở chuẩn UTC (`2026-08-12 00:00:00 UTC`).
  - Trong Go, toán tử so sánh `==` trên kiểu `time.Time` kiểm tra cả Location/Timezone và Monotonic Clock. Phép so sánh cũ:
    ```go
    if d.Info().ScheduledDate.Truncate(24*time.Hour) == date
    ```
    luôn trả về `false` do lệch múi giờ.
  - Vòng lặp duyệt qua toàn bộ 28 ngày trong lộ trình 4 tuần mà không tìm thấy ngày nào khớp, dẫn đến rơi vào fallback gán nhầm buổi tập vào **ngày cuối cùng của Tuần thứ 4** (`lastDay`).
* **Giải pháp (Fix)**:
  - Chuẩn hóa so sánh ngày theo chuỗi ngày lịch `YYYY-MM-DD`:
    ```go
    targetDateStr := date.Format("2006-01-02")
    if d.Info().ScheduledDate.Format("2006-01-02") == targetDateStr {
        return d
    }
    ```
  - Đảm bảo tìm chính xác DayPlan của ngày hôm nay bất kể người dùng hay server ở múi giờ nào.

---

### 2. 🛡️ Lỗi Crash API danh sách thông báo do Unmarshal JSONB chứa số (`internal/notification/infrastructure/persistence/postgres/models.go`)
* **Tình huống thực tế (User Journey)**:
  - Khi người dùng tập xong 1 hiệp có mức tạ (ví dụ: Bench Press 80kg x 8 reps), hệ thống tính toán Kỷ lục cá nhân (PR) và phát sự kiện `NewPersonalRecordAchieved` qua Kafka kèm payload JSONB có chứa số: `{"weight": 80, "reps": 8, "one_rep_max": 101.3}`.
* **Cơ chế lỗi (Root Cause)**:
  - Hàm `InAppNotificationModel.ToDomain()` thực hiện Unmarshal trực tiếp cột JSONB `m.Data` vào kiểu `map[string]string`:
    ```go
    if err := json.Unmarshal(m.Data, &dataMap); err != nil { ... }
    ```
  - Khi JSON parser gặp giá trị kiểu số (`80` hoặc `101.3`) hoặc kiểu boolean, Go JSON Decoder văng lỗi runtime:
    > `json: cannot unmarshal number into Go value of type string`
  - Hậu quả: Toàn bộ API gRPC/ConnectRPC `ListNotifications` bị văng lỗi mã **HTTP 500 (Internal Server Error)**, khiến Frontend ném ngoại lệ `FAILED_TO_FETCH_NOTIFICATIONS` và làm trắng trang Notifications của người dùng.
* **Giải pháp (Fix)**:
  - Chuyển sang Unmarshal linh hoạt vào `map[string]any` trước, sau đó chuyển đổi an toàn các kiểu nguyên thủy (số, chuỗi, boolean) sang string qua `fmt.Sprintf("%v", v)`:
    ```go
    var rawMap map[string]any
    if err := json.Unmarshal(m.Data, &rawMap); err != nil {
        if errDirect := json.Unmarshal(m.Data, &dataMap); errDirect != nil {
            return nil, fmt.Errorf("unmarshal in-app notification data JSON: %w", err)
        }
    } else {
        for k, v := range rawMap {
            dataMap[k] = fmt.Sprintf("%v", v)
        }
    }
    ```

---

### 3. 📨 Lỗi ngắt kết nối Kafka khi cấu hình nhiều Broker (`internal/notification/module.go`)
* **Tình huống thực tế (Deployment / Cluster)**:
  - Trong môi trường Docker hoặc cụm Kafka Cluster trên Production, biến môi trường `KAFKA_BROKERS` chứa danh sách nhiều địa chỉ ngăn cách bằng dấu phẩy: `KAFKA_BROKERS=localhost:9094,kafka:9092` hoặc `kafka1:9092,kafka2:9092`.
* **Cơ chế lỗi (Root Cause)**:
  - Code cũ truyền nguyên chuỗi vào 1 phần tử của slice:
    ```go
    brokers := []string{cfg.KafkaBrokers} // -> ["localhost:9094,kafka:9092"]
    ```
  - Thư viện `kafka-go` coi toàn bộ chuỗi chứa dấu phẩy đó là 1 tên miền máy chủ duy nhất và thực hiện truy vấn DNS, dẫn đến lỗi:
    > `lookup localhost:9094,kafka:9092: no such host`
  - Hậu quả: Notification Consumer bị crash ngầm, không thể kết nối tới Kafka Broker để lắng nghe sự kiện từ các module khác.
* **Giải pháp (Fix)**:
  - Tách chuỗi broker chuẩn xác bằng `strings.Split(cfg.KafkaBrokers, ",")`, đồng bộ với chuẩn thiết kế của tất cả các module khác (`workout_execution`, `coaching`, `profile`).

---

## 🧪 Kế hoạch kiểm thử (Verification Plan)

- [x] **Unit Tests**:
  - `go test ./internal/coaching/application/command/...` (PASS 100%)
  - `go test ./internal/notification/...` (PASS 100%)
- [x] **Kiểm thử tích hợp E2E thực tế**:
  - Đã xác thực thành công toàn bộ chuỗi nghiệp vụ:
    1. Tạo buổi tập tự do Ad-hoc đúng ngày hôm nay.
    2. Ghi nhận hiệp tập mức tạ lớn (40kg - 100kg).
    3. Hoàn tất buổi tập $\rightarrow$ Đẩy sự kiện PR vào Kafka.
    4. Notification Consumer nhận sự kiện $\rightarrow$ Tạo bản ghi In-App Notification an toàn trong PostgreSQL.
    5. API `ListNotifications` trả về dữ liệu chuẩn xác, không còn lỗi 500 hay crash Frontend.
