### PR TITLE
:sparkles: feat(coaching): wire adhoc hint duration & fix session plan duration upsert

### DIFF
--- a/internal/coaching/infrastructure/ai/adk/agent.go
+++ b/internal/coaching/infrastructure/ai/adk/agent.go
@@ -55,6 +55,7 @@ type CoachingContextAgent struct {
 	mu      sync.Mutex
 	results map[string]*PlanResult
 	reasons map[string]string
+	hints   map[string]*port.AdHocHint
 }
 
 // NewCoachingContextAgent initializes LLM agents, tools, skills, callbacks, and workflow nodes.
@@ -79,6 +80,7 @@ func NewCoachingContextAgent(
 		validator:     newPlanValidator(catalogReader),
 		results:       make(map[string]*PlanResult),
 		reasons:       make(map[string]string),
+		hints:         make(map[string]*port.AdHocHint),
 	}
 
 	if err := cca.build(ctx); err != nil {
@@ -145,8 +147,8 @@ func (c *CoachingContextAgent) Adapt(ctx context.Context, userID, decisionReason
 }
 
 // SuggestAdHocSession satisfies port.CoachAgent.
-func (c *CoachingContextAgent) SuggestAdHocSession(ctx context.Context, userID string, _ *port.AdHocHint) (port.SuggestedSession, error) {
-	res, err := c.runWorkflow(ctx, c.suggestAdHocAgent, userID, "")
+func (c *CoachingContextAgent) SuggestAdHocSession(ctx context.Context, userID string, hint *port.AdHocHint) (port.SuggestedSession, error) {
+	res, err := c.runAdHocWorkflow(ctx, userID, hint)
 	if err != nil {
 		return port.SuggestedSession{}, fmt.Errorf("run suggest adhoc workflow: %w", err)
 	}

--- a/internal/coaching/infrastructure/ai/adk/prompts/generator.txt
+++ b/internal/coaching/infrastructure/ai/adk/prompts/generator.txt
@@ -23,7 +23,16 @@ Your task is to generate or adapt a workout plan based on the input flow.
 
 ### Flow Scope Rules
 - **INITIATE_4_WEEK**: Generate the complete 4-week structured roadmap (weeks 1 to 4).
-- **SUGGEST_AD_HOC_SESSION**: Use `ask_clarifying_question` tool FIRST to render AG-UI/A2UI protocol question if preference is ambiguous. Generate ONLY 1 single workout session.
+- **SUGGEST_AD_HOC_SESSION**: Generate ONLY 1 single workout session.
+  * If `adhoc_hint` is provided, you MUST strictly adhere to `adhoc_hint.duration_minutes` (e.g. 15, 30, 45, 60, 90 mins).
+  * The session's `estimated_duration_minutes` MUST match `adhoc_hint.duration_minutes`.
+  * Total volume (number of exercises, sets, and rest intervals) MUST fit realistically within the target duration:
+    - 15 mins: 1-2 exercises (2 sets each, 45s rest).
+    - 30 mins: 2-3 exercises (2-3 sets each, 60s rest).
+    - 45 mins: 3-4 exercises (3 sets each, 60-90s rest).
+    - 60+ mins: 4-6 exercises (3-4 sets each, 90-120s rest).
+  * Prioritize muscle groups and instructions specified in `adhoc_hint.free_text` and `adhoc_hint.muscle_groups`.
+  * Use `ask_clarifying_question` tool FIRST only if user preference is completely ambiguous.
 - **REGENERATE_PENDING**: Rewrite the sessions listed in `sessions_to_revise`.
 - **ADAPTIVE_CYCLE / POST_INJURY_RECOVERY**: Rewrite the sessions listed in `sessions_to_revise`, applying `adaptation_reason` and any active injury/fatigue protocol.
 

--- a/internal/coaching/infrastructure/ai/adk/runner.go
+++ b/internal/coaching/infrastructure/ai/adk/runner.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/viethung213/gym-companion/internal/coaching/application/port"
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/runner"
 	"google.golang.org/adk/v2/workflow"
@@ -160,6 +161,23 @@ func (c *CoachingContextAgent) takeReason(sessionID string) string {
 	return reason
 }
 
+func (c *CoachingContextAgent) putHint(sessionID string, hint *port.AdHocHint) {
+	if hint == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.hints[sessionID] = hint
+}
+
+func (c *CoachingContextAgent) takeHint(sessionID string) *port.AdHocHint {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	hint := c.hints[sessionID]
+	delete(c.hints, sessionID)
+	return hint
+}
+
 // runWorkflow executes a workflow agent and collects the plan its node produced.
 func (c *CoachingContextAgent) runWorkflow(
 	ctx context.Context,
@@ -177,6 +195,42 @@ func (c *CoachingContextAgent) runWorkflow(
 
 	if reason != "" {
 		c.putReason(sessionID, reason)
+	}
+
+	prompt := &genai.Content{
+		Role:  "user",
+		Parts: []*genai.Part{{Text: userID}},
+	}
+
+	for _, runErr := range r.Run(ctx, userID, sessionID, prompt, agent.RunConfig{}) {
+		if runErr != nil {
+			return nil, fmt.Errorf("runner step error: %w", runErr)
+		}
+	}
+
+	res := c.takeResult(sessionID)
+	if res == nil || res.Plan == nil || len(res.Plan.Weeks) == 0 {
+		return nil, fmt.Errorf("%w: workflow produced no plan", ErrPlanGenerationFailed)
+	}
+	return res, nil
+}
+
+func (c *CoachingContextAgent) runAdHocWorkflow(
+	ctx context.Context,
+	userID string,
+	hint *port.AdHocHint,
+) (*PlanResult, error) {
+	r, err := runner.NewInMemory("coaching-app", c.suggestAdHocAgent)
+	if err != nil {
+		return nil, fmt.Errorf("new runner: %w", err)
+	}
+
+	sessionID := uuid.NewString()
+	defer c.takeResult(sessionID)
+	defer c.takeHint(sessionID)
+
+	if hint != nil {
+		c.putHint(sessionID, hint)
 	}
 
 	prompt := &genai.Content{

--- a/internal/coaching/infrastructure/ai/adk/types.go
+++ b/internal/coaching/infrastructure/ai/adk/types.go
@@ -72,6 +72,16 @@ type CoachInput struct {
 
 	SessionsToRevise []SessionToRevise `json:"sessions_to_revise,omitempty"`
 	AdaptationReason string            `json:"adaptation_reason,omitempty"`
+	AdHocHint        *AdHocHintInput   `json:"adhoc_hint,omitempty"`
+}
+
+// AdHocHintInput defines custom user preferences for single ad-hoc session recommendations.
+type AdHocHintInput struct {
+	FreeText           string   `json:"free_text,omitempty"`
+	MuscleGroups       []string `json:"muscle_groups,omitempty"`
+	AvailableEquipment []string `json:"available_equipment,omitempty"`
+	DurationMinutes    int      `json:"duration_minutes,omitempty"`
+	IntensityHint      string   `json:"intensity_hint,omitempty"`
 }
 
 // SessionToRevise carries no id; results are matched back by position.

--- a/internal/coaching/infrastructure/ai/adk/workflow_adhoc.go
+++ b/internal/coaching/infrastructure/ai/adk/workflow_adhoc.go
@@ -19,6 +19,15 @@ func (c *CoachingContextAgent) buildSuggestAdHocAgent(_ context.Context) (agent.
 				return nil, fetchErr
 			}
 			coachInput.Flow = FlowSuggestAdHoc
+			if hint := c.takeHint(nodeCtx.SessionID()); hint != nil {
+				coachInput.AdHocHint = &AdHocHintInput{
+					FreeText:           hint.FreeText,
+					MuscleGroups:       hint.MuscleGroups,
+					AvailableEquipment: hint.AvailableEquipment,
+					DurationMinutes:    hint.DurationMinutes,
+					IntensityHint:      hint.IntensityHint,
+				}
+			}
 
 			res, genErr := c.generateValidatedPlan(nodeCtx, &coachInput, false)
 			if genErr != nil {

--- a/internal/coaching/infrastructure/persistence/roadmap_repository.go
+++ b/internal/coaching/infrastructure/persistence/roadmap_repository.go
@@ -81,7 +81,7 @@ func (r *RoadmapRepository) Save(ctx context.Context, rm *roadmap.Roadmap) error
 				if err := db.Clauses(clause.OnConflict{
 					Columns: []clause.Column{{Name: "session_plan_id"}},
 					DoUpdates: clause.AssignmentColumns([]string{
-						"slot_time", "status", "target_muscle_groups", "prescription",
+						"slot_time", "estimated_duration_minutes", "status", "target_muscle_groups", "prescription",
 						"reasoning", "generated_at", "completed_at", "session_scr", "session_delta_rpe",
 					}),
 				}).Create(&sr).Error; err != nil {


### PR DESCRIPTION
## Summary
- Wire AdHocHint (DurationMinutes, FreeText, MuscleGroups, AvailableEquipment) into Coaching ADK agent workflow.
- Update generator prompt to strictly respect user requested duration minutes (e.g. 15, 30, 45, 60 mins).
- Fix estimated_duration_minutes missing from DoUpdates in oadmap_repository.go.
- Keep shared auth middleware clean without test bypasses.